### PR TITLE
feature: SplitQuery Improvements - Error Propagation and Field Counting

### DIFF
--- a/src/main/java/io/indextables/tantivy4java/split/SplitQuery.java
+++ b/src/main/java/io/indextables/tantivy4java/split/SplitQuery.java
@@ -48,6 +48,40 @@ public abstract class SplitQuery {
         return parseQuery(queryString, schema, new String[0]);
     }
 
+    /**
+     * Count the number of unique fields that would be searched by a query.
+     * This is useful for understanding the scope of a query before executing it.
+     *
+     * @param queryString The query string to analyze (e.g., "title:hello AND body:world")
+     * @param schema The schema to validate field names against
+     * @param defaultSearchFields Default fields to search if no field is specified in the query
+     * @return The number of unique fields that the query would search
+     * @throws RuntimeException if the query cannot be parsed
+     */
+    public static int countQueryFields(String queryString, Schema schema, String[] defaultSearchFields) {
+        int count = nativeCountQueryFields(queryString, schema.getNativePtr(), defaultSearchFields);
+        if (count < 0) {
+            throw new RuntimeException("Failed to count query fields - query may be invalid");
+        }
+        return count;
+    }
+
+    /**
+     * Count the number of unique fields that would be searched by a query.
+     * Uses all indexed text fields from the schema as default search fields.
+     *
+     * @param queryString The query string to analyze
+     * @param schema The schema to validate field names against
+     * @return The number of unique fields that the query would search
+     * @throws RuntimeException if the query cannot be parsed
+     */
+    public static int countQueryFields(String queryString, Schema schema) {
+        return countQueryFields(queryString, schema, new String[0]);
+    }
+
     // Native method that takes the schema pointer directly
     private static native SplitQuery nativeParseQuery(String queryString, long schemaPtr, String[] defaultSearchFields);
+
+    // Native method to count fields in a query
+    private static native int nativeCountQueryFields(String queryString, long schemaPtr, String[] defaultSearchFields);
 }


### PR DESCRIPTION
# PR: SplitQuery Improvements - Error Propagation and Field Counting

## Summary

- `SplitQuery.parseQuery()` now throws exceptions with descriptive error messages instead of silently returning null
- Added `SplitQuery.countQueryFields()` to count the number of unique fields impacted by a query

## Changes

### 1. Error Propagation for `parseQuery()`

#### Problem

Previously, when `SplitQuery.parseQuery()` encountered a parsing error, it would silently return `null` with no indication of what went wrong. This made debugging query syntax issues difficult.

#### Solution

Modified the native JNI function to throw a Java `RuntimeException` with the full error message from Quickwit's query parser.

#### Rust (`native/src/split_query/mod.rs`)

```rust
// Before: Silent null return
Err(e) => {
    debug_println!("🚀 ERROR: Error parsing query string: {}", e);
    std::ptr::null_mut()
}

// After: Throw exception with error details
Err(e) => {
    debug_println!("🚀 ERROR: Error parsing query string: {}", e);
    crate::common::to_java_exception(&mut env, &e);
    std::ptr::null_mut()
}
```

#### Error Message Examples

**Unclosed parenthesis:**
```
Failed to parse query 'title:(unclosed': failed to parse query: `title:(unclosed`.
This query requires explicit field names (e.g., 'field:term') or valid default search fields in the schema.
```

**Malformed range query:**
```
Failed to parse query 'count:[10 TO': failed to parse query: `count:[10 TO`.
This query requires explicit field names (e.g., 'field:term') or valid default search fields in the schema.
```

#### Usage

```java
try {
    SplitQuery query = SplitQuery.parseQuery("title:(unclosed", schema);
} catch (RuntimeException e) {
    System.err.println("Query parse error: " + e.getMessage());
    // Handle the error appropriately
}
```

### 2. New Method: `countQueryFields()`

#### Purpose

Count the number of unique fields that would be searched by a query. This is useful for:
- Understanding query scope before execution
- Query optimization and analysis
- Validating that queries target expected fields

#### Java API (`SplitQuery.java`)

```java
/**
 * Count the number of unique fields that would be searched by a query.
 *
 * @param queryString The query string to analyze
 * @param schema The schema to validate field names against
 * @param defaultSearchFields Default fields if no field specified in query
 * @return The number of unique fields the query would search
 * @throws RuntimeException if the query cannot be parsed
 */
public static int countQueryFields(String queryString, Schema schema, String[] defaultSearchFields)

// Convenience overload using all indexed text fields as defaults
public static int countQueryFields(String queryString, Schema schema)
```

#### Implementation

- **Rust** (`native/src/split_query/parse_query.rs`): Added `extract_fields_from_query_ast()` and `count_query_fields()` functions
- **JNI** (`native/src/split_query/mod.rs`): Added `nativeCountQueryFields` entry point
- Recursively traverses QueryAst to collect unique field names
- Handles all query types: Term, TermSet, FullText, PhrasePrefix, Range, FieldPresence, Wildcard, Regex, Bool, Boost

#### Usage Examples

```java
try (Schema schema = Schema.fromDocMappingJson(json)) {
    // Single field query
    int count1 = SplitQuery.countQueryFields("title:hello", schema);
    // Returns: 1

    // Multi-field query
    int count2 = SplitQuery.countQueryFields("title:hello AND body:world", schema);
    // Returns: 2

    // Same field multiple times counts as 1
    int count3 = SplitQuery.countQueryFields("title:hello AND title:world", schema);
    // Returns: 1

    // Range query
    int count4 = SplitQuery.countQueryFields("year:[2020 TO 2024]", schema);
    // Returns: 1

    // Mixed text and numeric
    int count5 = SplitQuery.countQueryFields("title:test AND year:[2020 TO 2024]", schema);
    // Returns: 2

    // Unfielded query uses all default text fields
    int count6 = SplitQuery.countQueryFields("searchterm", schema);
    // Returns: 3 (all indexed text fields become default search fields)
}
```

## Test Plan

### Error Propagation
- [x] Malformed query syntax throws exception with descriptive message
- [x] Invalid range queries throw exception with descriptive message
- [x] Valid queries still parse successfully
- [x] Error messages include the original query string

### Field Counting
- [x] Single field query returns 1
- [x] Multi-field AND query returns correct count
- [x] Same field used multiple times counts as 1
- [x] Range queries on numeric fields counted correctly
- [x] Mixed text and numeric field queries counted correctly
- [x] Unfielded queries count all default search fields

## Test Coverage

Added tests in `SchemaFromDocMappingTest.java`:
- `testParseQueryErrorHandling` - Error propagation tests
- `testCountQueryFields` - Field counting tests

## Files Changed

- `src/main/java/io/indextables/tantivy4java/split/SplitQuery.java` - Added `countQueryFields()` methods
- `native/src/split_query/mod.rs` - Added JNI entry points, error propagation
- `native/src/split_query/parse_query.rs` - Added field extraction logic
- `src/test/java/io/indextables/tantivy4java/SchemaFromDocMappingTest.java` - Added tests
