### PR TITLE
scalability: Global Concurrency Configuration for Merge Operations

### DIFF
--- a/native/src/quickwit_split/merge_types.rs
+++ b/native/src/quickwit_split/merge_types.rs
@@ -20,6 +20,22 @@ pub struct MergeAwsConfig {
     pub force_path_style: bool,
 }
 
+/// Information about a split that was skipped during merge
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkippedSplit {
+    pub url: String,       // The URL/path of the split that was skipped
+    pub reason: String,    // Human-readable reason why it was skipped
+}
+
+impl SkippedSplit {
+    pub fn new(url: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            reason: reason.into(),
+        }
+    }
+}
+
 /// Metadata about a split after merge
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SplitMetadata {
@@ -30,7 +46,7 @@ pub struct SplitMetadata {
     pub time_range_end: Option<i64>,
     pub create_timestamp: u64,
     pub footer_offsets: Option<(u64, u64)>,
-    pub skipped_splits: Vec<String>,  // URLs/paths of splits that were skipped due to corruption or errors
+    pub skipped_splits: Vec<SkippedSplit>,  // Splits that were skipped with reasons
 }
 
 impl SplitMetadata {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.27.6</version>
+    <version>0.28.0</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>


### PR DESCRIPTION
# Pull Request: Global Concurrency Configuration for Merge Operations

## Summary

Adds configurable global concurrency settings to prevent upload timeout errors (`ThroughputBelowMinimum`) when running many concurrent merge operations at scale.

## Problem

When running many concurrent merge operations, users encounter timeout errors:

```
storage error(kind=Timeout, source=dispatch failure: timeout:
minimum throughput was specified at 1 B/s, but throughput of 0 B/s was observed)
```

**Root Cause:** Thread starvation in the Tokio runtime. With only `num_cpus` worker threads and unlimited concurrent uploads, too many operations compete for limited threads, causing some to stall completely (0 B/s throughput). The AWS SDK's stalled stream protection then aborts the operation.

## Solution

Added global concurrency configuration via `MergeConfig.configureGlobalConcurrency()`:

- **Worker threads** - Configurable Tokio runtime worker threads (default: num_cpus)
- **Download semaphore** - Limits concurrent split downloads across all merges
- **Upload semaphore** - Limits concurrent split uploads across all merges

## API

```java
// Configure at application startup (before any merge operations)
MergeConfig.configureGlobalConcurrency()
    .workerThreads(16)            // Tokio async I/O worker threads
    .maxConcurrentDownloads(32)   // Max concurrent split downloads
    .maxConcurrentUploads(16)     // Max concurrent split uploads
    .apply();

// Query current configuration
int workers = MergeConfig.getGlobalWorkerThreads();
int downloads = MergeConfig.getGlobalMaxConcurrentDownloads();
int uploads = MergeConfig.getGlobalMaxConcurrentUploads();
int defaultCount = MergeConfig.getDefaultThreadCount();
```

## Changes

### Java
- **`QuickwitSplit.java`**: Added `GlobalConcurrencyBuilder` inner class to `MergeConfig` with:
  - `configureGlobalConcurrency()` static method returning builder
  - `workerThreads(int)`, `maxConcurrentDownloads(int)`, `maxConcurrentUploads(int)` builder methods
  - `apply()` method to apply configuration to native runtime
  - Static getters for querying current configuration

### Rust
- **`runtime_manager.rs`**:
  - Added `RuntimeConfig` struct with worker threads and concurrency limits
  - Added upload/download semaphores to `QuickwitRuntimeManager`
  - Updated JNI function names to match new `MergeConfig` class path
- **`upload.rs`**: Added upload semaphore acquisition before uploads
- **`download.rs`**: Uses runtime manager's download semaphore (was already using a separate global)

### Documentation
- **`docs/RUNTIME_CONFIG_GUIDE.md`**: Developer guide for configuring global concurrency

## Design Decisions

1. **Static methods on MergeConfig** - Chose to integrate with existing `MergeConfig` class rather than a separate `RuntimeConfig` class, keeping merge-related configuration in one place.

2. **Global scope** - These settings are intentionally global because:
   - The Tokio runtime is a shared singleton
   - Semaphores must limit concurrency across ALL merge operations
   - Per-merge settings would not prevent the thread starvation issue

3. **Defaults based on num_cpus** - All settings default to the number of CPU cores, which works well for most workloads while preventing resource exhaustion.

4. **One-time configuration** - Configuration can only be applied before the runtime is initialized. This prevents inconsistent state and matches Tokio's runtime lifecycle.

## Testing

Build verified with `mvn compile`. The changes are backward compatible - existing code continues to work with default settings.

## Version

Requires tantivy4java version 0.28.0 or later.
