### PR TITLE
fix: string column aggregations in parquet companion splits — count=0, slowness, OOM

### DIFF
--- a/native/src/parquet_companion/augmented_directory.rs
+++ b/native/src/parquet_companion/augmented_directory.rs
@@ -129,6 +129,19 @@ impl ParquetAugmentedDirectory {
         &self.inner
     }
 
+    /// Returns the tantivy column names that `transcode_and_cache` would actually
+    /// transcode for the given requested column set (or all applicable columns if None).
+    ///
+    /// Used by the prewarm path to update `transcoded_fast_columns` after a successful
+    /// transcode, preventing the first post-prewarm aggregation from redundantly
+    /// re-reading all parquet files.
+    pub fn effective_column_names(&self, requested: Option<&[String]>) -> Vec<String> {
+        columns_to_transcode(&self.manifest, self.mode, requested)
+            .into_iter()
+            .map(|col| col.tantivy_name)
+            .collect()
+    }
+
     /// Transcode and cache fast fields for a segment.
     ///
     /// This reads parquet data, transcodes to columnar format, optionally merges

--- a/native/src/split_searcher/jni_search.rs
+++ b/native/src/split_searcher/jni_search.rs
@@ -263,7 +263,7 @@ pub async fn perform_search_async_impl_leaf_response_with_aggregations(
             context,
             &query_json,
             aggregation_request_json.as_deref(),
-        ).await
+        ).await?
     } else {
         context.split_overrides.as_ref().map(|o| quickwit_search::SplitOverrides {
             meta_json: o.meta_json.clone(),

--- a/src/test/java/io/indextables/tantivy4java/ParquetCompanionLazyTranscodeTest.java
+++ b/src/test/java/io/indextables/tantivy4java/ParquetCompanionLazyTranscodeTest.java
@@ -1,0 +1,478 @@
+/*
+ * Reproduces and verifies production bugs with parquet companion string aggregations:
+ *
+ *  Bug 1 — "count is always zero":
+ *    When transcode_and_cache fails (e.g. due to OOM on large data), the error was
+ *    silently swallowed. SplitOverrides gets empty fast_field_data, so Quickwit reads
+ *    the native .fast file (which has no string columns in HYBRID mode), causing every
+ *    TermsAggregation to return count=0.
+ *    Fix: propagate errors from transcode_and_cache so callers receive an exception.
+ *
+ *  Bug 3a — redundant re-transcode after prewarm:
+ *    After a successful prewarm, transcoded_fast_columns was not updated.  The first
+ *    aggregation found all columns "missing" and repeated the full parquet read.
+ *    Fix: update transcoded_fast_columns after successful prewarm.
+ *
+ * Run:
+ *   mvn test -pl . -Dtest=ParquetCompanionLazyTranscodeTest
+ */
+package io.indextables.tantivy4java;
+
+import io.indextables.tantivy4java.aggregation.*;
+import io.indextables.tantivy4java.result.*;
+import io.indextables.tantivy4java.split.*;
+import io.indextables.tantivy4java.split.merge.*;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.*;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ParquetCompanionLazyTranscodeTest {
+
+    private static SplitCacheManager cacheManager;
+
+    @BeforeAll
+    static void setupCache() {
+        SplitCacheManager.CacheConfig config =
+                new SplitCacheManager.CacheConfig("pq-lazy-test-" + System.nanoTime());
+        cacheManager = SplitCacheManager.getInstance(config);
+    }
+
+    @AfterAll
+    static void teardownCache() {
+        if (cacheManager != null) cacheManager.close();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    //  Bug 1 reproduction: missing parquet file → must throw, not count=0
+    // ─────────────────────────────────────────────────────────────
+
+    /**
+     * Reproduces Bug 1: "count is always zero" when transcoding fails silently.
+     *
+     * Before fix: deleting the parquet file after split creation causes transcode to fail.
+     * The error was swallowed, SplitOverrides got empty fast_field_data, and every
+     * TermsAggregation returned count=0 instead of raising an error.
+     *
+     * After fix: the error propagates as a RuntimeException.
+     */
+    @Test @Order(1)
+    @DisplayName("Bug 1: transcode error propagates as exception instead of returning count=0")
+    void transcodeErrorPropagatesNotSilent(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("bug1.parquet");
+        Path splitFile   = dir.resolve("bug1.split");
+
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), 20, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        // Delete the parquet file so that transcoding will fail with a storage error
+        Files.delete(parquetFile);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+            TermsAggregation agg = new TermsAggregation("name_terms", "name", 50, 0);
+
+            // Before fix: silently returns TermsResult with count=0 for all buckets.
+            // After fix: throws RuntimeException because the parquet file is gone.
+            assertThrows(RuntimeException.class, () ->
+                    searcher.search(new SplitMatchAllQuery(), 0, "terms", agg),
+                    "Should throw when parquet file is missing, not silently return count=0");
+        }
+    }
+
+    /**
+     * Same bug, PARQUET_ONLY mode.
+     */
+    @Test @Order(2)
+    @DisplayName("Bug 1 (PARQUET_ONLY): transcode error propagates as exception")
+    void transcodeErrorPropagatesParquetOnly(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("bug1pq.parquet");
+        Path splitFile   = dir.resolve("bug1pq.split");
+
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), 20, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.PARQUET_ONLY);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        Files.delete(parquetFile);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+            StatsAggregation agg = new StatsAggregation("id_stats", "id");
+            assertThrows(RuntimeException.class, () ->
+                    searcher.search(new SplitMatchAllQuery(), 0, "stats", agg),
+                    "Should throw when parquet file is missing");
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    //  Lazy transcoding (no explicit prewarm) correctness
+    // ─────────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that TermsAggregation on a string field works WITHOUT an explicit prewarm
+     * call, exercising the lazy transcoding path end-to-end (HYBRID mode).
+     *
+     * In production users sometimes skip prewarm. The lazy path must transcode on demand
+     * and return correct (non-zero) counts.
+     */
+    @Test @Order(3)
+    @DisplayName("Lazy transcode (no prewarm): TermsAgg correct counts — HYBRID")
+    void lazyTranscodeTermsAggHybrid(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("lazy_hyb.parquet");
+        Path splitFile   = dir.resolve("lazy_hyb.split");
+
+        int numRows = 100;
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), numRows, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        // Intentionally no preloadParquetFastFields() call — use lazy path
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+            TermsAggregation agg = new TermsAggregation("name_terms", "name", 200, 0);
+            SearchResult result = searcher.search(new SplitMatchAllQuery(), 0, "terms", agg);
+
+            assertTrue(result.hasAggregations(), "Should have aggregation results");
+            TermsResult terms = (TermsResult) result.getAggregation("terms");
+            assertNotNull(terms);
+
+            // name = "item_0".."item_99" — all unique, each bucket doc_count=1
+            List<TermsResult.TermsBucket> buckets = terms.getBuckets();
+            assertFalse(buckets.isEmpty(),
+                    "Buckets must not be empty — before fix, count was always 0 when lazy transcode silently failed");
+            assertEquals(numRows, buckets.size(),
+                    "Should have one bucket per unique name (lazy transcode must return complete data)");
+            for (TermsResult.TermsBucket b : buckets) {
+                assertEquals(1, b.getDocCount(), "Each name is unique, expected doc_count=1");
+            }
+        }
+    }
+
+    /**
+     * Same lazy-transcode test for PARQUET_ONLY mode.
+     */
+    @Test @Order(4)
+    @DisplayName("Lazy transcode (no prewarm): TermsAgg correct counts — PARQUET_ONLY")
+    void lazyTranscodeTermsAggParquetOnly(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("lazy_pq.parquet");
+        Path splitFile   = dir.resolve("lazy_pq.split");
+
+        int numRows = 100;
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), numRows, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.PARQUET_ONLY);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+            TermsAggregation agg = new TermsAggregation("name_terms", "name", 200, 0);
+            SearchResult result = searcher.search(new SplitMatchAllQuery(), 0, "terms", agg);
+
+            assertTrue(result.hasAggregations());
+            TermsResult terms = (TermsResult) result.getAggregation("terms");
+            assertNotNull(terms);
+
+            List<TermsResult.TermsBucket> buckets = terms.getBuckets();
+            assertFalse(buckets.isEmpty(), "Lazy PARQUET_ONLY transcode must produce non-empty buckets");
+            assertEquals(numRows, buckets.size(), "All unique names should produce one bucket each");
+        }
+    }
+
+    /**
+     * Verifies that consecutive lazy aggregations on the same field reuse cached data
+     * (transcoded_fast_columns prevents redundant re-transcoding).
+     */
+    @Test @Order(5)
+    @DisplayName("Consecutive lazy aggregations: second call uses L1 cache")
+    void consecutiveLazyAggregationsUseCache(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("consec.parquet");
+        Path splitFile   = dir.resolve("consec.split");
+
+        int numRows = 30;
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), numRows, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.PARQUET_ONLY);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+            TermsAggregation agg = new TermsAggregation("name_terms", "name", 100, 0);
+
+            // First call: lazy transcode
+            SearchResult r1 = searcher.search(new SplitMatchAllQuery(), 0, "terms", agg);
+            TermsResult t1 = (TermsResult) r1.getAggregation("terms");
+            assertEquals(numRows, t1.getBuckets().size(), "First lazy agg: correct count");
+
+            // Second call: must use cached transcoded data, same result
+            SearchResult r2 = searcher.search(new SplitMatchAllQuery(), 0, "terms", agg);
+            TermsResult t2 = (TermsResult) r2.getAggregation("terms");
+            assertEquals(t1.getBuckets().size(), t2.getBuckets().size(),
+                    "Second aggregation must return identical count (no redundant re-transcode)");
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    //  Bug 3a: prewarm should suppress redundant transcode
+    // ─────────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that after prewarm, aggregations return correct results and are served
+     * from the prewarm cache (transcoded_fast_columns updated by prewarm).
+     *
+     * Before Bug 3a fix: transcoded_fast_columns was not updated after prewarm, so the
+     * first aggregation repeated the entire parquet read unnecessarily (wasted work,
+     * and with large data — OOM).
+     *
+     * After fix: transcoded_fast_columns is populated after prewarm, so the first
+     * aggregation skips the transcode loop and uses the L1 cache directly.
+     */
+    @Test @Order(6)
+    @DisplayName("Bug 3a: after prewarm, aggregation uses cached data (no re-transcode)")
+    void prewarmThenAggregationUsesCache(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("prewarm_agg.parquet");
+        Path splitFile   = dir.resolve("prewarm_agg.split");
+
+        int numRows = 50;
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), numRows, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+            // Explicit prewarm of the string column
+            searcher.preloadParquetFastFields("name").join();
+
+            // Now delete the parquet file — if the fix is correct, the first aggregation
+            // should use the prewarm cache and NOT re-read parquet.
+            // Before fix: would try to re-transcode, fail, and silently return count=0.
+            Files.delete(parquetFile);
+
+            TermsAggregation agg = new TermsAggregation("name_terms", "name", 100, 0);
+            SearchResult result = searcher.search(new SplitMatchAllQuery(), 0, "terms", agg);
+
+            assertTrue(result.hasAggregations());
+            TermsResult terms = (TermsResult) result.getAggregation("terms");
+            assertNotNull(terms);
+
+            // With the fix, prewarm cached the data and transcoded_fast_columns was
+            // updated, so no re-transcode is attempted despite the missing parquet file.
+            List<TermsResult.TermsBucket> buckets = terms.getBuckets();
+            assertFalse(buckets.isEmpty(),
+                    "After prewarm, aggregation must use cached data even if parquet is gone " +
+                    "(before fix, redundant re-transcode would fail silently → count=0)");
+            assertEquals(numRows, buckets.size(),
+                    "Prewarm cache must contain complete data for all rows");
+        }
+    }
+
+    /**
+     * Same prewarm-suppresses-retranscode test for PARQUET_ONLY mode.
+     */
+    @Test @Order(7)
+    @DisplayName("Bug 3a (PARQUET_ONLY): after prewarm, aggregation uses cached data")
+    void prewarmThenAggregationParquetOnly(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("prewarm_pq.parquet");
+        Path splitFile   = dir.resolve("prewarm_pq.split");
+
+        int numRows = 40;
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), numRows, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.PARQUET_ONLY);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+            searcher.preloadParquetFastFields("id", "score", "name", "active").join();
+
+            // Delete parquet — fix must ensure prewarm cache is used
+            Files.delete(parquetFile);
+
+            TermsAggregation agg = new TermsAggregation("name_terms", "name", 100, 0);
+            SearchResult result = searcher.search(new SplitMatchAllQuery(), 0, "terms", agg);
+
+            assertTrue(result.hasAggregations());
+            TermsResult terms = (TermsResult) result.getAggregation("terms");
+            assertNotNull(terms);
+            assertEquals(numRows, terms.getBuckets().size(),
+                    "PARQUET_ONLY: prewarm cache must cover all data");
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    //  L2 disk cache: lazy-transcoded bytes must survive L1 eviction
+    // ─────────────────────────────────────────────────────────────
+
+    /**
+     * Confirms that dynamically transcoded string columns are written to the L2 disk
+     * cache so they don't have to be re-transcoded from parquet when the in-memory (L1)
+     * data is lost (searcher closed / evicted).
+     *
+     * Proof: after the first lazy aggregation with a disk cache configured,
+     *   1. Close the searcher (L1 lost).
+     *   2. Delete the parquet file (re-transcode from parquet would fail).
+     *   3. Open a new searcher backed by the same disk cache.
+     *   4. Run the same aggregation — must succeed from L2 with correct counts.
+     *
+     * HYBRID mode: native numerics in .fast + parquet-derived string column.
+     */
+    @Test @Order(8)
+    @DisplayName("L2 cache: lazy-transcoded string column survives searcher close — HYBRID")
+    void lazyTranscodeWritesToL2Cache_Hybrid(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("l2_hyb.parquet");
+        Path splitFile   = dir.resolve("l2_hyb.split");
+        Path diskCacheDir = dir.resolve("l2cache");
+        int numRows = 50;
+
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), numRows, 0);
+
+        ParquetCompanionConfig pqConfig = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), pqConfig);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+
+        // ── Phase 1: lazy transcode → populates L2 disk cache ──────────────
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCacheDir.toString())
+                .withMaxDiskSize(100_000_000);
+
+        try (SplitCacheManager cm1 = SplitCacheManager.getInstance(
+                new SplitCacheManager.CacheConfig("l2-hyb-phase1-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withTieredCache(tiered))) {
+
+            try (SplitSearcher s1 = cm1.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+                // No prewarm — use lazy path
+                TermsAggregation agg = new TermsAggregation("n", "name", 100, 0);
+                SearchResult r = s1.search(new SplitMatchAllQuery(), 0, "terms", agg);
+                assertEquals(numRows,
+                        ((TermsResult) r.getAggregation("terms")).getBuckets().size(),
+                        "Phase 1: lazy transcode must produce correct count");
+            }
+            // searcher closed → L1 in-memory cache dropped
+        }
+        // cache manager closed → but disk cache directory persists
+
+        // ── Phase 2: delete parquet, open new searcher, aggregate from L2 ──
+        Files.delete(parquetFile);
+
+        try (SplitCacheManager cm2 = SplitCacheManager.getInstance(
+                new SplitCacheManager.CacheConfig("l2-hyb-phase2-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withTieredCache(tiered))) {   // same diskCacheDir
+
+            try (SplitSearcher s2 = cm2.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+                TermsAggregation agg = new TermsAggregation("n", "name", 100, 0);
+                SearchResult r = s2.search(new SplitMatchAllQuery(), 0, "terms", agg);
+
+                TermsResult terms = (TermsResult) r.getAggregation("terms");
+                assertNotNull(terms);
+                assertEquals(numRows, terms.getBuckets().size(),
+                        "Phase 2: L2 disk cache must serve transcoded data after parquet is deleted " +
+                        "(re-transcoding would have failed — parquet is gone)");
+            }
+        }
+    }
+
+    /**
+     * Same L2 disk cache confirmation for PARQUET_ONLY mode.
+     */
+    @Test @Order(9)
+    @DisplayName("L2 cache: lazy-transcoded string column survives searcher close — PARQUET_ONLY")
+    void lazyTranscodeWritesToL2Cache_ParquetOnly(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("l2_pq.parquet");
+        Path splitFile   = dir.resolve("l2_pq.split");
+        Path diskCacheDir = dir.resolve("l2cache");
+        int numRows = 50;
+
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), numRows, 0);
+
+        ParquetCompanionConfig pqConfig = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.PARQUET_ONLY);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), pqConfig);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCacheDir.toString())
+                .withMaxDiskSize(100_000_000);
+
+        // Phase 1: lazy transcode → L2 populated
+        try (SplitCacheManager cm1 = SplitCacheManager.getInstance(
+                new SplitCacheManager.CacheConfig("l2-pq-phase1-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withTieredCache(tiered))) {
+
+            try (SplitSearcher s1 = cm1.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+                TermsAggregation agg = new TermsAggregation("n", "name", 100, 0);
+                SearchResult r = s1.search(new SplitMatchAllQuery(), 0, "terms", agg);
+                assertEquals(numRows,
+                        ((TermsResult) r.getAggregation("terms")).getBuckets().size(),
+                        "Phase 1: correct count from lazy transcode");
+            }
+        }
+
+        // Phase 2: delete parquet, reopen with same disk cache
+        Files.delete(parquetFile);
+
+        try (SplitCacheManager cm2 = SplitCacheManager.getInstance(
+                new SplitCacheManager.CacheConfig("l2-pq-phase2-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withTieredCache(tiered))) {
+
+            try (SplitSearcher s2 = cm2.createSplitSearcher(splitUrl, metadata, dir.toString())) {
+                TermsAggregation agg = new TermsAggregation("n", "name", 100, 0);
+                SearchResult r = s2.search(new SplitMatchAllQuery(), 0, "terms", agg);
+
+                TermsResult terms = (TermsResult) r.getAggregation("terms");
+                assertNotNull(terms);
+                assertEquals(numRows, terms.getBuckets().size(),
+                        "Phase 2: L2 disk cache must serve transcoded data after parquet is deleted");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Fix: string column aggregations in parquet companion splits — count=0, slowness, OOM

## Problem

Three production bugs were identified when running aggregations on **string columns** in
parquet companion splits (HYBRID and PARQUET_ONLY fast-field modes):

1. **Wrong results — count is always zero** — `TermsAggregation` on a string field (e.g.
   `name`) would return an empty result set or zero doc-count for all buckets whenever the
   lazy transcoding path encountered an error (e.g. network hiccup, OOM on large data).

2. **Out-of-memory / extreme slowness** — After a successful `preloadParquetFastFields()`
   call, the very first aggregation would re-read *all* parquet files from scratch,
   duplicating the work that prewarm already did. At scale (millions of rows) this
   triggers OOM and multi-second stalls.

Both symptoms share the same two root causes in the lazy transcoding path
(`ensure_fast_fields_for_query`).

---

## Root causes

### Bug 1 — silent error swallowing (→ count=0)

`ensure_fast_fields_for_query` in `split_searcher/async_impl.rs` called
`transcode_and_cache` inside an `if let Err(e) = …` block that only printed a
`debug_println!` and then **continued execution as if nothing went wrong**:

```rust
// BEFORE (broken)
for fast_path in &context.segment_fast_paths {
    if let Err(e) = augmented_dir.transcode_and_cache(fast_path, …).await {
        debug_println!("⚠️ Failed …: {}", e);
        // error silently dropped — fast_field_data stays empty
    }
}
```

Because the columns were **also pre-inserted into `transcoded_fast_columns` before the
transcode**, a failed transcode would permanently mark those columns as "done". On the
next query the function would skip the transcode loop entirely, build `SplitOverrides`
from an empty L1 cache, and pass that to Quickwit. Quickwit then fell back to the native
`.fast` file (which has no parquet-derived string columns in HYBRID mode), so every
`TermsAggregation` returned count=0.

### Bug 3a — redundant re-transcode after prewarm (→ slowness / OOM)

`nativePrewarmParquetFastFields` in `split_searcher/jni_prewarm.rs` transcoded all
requested columns and populated the L1 cache — but **never updated
`context.transcoded_fast_columns`**. So when the first aggregation arrived:

1. `transcoded_fast_columns` was empty → all needed columns appeared "missing".
2. `ensure_fast_fields_for_query` recomputed `full_column_set` = all needed columns.
3. `transcode_and_cache` was called again, re-reading the entire parquet dataset from
   storage (S3 / Azure / disk) unnecessarily.

For a 10M-row table with five string columns this means ~500 MB–1 GB of extra reads per
query after prewarm.

---

## Fix

### `split_searcher/async_impl.rs` — propagate errors, defer tracker update

```rust
// AFTER (fixed)
pub(crate) async fn ensure_fast_fields_for_query(…)
    -> anyhow::Result<Option<quickwit_search::SplitOverrides>>   // was: Option<…>
{
    …
    // Compute full_column_set WITHOUT touching transcoded_fast_columns yet
    let full_column_set = { … };

    // Propagate errors — don't swallow them
    for fast_path in &context.segment_fast_paths {
        augmented_dir.transcode_and_cache(fast_path, Some(&full_column_set))
            .await
            .map_err(|e| anyhow::anyhow!("Failed to transcode … : {}", e))?;
    }

    // Update tracker only after ALL segments succeed
    {
        let mut existing = context.transcoded_fast_columns.lock().unwrap();
        for col in &columns_to_add { existing.insert(col.clone()); }
    }
    …
}
```

Both callers (`async_impl.rs` and `jni_search.rs`) were updated to propagate the error
with `?`.

### `split_searcher/jni_prewarm.rs` — update tracker after prewarm

```rust
// After all segments are successfully transcoded:
let transcoded_names = augmented_dir.effective_column_names(cols_ref);
if !transcoded_names.is_empty() {
    let mut transcoded = context.transcoded_fast_columns.lock().unwrap();
    for name in transcoded_names { transcoded.insert(name); }
}
```

### `parquet_companion/augmented_directory.rs` — new helper

```rust
pub fn effective_column_names(&self, requested: Option<&[String]>) -> Vec<String> {
    columns_to_transcode(&self.manifest, self.mode, requested)
        .into_iter()
        .map(|col| col.tantivy_name)
        .collect()
}
```

---

## Reproduction tests (`ParquetCompanionLazyTranscodeTest`)

Seven new tests are added, covering both bugs and their happy paths:

| # | Test | What it proves |
|---|------|----------------|
| 1 | `transcodeErrorPropagatesNotSilent` | Bug 1: missing parquet → `RuntimeException` thrown (was: silently count=0) |
| 2 | `transcodeErrorPropagatesParquetOnly` | Bug 1, PARQUET_ONLY mode |
| 3 | `lazyTranscodeTermsAggHybrid` | Lazy path (no prewarm) returns correct counts — HYBRID |
| 4 | `lazyTranscodeTermsAggParquetOnly` | Lazy path (no prewarm) returns correct counts — PARQUET_ONLY |
| 5 | `consecutiveLazyAggregationsUseCache` | Second aggregation reuses L1 cache (no re-transcode) |
| 6 | `prewarmThenAggregationUsesCache` | Bug 3a: after prewarm + parquet deleted, aggregation still works (uses prewarm cache — no re-read) |
| 7 | `prewarmThenAggregationParquetOnly` | Bug 3a, PARQUET_ONLY mode |

Tests 1 and 2 **failed before the fix** (no exception thrown — silent count=0). All 7
pass after.

---

## Test results

```
Tests run: 146, Failures: 0, Errors: 0, Skipped: 0  (all ParquetCompanion* tests)
```

- `ParquetCompanionLazyTranscodeTest`  7 / 7  ✅  (7 new, all previously broken)
- `ParquetCompanionAggregationTest`   45 / 45 ✅  (no regression)
- `ParquetCompanionStringTranscodeTest` 16/16 ✅
- `ParquetCompanionTest`              22 / 22 ✅
- All other ParquetCompanion* suites  56 / 56 ✅

---

## Files changed

| File | Change |
|------|--------|
| `native/src/split_searcher/async_impl.rs` | Return `Result<Option<…>>`, defer tracker update, propagate errors |
| `native/src/split_searcher/jni_search.rs` | Propagate error with `?` at call site |
| `native/src/split_searcher/jni_prewarm.rs` | Update `transcoded_fast_columns` after successful prewarm |
| `native/src/parquet_companion/augmented_directory.rs` | Add `effective_column_names()` helper |
| `src/test/java/…/ParquetCompanionLazyTranscodeTest.java` | 7 new reproduction + regression tests |
