### PR TITLE
fix: reduce contention in prewarm disk writing

### DIFF
--- a/native/src/prewarm/all_fields.rs
+++ b/native/src/prewarm/all_fields.rs
@@ -367,17 +367,9 @@ pub async fn prewarm_store_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     // Success = already cached + newly downloaded
     let success_count = already_cached_count + downloaded_count;
 
-    // CRITICAL: Flush disk cache to ensure all async writes complete before returning.
-    // This prevents race conditions where subsequent cache lookups miss data that's
-    // still being written by the background writer thread.
-    if downloaded_count > 0 {
-        debug_println!(
-            "🔄 PREWARM_STORE_FLUSH: Flushing disk cache to ensure {} downloads are persisted",
-            downloaded_count
-        );
-        disk_cache.flush_async().await;
-        debug_println!("✅ PREWARM_STORE_FLUSH: Disk cache flush complete");
-    }
+    // NOTE: We no longer flush here - the background timer syncs every 1 second when dirty.
+    // This allows parallel prewarms to run without serializing on flush.
+    // The manifest_dirty flag is set by the background writer after each successful write.
 
     debug_println!(
         "✅ PREWARM_STORE: Completed - {} already cached, {} downloaded, {} failures",

--- a/src/test/java/io/indextables/tantivy4java/PrewarmCacheValidationTest.java
+++ b/src/test/java/io/indextables/tantivy4java/PrewarmCacheValidationTest.java
@@ -268,6 +268,10 @@ public class PrewarmCacheValidationTest {
             long firstPrewarmBytes = afterFirstPrewarm.getTotalBytes();
             System.out.println("   ✓ First prewarm downloaded " + firstPrewarmDownloads + " chunks (" + firstPrewarmBytes + " bytes)");
 
+            // Wait for background disk cache writes and manifest sync (timer runs every 1 second)
+            System.out.println("   Waiting 2 seconds for async disk cache writes and manifest sync...");
+            Thread.sleep(2000);
+
             // STEP 2.5: Validate disk cache files exist
             System.out.println("\n[STEP 2.5] Validating disk cache files exist on disk...");
             validateDiskCacheFiles(diskCachePath, splitUri);


### PR DESCRIPTION
# Fix Parallel Prewarm Serialization Bottleneck

## Problem

When running multiple prewarm operations in parallel, no speedup was observed despite launching concurrent futures. CPU utilization remained at only 25-30% even with significant work queued.

### Root Cause

Each prewarm operation called `flush_async()` after downloading, which:

1. Sent a `Flush` request to the background writer channel
2. The single-threaded dispatch loop processed `Flush` by calling `runtime.block_on(semaphore.acquire_many(num_writers))`
3. This **blocked the entire dispatch loop** until all pending writes completed
4. While blocked, no new `Put` requests from other prewarms could be dispatched
5. Multiple flush requests serialized behind each other

Even though downloads happened in parallel, the flush operations created a serialization bottleneck that prevented true parallelism.

## Solution

Replace the blocking flush-after-each-prewarm approach with a dirty-flag-based background sync:

1. **Remove explicit flush from prewarm** - Prewarm no longer waits for manifest sync
2. **Add dirty flag** - Background writer marks manifest dirty after each successful write
3. **1-second timer** - Background thread checks every second; if dirty, syncs manifest (non-blocking)

This allows:
- All prewarm downloads to run truly in parallel
- All disk writes to be dispatched without blocking
- Manifest to sync within ~1 second of writes completing
- No serialization between parallel prewarm operations

## Changes

### `native/src/disk_cache/mod.rs`
- Added `manifest_dirty: Arc<AtomicBool>` field to `L2DiskCache`
- Added `mark_dirty()` method to set the flag
- Added `check_and_clear_dirty()` method for atomic check-and-reset
- Timer now started unconditionally with dirty flag instead of interval

### `native/src/disk_cache/background.rs`
- `Put` handler now calls `cache.mark_dirty()` after successful write
- `Evict` handler now calls `cache.mark_dirty()` after successful eviction
- `manifest_sync_timer_static()` rewritten:
  - Checks every 1 second (in 100ms increments for fast shutdown)
  - Only syncs if dirty flag is set (atomic swap to clear)
  - Non-blocking: doesn't wait for pending writes

### `native/src/prewarm/cache_extension.rs`
- Removed `disk_cache.flush_async().await` call
- Added comment explaining the new approach

### `native/src/prewarm/all_fields.rs`
- Removed `disk_cache.flush_async().await` call from store prewarm
- Added comment explaining the new approach

## Trade-offs

| Before | After |
|--------|-------|
| Manifest persisted immediately after each prewarm | Manifest persisted within ~1 second |
| Prewarms serialized on flush | Prewarms run fully in parallel |
| 25-30% CPU utilization | Full parallel utilization expected |
| Guaranteed persistence before prewarm returns | Eventual persistence (acceptable for cache) |

### Crash Safety

If a crash occurs within 1 second of a write:
- Data files exist on disk but may not be in manifest
- On restart, orphaned files are ignored
- Data will be re-downloaded on next access
- This is acceptable behavior for a cache

### `src/test/java/.../PrewarmCacheValidationTest.java`
- Added 2-second sleep after first prewarm to allow async disk writes and manifest sync
- Required because prewarm now returns before manifest is persisted to disk
- All 3 tests (LOCAL, S3, AZURE) pass

## Testing

- `cargo check` passes with no errors
- `PrewarmCacheValidationTest` - all 3 tests pass (LOCAL, S3, AZURE)
- Existing functionality preserved (flush methods still available for explicit use)
- Parallel prewarm should now show linear speedup with concurrency
