### PR TITLE
fix: aggregations broken on merged HYBRID companion splits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.30.4</version>
+    <version>0.30.5</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>


### PR DESCRIPTION
# Fix aggregations on merged HYBRID companion splits

## Summary

Aggregations on merged HYBRID companion splits were failing with "not configured as fast field" because the merge path was missing the `promote_doc_mapping_all_fast()` call that the build path performs.

When `createFromParquet` builds a companion split, it promotes all fields to `fast=true` in the `doc_mapping_json` so clients know aggregations are available (via parquet transcoding or native fast fields). The merge path in `merge_impl.rs` extracted the raw doc mapping without this promotion, so merged splits reported fields as non-fast.

## Root cause

```
Build path (indexing.rs):
  extract_doc_mapping_from_index() → promote_doc_mapping_all_fast() → fast=true ✓

Merge path (merge_impl.rs) BEFORE fix:
  extract_doc_mapping_from_index() → fast=false ✗ → aggregations fail
```

## Fix

Added `promote_doc_mapping_all_fast()` to the merge path, gated on `is_companion_merge` so non-companion splits continue to report their actual fast field configuration. The companion/non-companion distinction comes from whether `combine_parquet_manifests()` found manifests in the source splits.

## Changes

| File | Description |
|------|-------------|
| `native/src/quickwit_split/merge_impl.rs` | Hoist `is_companion_merge` flag from manifest combination; conditionally promote doc mapping fields to fast |
| `ParquetCompanionAggregationTest.java` | New regression test: build two HYBRID companion splits, merge them, run stats + terms aggregations on the merged result |
| `pom.xml` | Version 0.30.4 → 0.30.5 |

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `mvn test -Dtest="ParquetCompanionAggregationTest#mergedHybridCompanionSplitAggregation"` — new regression test passes
- [x] `mvn test -Dtest="ParquetCompanionAggregationTest"` — all 46 tests pass
- [x] Non-companion merges unaffected (promotion only runs when `is_companion_merge == true`)
