### PR TITLE
review: Address critical and performance issues identified in the PR81 performance review and parquet companion code review.

### DIFF
--- a/native/src/parquet_companion/augmented_directory.rs
+++ b/native/src/parquet_companion/augmented_directory.rs
@@ -209,7 +209,8 @@ impl ParquetAugmentedDirectory {
             columns.len(), fast_file_path
         );
 
-        let num_docs = self.manifest.total_rows as u32;
+        let num_docs: u32 = self.manifest.total_rows.try_into()
+            .map_err(|_| anyhow::anyhow!("total_rows {} exceeds u32::MAX", self.manifest.total_rows))?;
 
         // Transcode parquet columns to columnar bytes
         let parquet_columnar_bytes = transcode_columns_from_parquet(

--- a/native/src/split_searcher/jni_lifecycle.rs
+++ b/native/src/split_searcher/jni_lifecycle.rs
@@ -828,7 +828,7 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_crea
                                 parquet_byte_range_cache: crate::parquet_companion::cached_reader::new_byte_range_cache(),
                                 parquet_file_hash_index,
                                 has_merge_safe_tracking,
-                                pq_doc_locations: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                                pq_doc_locations: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
                             };
 
                             let searcher_context = std::sync::Arc::new(cached_context);


### PR DESCRIPTION
## Summary

Address critical and performance issues identified in the PR81 performance review and parquet companion code review.

**Group 1 — Critical Fixes (P0):**

- **1A: `u32` overflow guard on `total_rows`** — `augmented_directory.rs` now uses `try_into()` with a descriptive error instead of a silent truncating `as u32` cast. Splits with >4B rows will now fail with a clear message instead of silently wrapping.

- **1B: Decimal256 mapped to text instead of f64** — Decimal256 values (256-bit) exceed f64 precision (~53-bit mantissa). Schema derivation, indexing, arrow-to-tant serialization, and type mapping now consistently treat Decimal256 as text (string representation). Decimal128 remains f64 (precision loss is acceptable and documented). Updated test assertions to expect `Str` type for Decimal256.

- **1C: UTF-8 safe string truncation** — `statistics.rs` `observe_string()` previously used byte-offset slicing (`value[..truncate_length]`) which panics on multi-byte UTF-8 characters (emoji, CJK). Added `safe_truncate()` that finds the last complete character boundary within the byte budget. Added 2 new tests covering emoji and CJK truncation.

- **1D: Replace hand-rolled JSON with Jackson** — `ParquetCompanionConfig.toIndexingConfigJson()` replaced 70+ lines of `StringBuilder` with Jackson `ObjectMapper.writeValueAsString()`. This automatically fixes incomplete JSON escaping (newlines, tabs, control chars) and adds previously missing fields: `missing_file_policy`, `default_retrieval_fields`, and parquet storage credentials (`parquet_aws_config`, `parquet_azure_config`).

- **1D+3C+3D+3G (Java hardening):** Also applied to `ParquetCompanionConfig.java`:
  - `Objects.requireNonNull()` on constructor (`tableRoot`), `withFastFieldMode()`, `withMissingFilePolicy()`
  - `length >= 1` validation on `withStatisticsTruncateLength()`
  - Defensive `.clone()` on all varargs setters (5 methods)
  - Defensive copies on array getters, `Collections.unmodifiableMap()` on map getters
  - `Collections.unmodifiableMap()` on `ParquetStorageConfig.getAwsConfig()`/`getAzureConfig()`
  - Removed dead `toConfigMap()` method (zero callers)

**Group 2 — Performance Fixes (PR81 review):**

- **2A: `Mutex` → `RwLock` on `pq_doc_locations`** — The `__pq` fast field location cache (`pq_doc_locations`) is read on every single-doc retrieval but only written once per segment (lazy load). Changed from `Mutex` to `RwLock` so concurrent doc retrievals no longer serialize on the lock. `get_pq_location()` and the quick-check in `ensure_pq_segment_loaded()` now use `.read()`, only the store path uses `.write()`.

## Test plan

- [x] `cargo check` — compiles with no new warnings
- [x] `cargo test --lib parquet_companion` — 176 tests pass (174 existing + 2 new UTF-8 truncation tests)
- [x] `cargo test --lib split_searcher` — 2 tests pass
- [x] `mvn package -DskipTests` — Java compiles cleanly
- [ ] `mvn test -Dtest=ParquetCompanionTest` — verify parquet companion integration
- [ ] `mvn test -Dtest=ParquetCompanionAggregationTest` — verify aggregation path
- [ ] `mvn test -Dtest=CompanionIndexerTypesTest` — verify Decimal256-as-text round-trip
- [ ] Full suite: baseline 1030 tests, 0 failures, 5 skipped — no regressions

### Files changed

**Rust (`native/src/`):**
| File | Changes |
|------|---------|
| `parquet_companion/augmented_directory.rs` | `total_rows as u32` → `try_into()` with error |
| `parquet_companion/statistics.rs` | Added `safe_truncate()`, fixed `observe_string()` |
| `parquet_companion/schema_derivation.rs` | Decimal256 → text field, updated `should_add_fast`, type mappings, tests |
| `parquet_companion/indexing.rs` | Decimal256: `add_f64` → `add_text`, `observe_f64` → `observe_string` |
| `split_searcher/types.rs` | `Mutex` → `RwLock` on `pq_doc_locations`, updated all 3 access sites |
| `split_searcher/jni_lifecycle.rs` | `RwLock::new()` at construction |

**Java (`src/main/java/`):**
| File | Changes |
|------|---------|
| `split/ParquetCompanionConfig.java` | Jackson JSON serialization, null validation, defensive copies, removed dead code |
