### PR TITLE
optimization: Parquet Read Path Optimizations

### DIFF
--- a/native/src/parquet_companion/augmented_directory.rs
+++ b/native/src/parquet_companion/augmented_directory.rs
@@ -217,6 +217,7 @@ impl ParquetAugmentedDirectory {
             &self.manifest,
             &self.storage,
             num_docs,
+            None, // metadata cache populated via prewarm/doc retrieval paths
         ).await?;
 
         // Merge with native fast fields if in hybrid mode

--- a/native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs
+++ b/native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs
@@ -862,6 +862,7 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
                     &storage,
                     Some(metadata_cache),
                     Some(byte_cache),
+                    None, // use default CoalesceConfig (512KB gap, 8MB max)
                 )
                 .await
             })
@@ -1022,6 +1023,7 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
                     &storage,
                     Some(metadata_cache),
                     Some(byte_cache),
+                    None, // use default CoalesceConfig (512KB gap, 8MB max)
                 )
                 .await
             })


### PR DESCRIPTION
# Parquet Read Path Optimizations

## Summary

Four targeted optimizations to the parquet companion read path, informed by a comparative analysis against Apache DataFusion's parquet reader. Because tantivy4java's access pattern is exact-row-number lookups (tantivy handles all filtering), the relevant optimizations are around I/O efficiency for scattered point reads rather than predicate pushdown.

- **8x larger coalesce gap** for cloud storage (64KB → 512KB default), saving 50-100ms per eliminated S3/Azure round-trip
- **Max coalesce size cap** (8MB) to prevent over-fetching when scattered ranges span large byte regions
- **Zero-copy `OwnedBytes` → `Bytes` conversion** via `Bytes::from_owner()`, eliminating an allocation+copy per storage fetch (dictionary pages are ~1MB each)
- **Shared metadata cache** plumbing for the transcode path, avoiding redundant footer reads from S3/Azure

## Changes

### `cached_reader.rs` — Coalescing & zero-copy

- New `CoalesceConfig` struct with `max_gap` (512KB default) and `max_total` (8MB default)
- `CoalesceConfig::local()` constructor for local/NVMe workloads (64KB gap)
- `CachedParquetReader::with_coalesce_config()` builder method
- `fetch_ranges_with_coalescing()` now accepts `CoalesceConfig` and enforces both gap and total-size limits
- All three `Bytes::from(owned_bytes.to_vec())` sites replaced with `Bytes::from_owner(owned_bytes)` (requires bytes ≥1.9.0; we have 1.11.1)

### `doc_retrieval.rs` — API threading

- `retrieve_document_from_parquet()` and `batch_retrieve_from_parquet()` accept optional `CoalesceConfig`
- Introduced `MetadataCache` type alias (from `transcode.rs`) to replace inline type signatures

### `transcode.rs` — Metadata cache sharing

- New `MetadataCache` type alias: `Arc<Mutex<HashMap<PathBuf, Arc<ParquetMetaData>>>>`
- `transcode_columns_from_parquet()` accepts optional `&MetadataCache`
- Checks cache before reading footer; populates cache after reading for reuse by doc retrieval

### `augmented_directory.rs` / `doc_retrieval_jni.rs` — Call-site updates

- Updated call sites to pass new parameters (`None` for defaults)

## Why these specific optimizations

The parquet companion's access pattern is **exact row numbers determined by tantivy's inverted index**. By the time we hit parquet, all filtering is done. This makes DataFusion's predicate-focused optimizations (statistics pruning, bloom filters, late materialization, filter reordering) irrelevant. What matters is:

1. **Minimizing S3/Azure round-trips** — the coalesce gap directly controls this
2. **Preventing over-fetching** — the max total size caps waste
3. **Reducing per-fetch allocation overhead** — zero-copy conversion
4. **Avoiding redundant metadata reads** — shared cache across code paths

## Test plan

- [x] `cargo check` — zero compilation errors
- [x] `cargo test --lib parquet_companion` — all 134 tests pass
- [ ] Verify S3 doc retrieval latency improvement with `TANTIVY4JAVA_DEBUG=1` (fewer coalesced groups in log output)
- [ ] Verify no regression in Java integration tests (`ParquetCompanionTest`, `ParquetCompanionAggregationTest`)
