### PR TITLE
bugfix: fix issue where "first-in" AWS credentials are sticky

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.27.5</version>
+    <version>0.27.6</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>


### PR DESCRIPTION
# Fix AWS/Azure Credential Caching Bug in StorageResolver and SearcherContext

## Summary

Fixes a critical security bug where AWS and Azure credentials were being incorrectly cached and reused, causing queries with invalid credentials to succeed by using cached data from previous requests with valid credentials.

## Problem

There were TWO layers of caching that caused this security issue:

### 1. StorageResolver Cache Key Bug
The `StorageResolver` cache key generation in `storage_resolver.rs` was using only partial credential information:

**S3:**
- Only first 8 characters of `access_key_id`
- Missing `secret_access_key` entirely
- Missing `session_token` entirely

**Azure:**
- Only first 8 characters of `access_key`
- Missing `bearer_token` entirely

### 2. Global SearcherContext Cache Bug (Root Cause)
Even with different StorageResolvers, the `SearcherContext` (containing split footer cache, fast fields cache, etc.) was GLOBAL and shared across all credential sets. Once data was loaded with valid credentials, it was served from cache to any subsequent request regardless of credentials.

This resulted in:
- Authentication appearing to succeed when switching between AWS accounts
- Session token changes (common with STS/IAM roles) being ignored
- Azure OAuth bearer token changes being ignored

## Solution

### Fix 1: StorageResolver Cache Keys
Added `generate_storage_cache_key()` helper function that creates proper cache keys including all credential components:

**S3 cache key now includes:**
- Full `region`
- Full `endpoint`
- Full `access_key_id` (not truncated)
- `force_path_style_access` flag
- Hash of `secret_access_key` + `session_token`

**Azure cache key now includes:**
- Full `account_name`
- Hash of `access_key` + `bearer_token`

### Fix 2: Credential-Specific SearcherContexts
Added credential-specific `SearcherContext` caching to ensure each credential set gets its own caches:

- New `get_credential_searcher_context(credential_key)` function
- Separate cache instances per credential set
- Prevents cached data from one credential set being served to another

## Changes

- `native/src/global_cache/storage_resolver.rs`:
  - Added `generate_storage_cache_key()` helper (now public for reuse)
  - Updated all 4 cache key generation sites (async S3, async Azure, sync S3, sync Azure)

- `native/src/global_cache/mod.rs`:
  - Added `CREDENTIAL_SEARCHER_CONTEXTS` static cache
  - Added `get_credential_searcher_context()` function
  - Exported `generate_storage_cache_key`

- `native/src/split_searcher/jni_lifecycle.rs`:
  - Generate credential key from aws_config/azure_config
  - Use `get_credential_searcher_context()` instead of `get_global_searcher_context()`

## Testing

- Build verified with `mvn compile`
- `RealS3EndToEndTest.step10_credentialCachingValidation` now passes:
  - Real credentials: Successfully queries split
  - Fake credentials: Correctly rejected with "failed to fetch hotcache and footer" error

## Before/After

**Before (broken):**
```
Request 1 (real creds): Success, data cached in global SearcherContext
Request 2 (fake creds): Success (incorrectly!) - served from cache
```

**After (fixed):**
```
Request 1 (real creds): Success, data cached in credential-specific SearcherContext
Request 2 (fake creds): Rejected - different SearcherContext, must re-fetch from S3
```

## Security Impact

This fix is critical for multi-tenant deployments where different users may have different AWS/Azure credentials. Without this fix, a user could potentially access cached data from splits they don't have permission to access.
