### PR TITLE
feature:  Delta Table Schema Reading from Transaction Log

### DIFF
--- a/native/src/delta_reader/jni.rs
+++ b/native/src/delta_reader/jni.rs
@@ -12,8 +12,8 @@ use crate::common::to_java_exception;
 use crate::debug_println;
 
 use super::engine::DeltaStorageConfig;
-use super::scan::list_delta_files;
-use super::serialization::serialize_delta_entries;
+use super::scan::{list_delta_files, read_delta_schema};
+use super::serialization::{serialize_delta_entries, serialize_delta_schema};
 
 /// Helper to extract a String value from a Java HashMap<String,String>.
 fn extract_string(env: &mut JNIEnv, map: &JObject, key: &str) -> Option<String> {
@@ -105,6 +105,73 @@ pub extern "system" fn Java_io_indextables_tantivy4java_delta_DeltaTableReader_n
             let buffer = serialize_delta_entries(&entries, actual_version, compact != 0);
 
             // Create Java byte array and copy data
+            match env.new_byte_array(buffer.len() as i32) {
+                Ok(byte_array) => {
+                    let byte_slice: &[i8] = unsafe {
+                        std::slice::from_raw_parts(buffer.as_ptr() as *const i8, buffer.len())
+                    };
+                    if let Err(e) = env.set_byte_array_region(&byte_array, 0, byte_slice) {
+                        to_java_exception(
+                            &mut env,
+                            &anyhow::anyhow!("Failed to copy byte array: {}", e),
+                        );
+                        return std::ptr::null_mut();
+                    }
+                    byte_array.into_raw()
+                }
+                Err(e) => {
+                    to_java_exception(
+                        &mut env,
+                        &anyhow::anyhow!("Failed to allocate byte array: {}", e),
+                    );
+                    std::ptr::null_mut()
+                }
+            }
+        }
+        Err(e) => {
+            to_java_exception(&mut env, &e);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_io_indextables_tantivy4java_delta_DeltaTableReader_nativeReadSchema(
+    mut env: JNIEnv,
+    _class: JClass,
+    table_url: JString,
+    version: jlong,
+    config_map: JObject,
+) -> jbyteArray {
+    debug_println!("🔧 DELTA_JNI: nativeReadSchema called");
+
+    let url_str = match env.get_string(&table_url) {
+        Ok(s) => s.to_string_lossy().to_string(),
+        Err(e) => {
+            to_java_exception(&mut env, &anyhow::anyhow!("Failed to read table URL: {}", e));
+            return std::ptr::null_mut();
+        }
+    };
+
+    let config = build_config(&mut env, &config_map);
+    let version_opt = if version < 0 { None } else { Some(version as u64) };
+
+    debug_println!(
+        "🔧 DELTA_JNI: readSchema url={}, version={:?}",
+        url_str,
+        version_opt
+    );
+
+    match read_delta_schema(&url_str, &config, version_opt) {
+        Ok((fields, schema_json, actual_version)) => {
+            debug_println!(
+                "🔧 DELTA_JNI: Schema has {} fields at version {}",
+                fields.len(),
+                actual_version
+            );
+
+            let buffer = serialize_delta_schema(&fields, &schema_json, actual_version);
+
             match env.new_byte_array(buffer.len() as i32) {
                 Ok(byte_array) => {
                     let byte_slice: &[i8] = unsafe {

--- a/native/src/delta_reader/mod.rs
+++ b/native/src/delta_reader/mod.rs
@@ -10,4 +10,4 @@ pub mod serialization;
 pub mod jni;
 
 pub use engine::DeltaStorageConfig;
-pub use scan::{DeltaFileEntry, list_delta_files};
+pub use scan::{DeltaFileEntry, DeltaSchemaField, list_delta_files, read_delta_schema};

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.29.1</version>
+    <version>0.29.2</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>

--- a/src/main/java/io/indextables/tantivy4java/delta/DeltaSchemaField.java
+++ b/src/main/java/io/indextables/tantivy4java/delta/DeltaSchemaField.java
@@ -1,0 +1,92 @@
+package io.indextables.tantivy4java.delta;
+
+import java.util.Map;
+
+/**
+ * Immutable data class representing a single field (column) in a Delta table schema.
+ *
+ * <p>Instances are returned by {@link DeltaTableReader#readSchema(String)} and contain
+ * the column name, Delta data type, nullability, and any column-level metadata from
+ * the Delta transaction log.
+ *
+ * <p>For primitive types, {@link #getDataType()} returns a simple string like
+ * {@code "string"}, {@code "long"}, {@code "integer"}, {@code "double"}, {@code "boolean"},
+ * {@code "date"}, {@code "timestamp"}, etc.
+ *
+ * <p>For complex types (struct, array, map), {@link #getDataType()} returns the
+ * JSON representation of the type definition.
+ */
+public class DeltaSchemaField {
+
+    private final String name;
+    private final String dataType;
+    private final boolean nullable;
+    private final String metadata;
+
+    DeltaSchemaField(String name, String dataType, boolean nullable, String metadata) {
+        this.name = name;
+        this.dataType = dataType;
+        this.nullable = nullable;
+        this.metadata = metadata != null ? metadata : "{}";
+    }
+
+    /**
+     * @return the column name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the Delta data type (e.g. "string", "long", "double", or JSON for complex types)
+     */
+    public String getDataType() {
+        return dataType;
+    }
+
+    /**
+     * @return true if this column allows null values
+     */
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    /**
+     * @return column metadata as a JSON string (e.g. column mapping info)
+     */
+    public String getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * @return true if this is a primitive type (string, long, integer, double, etc.)
+     */
+    public boolean isPrimitive() {
+        return !dataType.startsWith("{");
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DeltaSchemaField{name='%s', type='%s', nullable=%s}",
+                name, dataType, nullable);
+    }
+
+    /**
+     * Construct a DeltaSchemaField from a parsed TANT byte buffer map.
+     * Package-private; used by DeltaTableReader.
+     */
+    static DeltaSchemaField fromMap(Map<String, Object> map) {
+        String name = (String) map.get("name");
+        String dataType = (String) map.get("data_type");
+        boolean nullable = toBoolean(map.get("nullable"));
+        String metadata = (String) map.get("metadata");
+        return new DeltaSchemaField(name, dataType, nullable, metadata);
+    }
+
+    private static boolean toBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return false;
+    }
+}

--- a/src/main/java/io/indextables/tantivy4java/delta/DeltaTableSchema.java
+++ b/src/main/java/io/indextables/tantivy4java/delta/DeltaTableSchema.java
@@ -1,0 +1,67 @@
+package io.indextables.tantivy4java.delta;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable result class representing a Delta table's schema read from the transaction log.
+ *
+ * <p>Contains the list of top-level fields, the raw Delta schema JSON for advanced use,
+ * and the snapshot version the schema was read from.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * DeltaTableSchema schema = DeltaTableReader.readSchema("s3://bucket/my_delta_table", config);
+ * System.out.println("Version: " + schema.getTableVersion());
+ * for (DeltaSchemaField field : schema.getFields()) {
+ *     System.out.println(field.getName() + " : " + field.getDataType());
+ * }
+ * // For advanced use: full Delta schema JSON
+ * String json = schema.getSchemaJson();
+ * }</pre>
+ */
+public class DeltaTableSchema {
+
+    private final List<DeltaSchemaField> fields;
+    private final String schemaJson;
+    private final long tableVersion;
+
+    DeltaTableSchema(List<DeltaSchemaField> fields, String schemaJson, long tableVersion) {
+        this.fields = Collections.unmodifiableList(fields);
+        this.schemaJson = schemaJson;
+        this.tableVersion = tableVersion;
+    }
+
+    /**
+     * @return the list of top-level columns in the Delta table schema
+     */
+    public List<DeltaSchemaField> getFields() {
+        return fields;
+    }
+
+    /**
+     * @return the full Delta schema as a JSON string (Delta Lake's native schema format)
+     */
+    public String getSchemaJson() {
+        return schemaJson;
+    }
+
+    /**
+     * @return the snapshot version this schema was read from
+     */
+    public long getTableVersion() {
+        return tableVersion;
+    }
+
+    /**
+     * @return the number of top-level columns
+     */
+    public int getFieldCount() {
+        return fields.size();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DeltaTableSchema{fields=%d, version=%d}", fields.size(), tableVersion);
+    }
+}


### PR DESCRIPTION
# PR: Delta Table Schema Reading from Transaction Log

## Summary

Adds the ability to read a Delta Lake table's schema directly from the transaction log without scanning any parquet data files. This enables callers to discover column names, types, and nullability before issuing queries or setting up parquet companion mode.

## Changes

### Rust (`native/src/delta_reader/`)

- **`scan.rs`**: Added `DeltaSchemaField` struct and `read_delta_schema()` function that builds a delta-kernel `Snapshot`, calls `snapshot.schema()`, and converts the `StructType` into a list of field descriptors plus raw schema JSON.
- **`serialization.rs`**: Added `serialize_delta_schema()` function that encodes schema fields into the TANT byte buffer protocol (one header doc with `schema_json`/`table_version`/`field_count`, followed by one doc per field with `name`/`data_type`/`nullable`/`metadata`).
- **`jni.rs`**: Added `nativeReadSchema` JNI entry point bridging `DeltaTableReader.readSchema()` to the Rust layer.
- **`mod.rs`**: Exported `DeltaSchemaField` and `read_delta_schema`.

### Java (`src/main/java/.../delta/`)

- **`DeltaTableReader.java`**: Added `readSchema()` overloads (no-args, with config, with config+version) that call the native layer and parse the TANT buffer into a `DeltaTableSchema`.
- **`DeltaSchemaField.java`** (new): Immutable data class for a single column — `name`, `dataType`, `nullable`, `metadata`. Primitive types return simple strings (e.g. `"string"`, `"long"`); complex types return JSON.
- **`DeltaTableSchema.java`** (new): Immutable result class containing the field list, raw schema JSON, and snapshot version.

### Version

- Bumped `pom.xml` version from `0.29.1` to `0.29.2`.

## Usage

```java
// Read schema from local Delta table
DeltaTableSchema schema = DeltaTableReader.readSchema("/data/my_delta_table");
System.out.println("Version: " + schema.getTableVersion());
System.out.println("Columns: " + schema.getFieldCount());

for (DeltaSchemaField field : schema.getFields()) {
    System.out.println(field.getName() + " : " + field.getDataType()
        + (field.isNullable() ? " (nullable)" : ""));
}

// With S3 credentials
Map<String, String> config = new HashMap<>();
config.put("aws_access_key_id", "AKIA...");
config.put("aws_secret_access_key", "...");
config.put("aws_region", "us-east-1");
DeltaTableSchema s3Schema = DeltaTableReader.readSchema("s3://bucket/delta_table", config);

// At a specific version
DeltaTableSchema v5Schema = DeltaTableReader.readSchema("s3://bucket/delta_table", config, 5);

// Access raw Delta schema JSON for advanced use
String json = schema.getSchemaJson();
```

## Test Coverage

- **`test_read_delta_schema_local`**: Verifies reading a 4-column schema (long, string, double, boolean) from a minimal Delta table, checks field names, types, nullability, and schema JSON round-trip.
- **`test_read_delta_schema_complex_types`**: Verifies handling of complex types (array, map) — ensures they serialize as JSON type descriptors.
- All 11 delta_reader tests pass (3 scan tests + 8 serialization tests).

## Design Notes

- **No parquet file reads**: Schema is read entirely from the `_delta_log` transaction log via delta-kernel's `Snapshot::schema()`. No data files are opened.
- **Primitive vs complex types**: `DeltaSchemaField.getDataType()` returns `"string"`, `"long"`, etc. for primitives. For complex types (struct, array, map), it returns the JSON representation. `isPrimitive()` helper distinguishes the two.
- **Full schema JSON**: `DeltaTableSchema.getSchemaJson()` returns the complete Delta schema in its native JSON format for callers that need the full type information (e.g. for schema evolution tracking or compatibility checks).
- **TANT protocol reuse**: Uses the same batch document byte buffer protocol as `listFiles()`, parsed by the existing `BatchDocumentReader` on the Java side.
