### PR TITLE
storage: Disable Fieldnorms by Default in Companion Splits

### DIFF
--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -186,6 +186,7 @@ pub async fn create_split_from_parquet(
         tokenizer_overrides: parquet_config.schema_config.tokenizer_overrides.clone(),
         ip_address_fields: parquet_config.schema_config.ip_address_fields.clone(),
         json_fields: parquet_config.schema_config.json_fields.clone(),
+        fieldnorms_enabled: parquet_config.schema_config.fieldnorms_enabled,
     };
 
     let derived_schema = derive_tantivy_schema_with_mapping(&arrow_schema, &config, Some(&name_mapping))?;

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -25,6 +25,8 @@ pub struct SchemaDerivationConfig {
     pub ip_address_fields: HashSet<String>,
     /// Fields that should be treated as JSON object type (parquet stores as UTF8 strings)
     pub json_fields: HashSet<String>,
+    /// Whether to enable fieldnorms for text fields (default: false)
+    pub fieldnorms_enabled: bool,
 }
 
 impl Default for SchemaDerivationConfig {
@@ -35,6 +37,7 @@ impl Default for SchemaDerivationConfig {
             tokenizer_overrides: std::collections::HashMap::new(),
             ip_address_fields: HashSet::new(),
             json_fields: HashSet::new(),
+            fieldnorms_enabled: false,
         }
     }
 }
@@ -141,7 +144,8 @@ fn add_field_for_arrow_type(
                     .set_indexing_options(
                         TextFieldIndexing::default()
                             .set_tokenizer("default")
-                            .set_index_option(IndexRecordOption::Basic),
+                            .set_index_option(IndexRecordOption::Basic)
+                            .set_fieldnorms(config.fieldnorms_enabled),
                     );
                 builder.add_json_field(name, opts);
                 return Ok(());
@@ -212,7 +216,8 @@ fn add_field_for_arrow_type(
                             .set_indexing_options(
                                 TextFieldIndexing::default()
                                     .set_tokenizer("default")
-                                    .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+                                    .set_index_option(IndexRecordOption::WithFreqsAndPositions)
+                                    .set_fieldnorms(config.fieldnorms_enabled),
                             );
                         builder.add_text_field(name, text_opts);
                         // Companion field: U64 hash field for extracted patterns
@@ -234,7 +239,8 @@ fn add_field_for_arrow_type(
                             .set_indexing_options(
                                 TextFieldIndexing::default()
                                     .set_tokenizer("default")
-                                    .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+                                    .set_index_option(IndexRecordOption::WithFreqsAndPositions)
+                                    .set_fieldnorms(config.fieldnorms_enabled),
                             );
                         builder.add_text_field(name, text_opts);
                     }
@@ -247,7 +253,8 @@ fn add_field_for_arrow_type(
                     .set_indexing_options(
                         TextFieldIndexing::default()
                             .set_tokenizer(tok)
-                            .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+                            .set_index_option(IndexRecordOption::WithFreqsAndPositions)
+                            .set_fieldnorms(config.fieldnorms_enabled),
                     );
                 if should_add_fast(config, name, data_type) {
                     opts = opts.set_fast(Some(tok));
@@ -273,7 +280,8 @@ fn add_field_for_arrow_type(
                 .set_indexing_options(
                     TextFieldIndexing::default()
                         .set_tokenizer(tok)
-                        .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+                        .set_index_option(IndexRecordOption::WithFreqsAndPositions)
+                        .set_fieldnorms(config.fieldnorms_enabled),
                 );
             if should_add_fast(config, name, data_type) {
                 opts = opts.set_fast(Some(tok));
@@ -301,7 +309,8 @@ fn add_field_for_arrow_type(
                 .set_indexing_options(
                     TextFieldIndexing::default()
                         .set_tokenizer("default")
-                        .set_index_option(IndexRecordOption::Basic),
+                        .set_index_option(IndexRecordOption::Basic)
+                        .set_fieldnorms(config.fieldnorms_enabled),
                 );
             builder.add_json_field(name, opts);
         }

--- a/native/src/quickwit_split/jni_functions.rs
+++ b/native/src/quickwit_split/jni_functions.rs
@@ -526,6 +526,10 @@ fn parse_create_from_parquet_config(json_str: &str) -> anyhow::Result<CreateFrom
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
 
+    let fieldnorms_enabled = parsed.get("fieldnorms_enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
     Ok(CreateFromParquetConfig {
         table_root,
         fast_field_mode,
@@ -535,6 +539,7 @@ fn parse_create_from_parquet_config(json_str: &str) -> anyhow::Result<CreateFrom
             tokenizer_overrides,
             ip_address_fields,
             json_fields,
+            fieldnorms_enabled,
         },
         statistics_fields,
         statistics_truncate_length,


### PR DESCRIPTION
# Disable Fieldnorms by Default in Companion Splits

## Summary

- Disable fieldnorms for all text fields in companion split indexing by default, saving ~1 byte per document per indexed field
- Add `ParquetCompanionConfig.withFieldnorms(boolean)` Java API to opt back in when BM25 length normalization is needed

## Motivation

Fieldnorms store 1 byte per document per indexed field, encoding approximate token count for BM25 length normalization. In companion splits, most text fields use the "raw" tokenizer (1 token per value), making fieldnorms constant across all documents and therefore wasteful. For a table with 10M documents and 20 indexed text fields, this saves ~200MB of redundant data.

Numeric, date, bool, and IP fields already default to `fieldnorms: false` (via `NumericOptions::default().set_indexed()`). This change extends that behavior to text fields in companion splits.

## Changes

### Java
- **`ParquetCompanionConfig.java`**: Added `fieldnormsEnabled` field (default `false`), `withFieldnorms(boolean)` builder method, `isFieldnormsEnabled()` getter, and JSON serialization in `toIndexingConfigJson()`

### Rust
- **`schema_derivation.rs`**: Added `fieldnorms_enabled: bool` to `SchemaDerivationConfig` struct (default `false`). Applied `.set_fieldnorms(config.fieldnorms_enabled)` to all 6 `TextFieldIndexing` construction sites:
  - JSON fields (Utf8 forced to JSON)
  - TextUuidExactonly / TextCustomExactonly string indexing modes
  - TextUuidStrip / TextCustomStrip string indexing modes
  - Standard tokenizer path (default "raw")
  - Decimal256 text mapping
  - Complex types (List/Map/Struct) to JSON
- **`jni_functions.rs`**: Parse `fieldnorms_enabled` from indexing config JSON and pass to `SchemaDerivationConfig`
- **`indexing.rs`**: Propagate `fieldnorms_enabled` from `parquet_config.schema_config` to derived config

## Test Plan

- [x] `cargo check` compiles without errors
- [x] `cargo test --lib parquet_companion::schema_derivation` — all 37 tests pass
- [ ] Verify default (false) produces splits without fieldnorm data for text fields
- [ ] Verify `withFieldnorms(true)` restores fieldnorm generation
