### PR TITLE
config: Per-Split ParquetStorageConfig Override

### DIFF
--- a/native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs
+++ b/native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs
@@ -840,11 +840,18 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
         // an explicit error instead of silently falling back to the wrong storage.
         let storage = match ctx.parquet_storage.as_ref() {
             Some(s) => s.clone(),
-            None => return Err(anyhow::anyhow!(
-                "Parquet companion split requires parquet_table_root to be set. \
-                 Pass the table root path as the 3rd argument to createSplitSearcher() \
-                 or configure it via CacheConfig.withParquetTableRoot()."
-            )),
+            None => {
+                let reason = if ctx.parquet_table_root.is_none() {
+                    "parquet_table_root was not set. Pass the table root path to createSplitSearcher() \
+                     or configure it via CacheConfig.withParquetTableRoot()."
+                } else {
+                    "parquet storage creation failed (likely bad credentials or unreachable endpoint). \
+                     Enable TANTIVY4JAVA_DEBUG=1 and check stderr for the storage creation error."
+                };
+                return Err(anyhow::anyhow!(
+                    "Parquet companion doc retrieval failed: {}", reason
+                ));
+            }
         };
         let metadata_cache = &ctx.parquet_metadata_cache;
         let byte_cache = &ctx.parquet_byte_range_cache;
@@ -1002,11 +1009,18 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
         // an explicit error instead of silently falling back to the wrong storage.
         let storage = match ctx.parquet_storage.as_ref() {
             Some(s) => s.clone(),
-            None => return Err(anyhow::anyhow!(
-                "Parquet companion split requires parquet_table_root to be set. \
-                 Pass the table root path as the 3rd argument to createSplitSearcher() \
-                 or configure it via CacheConfig.withParquetTableRoot()."
-            )),
+            None => {
+                let reason = if ctx.parquet_table_root.is_none() {
+                    "parquet_table_root was not set. Pass the table root path to createSplitSearcher() \
+                     or configure it via CacheConfig.withParquetTableRoot()."
+                } else {
+                    "parquet storage creation failed (likely bad credentials or unreachable endpoint). \
+                     Enable TANTIVY4JAVA_DEBUG=1 and check stderr for the storage creation error."
+                };
+                return Err(anyhow::anyhow!(
+                    "Parquet companion batch retrieval failed: {}", reason
+                ));
+            }
         };
         let metadata_cache = &ctx.parquet_metadata_cache;
         let byte_cache = &ctx.parquet_byte_range_cache;

--- a/native/src/split_searcher/jni_lifecycle.rs
+++ b/native/src/split_searcher/jni_lifecycle.rs
@@ -619,6 +619,8 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_crea
                                         Some(storage)
                                     }
                                     Err(e) => {
+                                        eprintln!("WARNING: PARQUET_COMPANION: Failed to create parquet storage for '{}': {}. \
+                                                   Doc retrieval/prewarm will fail for this split.", table_uri, e);
                                         debug_println!("⚠️ PARQUET_COMPANION: Failed to create parquet storage for '{}': {}", table_uri, e);
                                         None
                                     }

--- a/native/src/split_searcher/jni_prewarm.rs
+++ b/native/src/split_searcher/jni_prewarm.rs
@@ -428,7 +428,18 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
 
         let storage = match &context.parquet_storage {
             Some(s) => s.clone(),
-            None => return Err(anyhow::anyhow!("No parquet storage configured")),
+            None => {
+                let reason = if context.parquet_table_root.is_none() {
+                    "parquet_table_root was not set. Pass the table root path to createSplitSearcher() \
+                     or configure it via CacheConfig.withParquetTableRoot()."
+                } else {
+                    "parquet storage creation failed (likely bad credentials or unreachable endpoint). \
+                     Enable TANTIVY4JAVA_DEBUG=1 and check stderr for the storage creation error."
+                };
+                return Err(anyhow::anyhow!(
+                    "Parquet column prewarm failed: {}", reason
+                ));
+            }
         };
 
         // Determine which columns to prewarm

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.29.3</version>
+    <version>0.29.4</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>


### PR DESCRIPTION
# PR: Per-Split ParquetStorageConfig Override

## Title

Add per-split parquet storage config override to createSplitSearcher

## Summary

- `getCacheKey()` omits `parquetTableRoot` and `parquetStorageConfig`, so `getInstance()` can return a cached manager missing parquet config. Callers wanting different parquet credentials per split were forced to create separate `SplitCacheManager` instances, duplicating the expensive native L1/L2 cache.
- Adds a 4-arg `createSplitSearcher(path, metadata, tableRoot, storageConfig)` overload that accepts a per-split `ParquetStorageConfig`, matching the existing per-split `parquetTableRoot` pattern.
- Improves error messages for parquet storage failures: specific root-cause messages instead of generic "not configured", and a stderr WARNING when storage creation fails (visible without debug mode).
- Bumps version `0.29.3` -> `0.29.4`.

## Changed Files

| File | Change |
|------|--------|
| `SplitCacheManager.java` | New 4-arg `createSplitSearcher` overload; existing 2/3-arg delegate with `null`; per-split storage config precedence in `createSplitSearcherInternal`; comment on `getCacheKey()` explaining parquet exclusion |
| `jni_lifecycle.rs` | `eprintln!` WARNING on parquet storage creation failure (no longer silent) |
| `doc_retrieval_jni.rs` | Two error messages now check `parquet_table_root` to give specific root cause |
| `jni_prewarm.rs` | Prewarm error message now checks `parquet_table_root` for specific root cause |
| `pom.xml` | Version bump `0.29.3` -> `0.29.4` |

## Backwards Compatibility

Fully backwards compatible:
- 2-arg and 3-arg `createSplitSearcher` signatures unchanged; they delegate with `null`
- `CacheConfig.withParquetTableRoot()` / `withParquetStorage()` still work as defaults
- Cache key unchanged — existing manager instances remain valid
- No JNI signature changes — Rust reads same `parquet_aws_config`/`parquet_azure_config` map keys
- Workaround callers (separate cache names) continue to work, can migrate at their convenience

## Test Plan

- [ ] `cargo check` in `native/` passes
- [ ] `mvn clean compile -DskipTests` passes
- [ ] Existing `ParquetCompanionTest` (22 tests) still passes
- [ ] Existing `ParquetCompanionAggregationTest` (43 tests) still passes
- [ ] Verify 2-arg `createSplitSearcher` works identically (null delegation)
- [ ] Verify 3-arg `createSplitSearcher` works identically (null delegation)
- [ ] Verify new 4-arg overload puts per-split credentials into splitConfig map
- [ ] Verify error message specificity when `parquetTableRoot` is missing vs storage creation failure

## Documentation

See `docs/PER_SPLIT_PARQUET_STORAGE_CONFIG.md` for developer guide with migration examples.
