### PR TITLE
perf: Performance Optimizations, Instrumentation, Prewarm Gap Fixes & Parquet Page Index

### DIFF
--- a/native/src/parquet_companion/arrow_to_tant.rs
+++ b/native/src/parquet_companion/arrow_to_tant.rs
@@ -15,8 +15,8 @@ use quickwit_storage::Storage;
 use crate::perf_println;
 use super::cached_reader::{ByteRangeCache, CachedParquetReader, CoalesceConfig};
 use super::doc_retrieval::{
-    arrow_json_value, build_column_projection, build_row_selection_for_rows_in_selected_groups,
-    compute_row_group_filter,
+    arrow_json_value, attach_page_locations, build_column_projection,
+    build_row_selection_for_rows_in_selected_groups, compute_row_group_filter,
 };
 use super::docid_mapping::group_doc_addresses_by_file;
 use super::manifest::{ColumnMapping, ParquetManifest};
@@ -460,6 +460,7 @@ pub async fn batch_parquet_to_tant_buffer_by_groups(
                 } else {
                     reader
                 };
+                let reader = attach_page_locations(reader, file_entry);
 
                 let t_builder = std::time::Instant::now();
                 let builder = ParquetRecordBatchStreamBuilder::new(reader)

--- a/native/src/parquet_companion/mod.rs
+++ b/native/src/parquet_companion/mod.rs
@@ -24,11 +24,12 @@ pub mod arrow_to_tant;
 pub mod hash_field_rewriter;
 pub mod hash_touchup;
 pub mod string_indexing;
+pub(crate) mod page_index;
 
 pub use manifest::{
     ParquetManifest, FastFieldMode, SegmentRowRange, ParquetFileEntry,
     RowGroupEntry, ColumnChunkInfo, ColumnMapping, ParquetStorageConfigMeta,
-    SUPPORTED_MANIFEST_VERSION,
+    PageLocationEntry, SUPPORTED_MANIFEST_VERSION,
 };
 pub use manifest_io::{serialize_manifest, deserialize_manifest, MANIFEST_FILENAME};
 pub use docid_mapping::{translate_to_global_row, locate_row_in_file, group_doc_addresses_by_file};

--- a/native/src/parquet_companion/page_index.rs
+++ b/native/src/parquet_companion/page_index.rs
@@ -1,0 +1,635 @@
+// page_index.rs - Compute page-level offset index for parquet column chunks
+//
+// For parquet files that lack a native offset index in their footer, this module
+// scans the Thrift-encoded page headers within each column chunk to compute
+// page locations (offset, compressed_page_size, first_row_index). These are
+// stored in the manifest and injected at read time to enable page-level byte
+// range reads instead of full column chunk downloads.
+//
+// Uses a self-contained minimal Thrift compact protocol parser — no dependency
+// on the parquet crate's internal (non-public) Thrift types.
+
+use std::io::{Read, Seek, SeekFrom};
+
+use anyhow::{Context, Result};
+
+use super::manifest::PageLocationEntry;
+
+/// Parquet page type constants (from parquet.thrift)
+const PAGE_TYPE_DATA_PAGE: i32 = 0;
+const PAGE_TYPE_INDEX_PAGE: i32 = 1;
+const PAGE_TYPE_DICTIONARY_PAGE: i32 = 2;
+const PAGE_TYPE_DATA_PAGE_V2: i32 = 3;
+
+/// Compute page locations for a single column chunk by scanning
+/// Thrift-encoded page headers from the raw column chunk bytes.
+///
+/// This is used for parquet files that don't have an offset index
+/// in their footer. The computed locations enable page-level byte
+/// range reads at query time.
+///
+/// # Arguments
+/// * `file` - Open file handle for the parquet file
+/// * `data_page_offset` - Byte offset of the first data page in this column chunk
+/// * `total_compressed_size` - Total compressed size of the column chunk
+/// * `dictionary_page_offset` - Optional byte offset of the dictionary page
+pub fn compute_page_locations_from_column_chunk(
+    file: &std::fs::File,
+    data_page_offset: u64,
+    total_compressed_size: u64,
+    dictionary_page_offset: Option<u64>,
+) -> Result<Vec<PageLocationEntry>> {
+    // The column chunk starts at dictionary_page_offset (if present) or data_page_offset.
+    // total_compressed_size covers ALL pages in the chunk (dict + data), measured from the
+    // start of the column chunk.
+    let start_offset = dictionary_page_offset.unwrap_or(data_page_offset);
+    let end_offset = start_offset + total_compressed_size;
+
+    if end_offset <= start_offset {
+        return Ok(Vec::new());
+    }
+
+    let chunk_len = (end_offset - start_offset) as usize;
+
+    // Read column chunk bytes into buffer
+    let mut buf = vec![0u8; chunk_len];
+    let mut file_reader = std::io::BufReader::new(file);
+    file_reader
+        .seek(SeekFrom::Start(start_offset))
+        .context("Failed to seek to column chunk start")?;
+    file_reader
+        .read_exact(&mut buf)
+        .context("Failed to read column chunk bytes")?;
+
+    let mut locations = Vec::new();
+    let mut pos: usize = 0;
+    let mut cumulative_rows: i64 = 0;
+
+    while pos < chunk_len {
+        let page_file_offset = start_offset + pos as u64;
+        let remaining = &buf[pos..];
+
+        // Parse the Thrift-encoded PageHeader
+        let header = parse_page_header(remaining)
+            .with_context(|| format!(
+                "Failed to parse page header at offset {} (pos {} of {} chunk bytes)",
+                page_file_offset, pos, chunk_len
+            ))?;
+
+        // total_page_size = header_size + compressed_page_body_size
+        let total_page_size = header.header_size as i32 + header.compressed_page_size;
+
+        // Only include DATA pages in the offset index — per the Parquet spec,
+        // the OffsetIndex contains page locations for data pages only. Dictionary
+        // pages are NOT included; the reader handles them separately via the
+        // column chunk's dictionary_page_offset metadata.
+        match header.page_type {
+            PAGE_TYPE_DATA_PAGE => {
+                locations.push(PageLocationEntry {
+                    offset: page_file_offset as i64,
+                    compressed_page_size: total_page_size,
+                    first_row_index: cumulative_rows,
+                });
+                cumulative_rows += header.num_values as i64;
+            }
+            PAGE_TYPE_DATA_PAGE_V2 => {
+                locations.push(PageLocationEntry {
+                    offset: page_file_offset as i64,
+                    compressed_page_size: total_page_size,
+                    first_row_index: cumulative_rows,
+                });
+                cumulative_rows += header.num_values as i64;
+            }
+            PAGE_TYPE_DICTIONARY_PAGE | PAGE_TYPE_INDEX_PAGE => {
+                // Dictionary/index pages are NOT part of the offset index.
+                // The reader fetches dictionary pages separately using
+                // the column chunk metadata's dictionary_page_offset.
+            }
+            _ => {}
+        }
+
+        // Advance past header + compressed page body
+        let advance = header.header_size + header.compressed_page_size as usize;
+        if advance == 0 {
+            // Safety: prevent infinite loop on malformed data
+            break;
+        }
+        pos += advance;
+    }
+
+    Ok(locations)
+}
+
+/// Parsed page header — only the fields we need.
+struct ParsedPageHeader {
+    page_type: i32,
+    compressed_page_size: i32,
+    /// Number of values in this page (from data_page_header or data_page_header_v2).
+    /// 0 for dictionary/index pages.
+    num_values: i32,
+    /// Number of bytes consumed by the Thrift header encoding.
+    header_size: usize,
+}
+
+/// Parse a Thrift compact-encoded PageHeader from the start of `data`.
+///
+/// PageHeader fields (from parquet.thrift):
+///   1: required PageType type         (i32 enum)
+///   2: required i32 uncompressed_page_size
+///   3: required i32 compressed_page_size
+///   4: optional i32 crc
+///   5: optional DataPageHeader data_page_header
+///   6: optional IndexPageHeader index_page_header
+///   7: optional DictionaryPageHeader dictionary_page_header
+///   8: optional DataPageHeaderV2 data_page_header_v2
+fn parse_page_header(data: &[u8]) -> Result<ParsedPageHeader> {
+    let mut reader = ThriftReader::new(data);
+
+    let mut page_type: Option<i32> = None;
+    let mut compressed_page_size: Option<i32> = None;
+    let mut num_values: i32 = 0;
+
+    // Read struct fields until stop
+    let mut last_field_id: i16 = 0;
+    loop {
+        let (field_type, field_id) = reader.read_field_header(last_field_id)?;
+        if field_type == THRIFT_TYPE_STOP {
+            break;
+        }
+        last_field_id = field_id;
+
+        match field_id {
+            1 => {
+                // type: i32 (PageType enum)
+                page_type = Some(reader.read_i32()?);
+            }
+            2 => {
+                // uncompressed_page_size: i32 — read and discard
+                reader.read_i32()?;
+            }
+            3 => {
+                // compressed_page_size: i32
+                compressed_page_size = Some(reader.read_i32()?);
+            }
+            4 => {
+                // crc: optional i32
+                reader.read_i32()?;
+            }
+            5 => {
+                // data_page_header: DataPageHeader struct
+                // field 1 is num_values (i32)
+                num_values = read_first_i32_from_struct(&mut reader)?;
+            }
+            6 => {
+                // index_page_header: empty struct
+                reader.skip_field(field_type)?;
+            }
+            7 => {
+                // dictionary_page_header: DictionaryPageHeader struct
+                // field 1 is num_values — we don't need it but must skip the struct
+                reader.skip_field(field_type)?;
+            }
+            8 => {
+                // data_page_header_v2: DataPageHeaderV2 struct
+                // field 1 is num_values (i32)
+                num_values = read_first_i32_from_struct(&mut reader)?;
+            }
+            _ => {
+                reader.skip_field(field_type)?;
+            }
+        }
+    }
+
+    let page_type = page_type
+        .ok_or_else(|| anyhow::anyhow!("PageHeader missing required field: type"))?;
+    let compressed_page_size = compressed_page_size
+        .ok_or_else(|| anyhow::anyhow!("PageHeader missing required field: compressed_page_size"))?;
+
+    Ok(ParsedPageHeader {
+        page_type,
+        compressed_page_size,
+        num_values,
+        header_size: reader.position(),
+    })
+}
+
+/// Read the first i32 field from a sub-struct, then skip the rest.
+/// Used for DataPageHeader.num_values and DataPageHeaderV2.num_values.
+fn read_first_i32_from_struct(reader: &mut ThriftReader) -> Result<i32> {
+    let mut result: i32 = 0;
+    let mut last_field_id: i16 = 0;
+    let mut got_first = false;
+
+    loop {
+        let (field_type, field_id) = reader.read_field_header(last_field_id)?;
+        if field_type == THRIFT_TYPE_STOP {
+            break;
+        }
+        last_field_id = field_id;
+
+        if !got_first && field_id == 1 {
+            result = reader.read_i32()?;
+            got_first = true;
+        } else {
+            reader.skip_field(field_type)?;
+        }
+    }
+
+    Ok(result)
+}
+
+// ─── Minimal Thrift Compact Protocol Parser ────────────────────────────────
+
+/// Thrift compact protocol type constants
+const THRIFT_TYPE_STOP: u8 = 0;
+const THRIFT_TYPE_BOOL_TRUE: u8 = 1;
+const THRIFT_TYPE_BOOL_FALSE: u8 = 2;
+const THRIFT_TYPE_I8: u8 = 3;
+const THRIFT_TYPE_I16: u8 = 4;
+const THRIFT_TYPE_I32: u8 = 5;
+const THRIFT_TYPE_I64: u8 = 6;
+const THRIFT_TYPE_DOUBLE: u8 = 7;
+const THRIFT_TYPE_BINARY: u8 = 8;
+const THRIFT_TYPE_LIST: u8 = 9;
+const THRIFT_TYPE_SET: u8 = 10;
+const THRIFT_TYPE_MAP: u8 = 11;
+const THRIFT_TYPE_STRUCT: u8 = 12;
+
+/// Minimal Thrift compact protocol reader operating on a byte slice.
+struct ThriftReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> ThriftReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn position(&self) -> usize {
+        self.pos
+    }
+
+    fn read_byte(&mut self) -> Result<u8> {
+        if self.pos >= self.data.len() {
+            anyhow::bail!("Thrift: unexpected end of data at pos {}", self.pos);
+        }
+        let b = self.data[self.pos];
+        self.pos += 1;
+        Ok(b)
+    }
+
+    /// Read a varint (unsigned LEB128)
+    fn read_varint(&mut self) -> Result<u64> {
+        let mut result: u64 = 0;
+        let mut shift: u32 = 0;
+        loop {
+            let b = self.read_byte()?;
+            result |= ((b & 0x7F) as u64) << shift;
+            if b & 0x80 == 0 {
+                return Ok(result);
+            }
+            shift += 7;
+            if shift >= 64 {
+                anyhow::bail!("Thrift: varint too long at pos {}", self.pos);
+            }
+        }
+    }
+
+    /// Read a zigzag-encoded i32
+    fn read_i32(&mut self) -> Result<i32> {
+        let n = self.read_varint()? as u32;
+        Ok(((n >> 1) as i32) ^ -((n & 1) as i32))
+    }
+
+    /// Read a zigzag-encoded i64
+    fn read_i64(&mut self) -> Result<i64> {
+        let n = self.read_varint()?;
+        Ok(((n >> 1) as i64) ^ -((n & 1) as i64))
+    }
+
+    /// Read a zigzag-encoded i16
+    fn read_i16(&mut self) -> Result<i16> {
+        let n = self.read_varint()? as u16;
+        Ok(((n >> 1) as i16) ^ -((n & 1) as i16))
+    }
+
+    /// Read a field header. Returns (field_type, field_id).
+    /// field_type == THRIFT_TYPE_STOP (0) means end of struct.
+    fn read_field_header(&mut self, last_field_id: i16) -> Result<(u8, i16)> {
+        let b = self.read_byte()?;
+        if b == 0 {
+            return Ok((THRIFT_TYPE_STOP, 0));
+        }
+
+        let delta = (b >> 4) & 0x0F;
+        let field_type = b & 0x0F;
+
+        let field_id = if delta != 0 {
+            last_field_id + delta as i16
+        } else {
+            // Absolute field ID encoded as zigzag i16
+            self.read_i16()?
+        };
+
+        Ok((field_type, field_id))
+    }
+
+    /// Skip a field of the given type
+    fn skip_field(&mut self, field_type: u8) -> Result<()> {
+        match field_type {
+            THRIFT_TYPE_BOOL_TRUE | THRIFT_TYPE_BOOL_FALSE => {}
+            THRIFT_TYPE_I8 => {
+                self.read_byte()?;
+            }
+            THRIFT_TYPE_I16 | THRIFT_TYPE_I32 => {
+                self.read_varint()?;
+            }
+            THRIFT_TYPE_I64 => {
+                self.read_varint()?;
+            }
+            THRIFT_TYPE_DOUBLE => {
+                if self.pos + 8 > self.data.len() {
+                    anyhow::bail!("Thrift: unexpected end of data skipping double");
+                }
+                self.pos += 8;
+            }
+            THRIFT_TYPE_BINARY => {
+                let len = self.read_varint()? as usize;
+                if self.pos + len > self.data.len() {
+                    anyhow::bail!("Thrift: unexpected end of data skipping binary of len {}", len);
+                }
+                self.pos += len;
+            }
+            THRIFT_TYPE_LIST | THRIFT_TYPE_SET => {
+                self.skip_list()?;
+            }
+            THRIFT_TYPE_MAP => {
+                self.skip_map()?;
+            }
+            THRIFT_TYPE_STRUCT => {
+                self.skip_struct()?;
+            }
+            _ => {
+                anyhow::bail!("Thrift: unknown field type {} at pos {}", field_type, self.pos);
+            }
+        }
+        Ok(())
+    }
+
+    fn skip_struct(&mut self) -> Result<()> {
+        let mut last_field_id: i16 = 0;
+        loop {
+            let (ft, fid) = self.read_field_header(last_field_id)?;
+            if ft == THRIFT_TYPE_STOP {
+                break;
+            }
+            last_field_id = fid;
+            self.skip_field(ft)?;
+        }
+        Ok(())
+    }
+
+    fn skip_list(&mut self) -> Result<()> {
+        let header = self.read_byte()?;
+        let (size, elem_type) = if (header >> 4) == 0x0F {
+            let size = self.read_varint()? as usize;
+            let elem_type = header & 0x0F;
+            (size, elem_type)
+        } else {
+            let size = ((header >> 4) & 0x0F) as usize;
+            let elem_type = header & 0x0F;
+            (size, elem_type)
+        };
+        for _ in 0..size {
+            self.skip_field(elem_type)?;
+        }
+        Ok(())
+    }
+
+    fn skip_map(&mut self) -> Result<()> {
+        let size = self.read_varint()? as usize;
+        if size == 0 {
+            return Ok(());
+        }
+        let types = self.read_byte()?;
+        let key_type = (types >> 4) & 0x0F;
+        let val_type = types & 0x0F;
+        for _ in 0..size {
+            self.skip_field(key_type)?;
+            self.skip_field(val_type)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+    use parquet::file::reader::FileReader;
+
+    /// Create a minimal parquet file without offset index and verify page location computation.
+    #[test]
+    fn test_compute_page_locations_from_small_parquet() {
+        use parquet::file::properties::WriterProperties;
+        use parquet::arrow::ArrowWriter;
+        use arrow_array::{Int64Array, RecordBatch};
+        use arrow_schema::{Schema, Field, DataType};
+        use std::sync::Arc;
+
+        // Create a small parquet file with known structure
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+        ]));
+
+        let mut tmpfile = NamedTempFile::new().unwrap();
+
+        // Write with small page size to get multiple pages
+        let props = WriterProperties::builder()
+            .set_data_page_size_limit(64) // Force small pages
+            .set_write_batch_size(10)
+            .set_max_row_group_size(1000)
+            .build();
+
+        let ids: Vec<i64> = (0..100).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(ids))],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(
+            tmpfile.as_file_mut(),
+            schema.clone(),
+            Some(props),
+        ).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read metadata to get column chunk info
+        let file = std::fs::File::open(tmpfile.path()).unwrap();
+        let reader = parquet::file::serialized_reader::SerializedFileReader::new(file).unwrap();
+        let metadata = reader.metadata();
+
+        assert!(metadata.num_row_groups() > 0);
+        let rg = metadata.row_group(0);
+        assert!(rg.num_columns() > 0);
+        let col = rg.column(0);
+
+        let data_page_offset = col.data_page_offset() as u64;
+        let compressed_size = col.compressed_size() as u64;
+        let dict_offset = col.dictionary_page_offset().map(|o| o as u64);
+
+        // Compute page locations
+        let file = std::fs::File::open(tmpfile.path()).unwrap();
+        let locations = compute_page_locations_from_column_chunk(
+            &file,
+            data_page_offset,
+            compressed_size,
+            dict_offset,
+        ).unwrap();
+
+        // Verify: should have at least one page (data pages only, not dictionary)
+        assert!(!locations.is_empty(), "Expected at least one data page location");
+
+        // First data page offset should be at or after data_page_offset
+        // (dictionary pages come before data_page_offset and are excluded)
+        assert!(
+            locations[0].offset >= data_page_offset as i64,
+            "First data page offset ({}) should be >= data_page_offset ({})",
+            locations[0].offset, data_page_offset
+        );
+
+        // first_row_index should be monotonically non-decreasing
+        for i in 1..locations.len() {
+            assert!(
+                locations[i].first_row_index >= locations[i - 1].first_row_index,
+                "first_row_index should be monotonically non-decreasing"
+            );
+        }
+
+        // All compressed_page_size values should be positive
+        for loc in &locations {
+            assert!(
+                loc.compressed_page_size > 0,
+                "compressed_page_size should be positive, got {}",
+                loc.compressed_page_size
+            );
+        }
+
+        // Total first_row_index of last data page + its rows should account for all rows
+        // (We can't verify exact count without knowing per-page row counts, but the
+        // cumulative_rows tracking should equal num_rows for proper data pages)
+    }
+
+    /// Test with a parquet file that has a dictionary page
+    #[test]
+    fn test_compute_page_locations_with_dictionary() {
+        use parquet::file::properties::WriterProperties;
+        use parquet::arrow::ArrowWriter;
+        use arrow_array::{StringArray, RecordBatch};
+        use arrow_schema::{Schema, Field, DataType};
+        use std::sync::Arc;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("category", DataType::Utf8, false),
+        ]));
+
+        let mut tmpfile = NamedTempFile::new().unwrap();
+
+        // Use dictionary encoding (default for strings) with small pages
+        let props = WriterProperties::builder()
+            .set_dictionary_enabled(true)
+            .set_data_page_size_limit(128)
+            .set_max_row_group_size(1000)
+            .build();
+
+        // Create repeated strings to trigger dictionary encoding
+        let values: Vec<String> = (0..200).map(|i| format!("cat_{}", i % 10)).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(values))],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(
+            tmpfile.as_file_mut(),
+            schema.clone(),
+            Some(props),
+        ).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read metadata
+        let file = std::fs::File::open(tmpfile.path()).unwrap();
+        let reader = parquet::file::serialized_reader::SerializedFileReader::new(file).unwrap();
+        let metadata = reader.metadata();
+        let col = metadata.row_group(0).column(0);
+
+        let data_page_offset = col.data_page_offset() as u64;
+        let compressed_size = col.compressed_size() as u64;
+        let dict_offset = col.dictionary_page_offset().map(|o| o as u64);
+
+        let file = std::fs::File::open(tmpfile.path()).unwrap();
+        let locations = compute_page_locations_from_column_chunk(
+            &file,
+            data_page_offset,
+            compressed_size,
+            dict_offset,
+        ).unwrap();
+
+        assert!(!locations.is_empty());
+
+        // Dictionary pages should NOT appear in the offset index — only data pages.
+        // First data page should have first_row_index = 0.
+        assert_eq!(
+            locations[0].first_row_index, 0,
+            "First data page should have first_row_index = 0"
+        );
+
+        // Verify the first location offset is at or after the data_page_offset
+        // (dictionary pages, if any, come before data_page_offset)
+        if dict_offset.is_some() {
+            assert!(
+                locations[0].offset >= data_page_offset as i64,
+                "First data page offset ({}) should be at or after data_page_offset ({})",
+                locations[0].offset, data_page_offset
+            );
+        }
+    }
+
+    #[test]
+    fn test_thrift_reader_varint() {
+        // Test varint decoding
+        let data = [0x00]; // varint 0
+        let mut reader = ThriftReader::new(&data);
+        assert_eq!(reader.read_varint().unwrap(), 0);
+
+        let data = [0x01]; // varint 1
+        let mut reader = ThriftReader::new(&data);
+        assert_eq!(reader.read_varint().unwrap(), 1);
+
+        let data = [0xAC, 0x02]; // varint 300
+        let mut reader = ThriftReader::new(&data);
+        assert_eq!(reader.read_varint().unwrap(), 300);
+    }
+
+    #[test]
+    fn test_thrift_reader_zigzag_i32() {
+        // zigzag: 0 → 0, 1 → -1, 2 → 1, 3 → -2, 4 → 2
+        let data = [0x00]; // zigzag 0 → 0
+        let mut reader = ThriftReader::new(&data);
+        assert_eq!(reader.read_i32().unwrap(), 0);
+
+        let data = [0x01]; // zigzag 1 → -1
+        let mut reader = ThriftReader::new(&data);
+        assert_eq!(reader.read_i32().unwrap(), -1);
+
+        let data = [0x02]; // zigzag 2 → 1
+        let mut reader = ThriftReader::new(&data);
+        assert_eq!(reader.read_i32().unwrap(), 1);
+
+        let data = [0x04]; // zigzag 4 → 2
+        let mut reader = ThriftReader::new(&data);
+        assert_eq!(reader.read_i32().unwrap(), 2);
+    }
+}

--- a/native/src/prewarm/field_specific.rs
+++ b/native/src/prewarm/field_specific.rs
@@ -16,7 +16,7 @@ use crate::utils::with_arc_safe;
 /// For field "X": also includes "X__uuids" and "_phash_X" if they exist.
 /// This ensures that field-specific prewarm also warms companion fields used by
 /// aggregations and doc retrieval, preventing query-time downloads.
-fn expand_companion_fields(
+pub(crate) fn expand_companion_fields(
     field_names: &HashSet<String>,
     schema: &tantivy::schema::Schema,
 ) -> HashSet<String> {

--- a/native/src/prewarm/mod.rs
+++ b/native/src/prewarm/mod.rs
@@ -52,7 +52,7 @@
 mod all_fields;
 mod cache_extension;
 mod component_sizes;
-mod field_specific;
+pub(crate) mod field_specific;
 mod helpers;
 
 // Re-export public API - all-fields prewarm functions

--- a/native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs
+++ b/native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs
@@ -896,7 +896,7 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
                     &storage,
                     Some(metadata_cache),
                     Some(byte_cache),
-                    None,
+                    ctx.parquet_coalesce_config,
                 )
                 .await
             })
@@ -1098,7 +1098,7 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
                     &storage,
                     Some(metadata_cache),
                     Some(byte_cache),
-                    None,
+                    ctx.parquet_coalesce_config,
                 )
                 .await;
                 perf_println!(

--- a/native/src/split_searcher/types.rs
+++ b/native/src/split_searcher/types.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::ops::Range;
 use quickwit_storage::{Storage, ByteRangeCache};
 use crate::perf_println;
+use crate::debug_println;
 use crate::standalone_searcher::StandaloneSearcher;
 use crate::parquet_companion::manifest::ParquetManifest;
 
@@ -202,6 +203,54 @@ impl CachedSearcherContext {
 
         perf_println!("⏱️ PROJ_DIAG: ensure_pq_segment_loaded seg={} TOTAL {}ms (self={:p})",
             seg_ord, t0.elapsed().as_millis(), self);
+        Ok(())
+    }
+
+    /// Warm all native fast field columns into L1 CachingDirectory cache.
+    /// The component-level FASTFIELD prewarm writes .fast files to L2 disk cache,
+    /// but the CachingDirectory's L1 ByteRangeCache needs individual column byte ranges
+    /// to be read through the async path. Without this, the first aggregation that touches
+    /// a native fast field column (e.g. _phash_*) triggers a storage download.
+    pub(crate) async fn warm_native_fast_fields_l1(&self) -> anyhow::Result<()> {
+        let schema = self.cached_searcher.index().schema();
+        let field_names: Vec<String> = schema.fields()
+            .map(|(_, entry)| entry.name().to_string())
+            .collect();
+        self.warm_native_fast_fields_l1_for_fields(&field_names).await
+    }
+
+    /// Warm specific native fast field columns into L1 CachingDirectory cache.
+    /// Only reads byte ranges for the given field names (and silently skips any
+    /// that don't have fast field data in the segment).
+    pub(crate) async fn warm_native_fast_fields_l1_for_fields(&self, field_names: &[String]) -> anyhow::Result<()> {
+        let num_segments = self.cached_searcher.segment_readers().len();
+        let mut total_bytes = 0usize;
+        let mut total_columns = 0usize;
+
+        for seg_ord in 0..num_segments {
+            let segment_reader = self.cached_searcher.segment_reader(seg_ord as u32);
+            let fast_fields = segment_reader.fast_fields();
+
+            for field_name in field_names {
+                let handles = match fast_fields.list_dynamic_column_handles(field_name).await {
+                    Ok(h) => h,
+                    Err(_) => continue, // field may not have fast field data
+                };
+                for handle in handles {
+                    let file_slice = handle.file_slice();
+                    match file_slice.read_bytes_async().await {
+                        Ok(bytes) => {
+                            total_bytes += bytes.len();
+                            total_columns += 1;
+                        }
+                        Err(_) => {} // skip on error
+                    }
+                }
+            }
+        }
+
+        debug_println!("✅ PREWARM: Warmed {} native fast field columns ({} bytes) into L1 across {} segments",
+            total_columns, total_bytes, num_segments);
         Ok(())
     }
 

--- a/native/src/split_searcher/types.rs
+++ b/native/src/split_searcher/types.rs
@@ -90,6 +90,10 @@ pub(crate) struct CachedSearcherContext {
     // Dictionary pages are large (800KB-1MB) and must be fetched for every doc retrieval.
     // This cache ensures they're fetched from S3/Azure only once and reused across calls.
     pub(crate) parquet_byte_range_cache: crate::parquet_companion::cached_reader::ByteRangeCache,
+    // Parquet companion mode: optional coalesce configuration for byte-range merging.
+    // Controls max_gap between ranges that get merged into single fetch requests.
+    // None = use default (512KB gap). Smaller values reduce over-fetch for projected reads.
+    pub(crate) parquet_coalesce_config: Option<crate::parquet_companion::cached_reader::CoalesceConfig>,
     // Parquet companion mode: pre-built lookup from file path hash → file index.
     // Built once from manifest.parquet_files, used for O(1) fast-field-based doc resolution.
     pub(crate) parquet_file_hash_index: HashMap<u64, usize>,

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.30.7</version>
+    <version>0.30.8</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.30.6</version>
+    <version>0.30.7</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>

--- a/src/main/java/io/indextables/tantivy4java/split/SplitSearcher.java
+++ b/src/main/java/io/indextables/tantivy4java/split/SplitSearcher.java
@@ -827,7 +827,13 @@ public class SplitSearcher implements AutoCloseable {
      */
     public CompletableFuture<Void> preloadParquetFastFields(String... columns) {
         return CompletableFuture.runAsync(() -> {
-            nativePrewarmParquetFastFields(nativePtr, columns);
+            boolean success = nativePrewarmParquetFastFields(nativePtr, columns);
+            if (!success) {
+                throw new RuntimeException(
+                    "preloadParquetFastFields failed — check stderr for details. "
+                    + "Common cause: parquet_table_root not set. "
+                    + "Configure via CacheConfig.withParquetTableRoot() or pass table root to createSplitSearcher().");
+            }
         });
     }
 
@@ -843,7 +849,13 @@ public class SplitSearcher implements AutoCloseable {
      */
     public CompletableFuture<Void> preloadParquetColumns(String... columns) {
         return CompletableFuture.runAsync(() -> {
-            nativePrewarmParquetColumns(nativePtr, columns);
+            boolean success = nativePrewarmParquetColumns(nativePtr, columns);
+            if (!success) {
+                throw new RuntimeException(
+                    "preloadParquetColumns failed — check stderr for details. "
+                    + "Common cause: parquet_table_root not set. "
+                    + "Configure via CacheConfig.withParquetTableRoot() or pass table root to createSplitSearcher().");
+            }
         });
     }
 

--- a/src/main/java/io/indextables/tantivy4java/split/merge/QuickwitSplit.java
+++ b/src/main/java/io/indextables/tantivy4java/split/merge/QuickwitSplit.java
@@ -1365,6 +1365,15 @@ public class QuickwitSplit {
     public static native void nativeWriteTestParquet(String path, int numRows, long idOffset);
 
     /**
+     * Test helper: write a parquet file WITHOUT offset index (legacy format).
+     * Same schema as nativeWriteTestParquet but with offset index explicitly disabled,
+     * simulating legacy parquet files that don't have page-level offset information.
+     * Schema: id (i64), name (utf8), score (f64), active (bool), category (utf8).
+     * Rows: numRows rows with ids starting from idOffset.
+     */
+    public static native void nativeWriteTestParquetNoPageIndex(String path, int numRows, long idOffset);
+
+    /**
      * Test helper: write a parquet file with ALL data types including complex ones.
      * Schema: id (i64), name (utf8), score (f64), active (bool),
      *         created_at (timestamp micros), tags (list&lt;utf8&gt;),

--- a/src/test/java/io/indextables/tantivy4java/MultiParquetPrewarmTest.java
+++ b/src/test/java/io/indextables/tantivy4java/MultiParquetPrewarmTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.indextables.tantivy4java;
+
+import io.indextables.tantivy4java.core.DocAddress;
+import io.indextables.tantivy4java.core.Document;
+import io.indextables.tantivy4java.result.*;
+import io.indextables.tantivy4java.split.*;
+import io.indextables.tantivy4java.split.merge.*;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates that a companion split backed by 5 parquet files correctly prewarms
+ * and retrieves data from ALL files with zero post-prewarm storage downloads.
+ *
+ * Setup:
+ *   - 5 parquet files, each with 20 rows (100 total), 5 columns each
+ *   - idOffset ensures non-overlapping IDs across files (0-19, 20-39, ..., 80-99)
+ *   - Prewarm only 1 parquet column ("name") + TERM dictionary
+ *   - Query match-all, retrieve all 100 rows, assert data from all 5 files present
+ *   - Assert zero storage downloads after prewarm
+ *
+ * Run with: mvn test -Dtest=MultiParquetPrewarmTest
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class MultiParquetPrewarmTest {
+
+    private static final int NUM_FILES = 5;
+    private static final int ROWS_PER_FILE = 20;
+    private static final int TOTAL_ROWS = NUM_FILES * ROWS_PER_FILE;
+
+    @Test
+    @Order(1)
+    @DisplayName("5 parquet files: prewarm 1 column + TERM, retrieve all rows, zero downloads")
+    void multiFilePrewarmAndRetrieve(@TempDir Path dir) throws Exception {
+        // ── CREATE 5 PARQUET FILES ──────────────────────────────────
+        List<String> parquetPaths = new ArrayList<>();
+        for (int i = 0; i < NUM_FILES; i++) {
+            Path pqFile = dir.resolve("data_" + i + ".parquet");
+            long idOffset = (long) i * ROWS_PER_FILE;
+            QuickwitSplit.nativeWriteTestParquet(pqFile.toString(), ROWS_PER_FILE, idOffset);
+            parquetPaths.add(pqFile.toString());
+            System.out.println("Created parquet file " + i + ": " + pqFile.getFileName()
+                    + " (ids " + idOffset + ".." + (idOffset + ROWS_PER_FILE - 1) + ")");
+        }
+
+        // ── INDEX INTO A SINGLE COMPANION SPLIT ─────────────────────
+        Path splitFile = dir.resolve("multi.split");
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                parquetPaths, splitFile.toString(), config);
+
+        assertNotNull(metadata);
+        assertEquals(TOTAL_ROWS, metadata.getNumDocs(),
+                "Split should contain all " + TOTAL_ROWS + " rows from " + NUM_FILES + " files");
+        System.out.println("Created companion split: " + splitFile.getFileName()
+                + " (" + metadata.getNumDocs() + " docs from " + NUM_FILES + " files)");
+
+        // ── OPEN SEARCHER ───────────────────────────────────────────
+        Path diskCache = dir.resolve("disk-cache");
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCache.toString())
+                .withMaxDiskSize(100_000_000);
+
+        SplitCacheManager.CacheConfig cacheConfig =
+                new SplitCacheManager.CacheConfig("multi-pq-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withParquetTableRoot(dir.toString())
+                        .withTieredCache(tiered);
+
+        try (SplitCacheManager cm = SplitCacheManager.getInstance(cacheConfig)) {
+            String splitUri = "file://" + splitFile.toAbsolutePath();
+            try (SplitSearcher searcher = cm.createSplitSearcher(splitUri, metadata)) {
+                assertTrue(searcher.hasParquetCompanion(), "Should be a parquet companion split");
+
+                // ── PREWARM: TERM dictionary + 1 parquet column ("name") ──
+                System.out.println("\n[PREWARM] Loading TERM dictionary...");
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                searcher.preloadComponents(
+                        SplitSearcher.IndexComponent.TERM,
+                        SplitSearcher.IndexComponent.POSTINGS,
+                        SplitSearcher.IndexComponent.FASTFIELD,
+                        SplitSearcher.IndexComponent.FIELDNORM
+                ).join();
+
+                var afterSplitPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("   Split component prewarm: "
+                        + afterSplitPrewarm.getTotalDownloads() + " downloads ("
+                        + afterSplitPrewarm.getTotalBytes() + " bytes)");
+
+                System.out.println("[PREWARM] Loading parquet column 'name' across all files...");
+                searcher.preloadParquetColumns("name").join();
+
+                var afterPqPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("   After parquet column prewarm: "
+                        + afterPqPrewarm.getTotalDownloads() + " total downloads ("
+                        + afterPqPrewarm.getTotalBytes() + " bytes)");
+                assertTrue(afterPqPrewarm.getTotalDownloads() > 0,
+                        "Prewarm should have downloaded data");
+
+                // Wait for async cache writes
+                Thread.sleep(3000);
+
+                // ── RESET ───────────────────────────────────────────────
+                System.out.println("\n[RESET] Clearing download metrics — all subsequent ops must be zero downloads");
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                // ── QUERY: match-all, retrieve ALL rows ─────────────────
+                System.out.println("\n[QUERY] Searching for all " + TOTAL_ROWS + " rows...");
+                SplitQuery query = searcher.parseQuery("*");
+                SearchResult results = searcher.search(query, TOTAL_ROWS + 10);
+                assertEquals(TOTAL_ROWS, results.getHits().size(),
+                        "Should return all " + TOTAL_ROWS + " rows");
+                System.out.println("   Search returned " + results.getHits().size() + " hits");
+
+                var afterSearch = SplitCacheManager.getStorageDownloadMetrics();
+                assertEquals(0, afterSearch.getTotalDownloads(),
+                        "Search should have 0 storage downloads but got "
+                                + afterSearch.getTotalDownloads() + " ("
+                                + afterSearch.getTotalBytes() + " bytes)");
+                System.out.println("   => 0 downloads (cache hit)");
+
+                // ── RETRIEVE: all docs with projected "name" field ──────
+                System.out.println("\n[RETRIEVE] Fetching 'name' field from all " + TOTAL_ROWS + " docs...");
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                Set<Long> seenIds = new HashSet<>();
+                Set<String> seenNames = new HashSet<>();
+                Set<Integer> fileIndicesSeen = new HashSet<>();
+
+                for (SearchResult.Hit hit : results.getHits()) {
+                    DocAddress addr = hit.getDocAddress();
+                    Document doc = searcher.docProjected(addr, "id", "name");
+
+                    Object idVal = doc.getFirst("id");
+                    assertNotNull(idVal, "id should not be null");
+                    long id = ((Number) idVal).longValue();
+                    seenIds.add(id);
+
+                    Object nameVal = doc.getFirst("name");
+                    assertNotNull(nameVal, "name should not be null");
+                    String name = nameVal.toString();
+                    seenNames.add(name);
+                    assertEquals("item_" + id, name,
+                            "name should match id pattern");
+
+                    // Track which source file this row came from
+                    int fileIndex = (int) (id / ROWS_PER_FILE);
+                    fileIndicesSeen.add(fileIndex);
+                }
+
+                var afterRetrieval = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("   Retrieved " + seenIds.size() + " unique docs");
+                System.out.println("   Files represented: " + fileIndicesSeen.stream()
+                        .sorted().map(i -> "data_" + i + ".parquet")
+                        .collect(Collectors.joining(", ")));
+                System.out.println("   Downloads: " + afterRetrieval.getTotalDownloads()
+                        + " (" + afterRetrieval.getTotalBytes() + " bytes)");
+
+                // ── ASSERTIONS ──────────────────────────────────────────
+
+                // All 100 unique IDs present
+                assertEquals(TOTAL_ROWS, seenIds.size(),
+                        "Should see all " + TOTAL_ROWS + " unique IDs");
+
+                // All 5 files contributed data
+                assertEquals(NUM_FILES, fileIndicesSeen.size(),
+                        "Data should come from all " + NUM_FILES + " parquet files, "
+                                + "but only got files: " + fileIndicesSeen);
+
+                // Verify complete ID range: 0..99
+                for (long expectedId = 0; expectedId < TOTAL_ROWS; expectedId++) {
+                    assertTrue(seenIds.contains(expectedId),
+                            "Missing id=" + expectedId + " (from file data_"
+                                    + (expectedId / ROWS_PER_FILE) + ".parquet)");
+                }
+
+                // Zero downloads after prewarm
+                assertEquals(0, afterRetrieval.getTotalDownloads(),
+                        "Doc retrieval should have 0 storage downloads but got "
+                                + afterRetrieval.getTotalDownloads() + " ("
+                                + afterRetrieval.getTotalBytes() + " bytes). "
+                                + "Parquet column prewarm should cover all " + NUM_FILES + " files.");
+
+                System.out.println("\n" + "=".repeat(60));
+                System.out.println("  PASSED: " + TOTAL_ROWS + " docs from " + NUM_FILES
+                        + " parquet files, 0 downloads after prewarm");
+                System.out.println("=".repeat(60));
+            }
+        }
+    }
+}

--- a/src/test/java/io/indextables/tantivy4java/ParquetCompanionPageIndexTest.java
+++ b/src/test/java/io/indextables/tantivy4java/ParquetCompanionPageIndexTest.java
@@ -1,0 +1,753 @@
+package io.indextables.tantivy4java;
+
+import io.indextables.tantivy4java.core.Document;
+import io.indextables.tantivy4java.core.Schema;
+import io.indextables.tantivy4java.result.SearchResult;
+import io.indextables.tantivy4java.split.*;
+import io.indextables.tantivy4java.split.merge.*;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Parquet Page Index — both retrieval paths.
+ *
+ * Path 1 (legacy files): Parquet files WITHOUT native offset index in their footer.
+ *   At indexing time, page locations are computed via Thrift page header scanning
+ *   and stored in the split manifest. At read time, they are injected into
+ *   ParquetMetaData so the reader uses page-level byte range requests.
+ *
+ * Path 2 (modern files): Parquet files WITH native offset index in their footer.
+ *   At indexing time, NO page locations are computed or stored — the manifest
+ *   page_locations are empty. At read time, CachedParquetReader loads the
+ *   offset index directly from the parquet footer via PageIndexPolicy::Optional.
+ *
+ * Both paths must produce correct search results and document retrieval.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ParquetCompanionPageIndexTest {
+
+    private static SplitCacheManager cacheManager;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeAll
+    static void setUp() {
+        SplitCacheManager.CacheConfig config =
+                new SplitCacheManager.CacheConfig("parquet-page-index-test")
+                        .withMaxCacheSize(200_000_000);
+        cacheManager = SplitCacheManager.getInstance(config);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (cacheManager != null) {
+            try { cacheManager.close(); } catch (Exception e) { /* ignore */ }
+        }
+    }
+
+    /** Write parquet WITH native offset index (default Arrow behavior). */
+    private static void writeModernParquet(String path, int numRows, long idOffset) {
+        QuickwitSplit.nativeWriteTestParquet(path, numRows, idOffset);
+    }
+
+    /** Write parquet WITHOUT native offset index (legacy format). */
+    private static void writeLegacyParquet(String path, int numRows, long idOffset) {
+        QuickwitSplit.nativeWriteTestParquetNoPageIndex(path, numRows, idOffset);
+    }
+
+    /**
+     * Assert that ALL files in the split have the expected pageIndexSource.
+     * Validates that:
+     * - Legacy files have "manifest" (computed at indexing time, stored in manifest)
+     * - Modern files have "native" (offset index in parquet footer, used at read time)
+     */
+    private void assertPageIndexSource(SplitSearcher searcher, String expectedSource,
+                                        String testLabel) throws Exception {
+        String statsJson = searcher.getParquetRetrievalStats();
+        assertNotNull(statsJson, testLabel + ": stats should not be null");
+
+        JsonNode stats = MAPPER.readTree(statsJson);
+        JsonNode fileSizes = stats.get("fileSizes");
+        assertNotNull(fileSizes, testLabel + ": fileSizes should be present");
+        assertTrue(fileSizes.isArray() && fileSizes.size() > 0,
+                testLabel + ": fileSizes should be non-empty array");
+
+        for (int i = 0; i < fileSizes.size(); i++) {
+            JsonNode file = fileSizes.get(i);
+            String source = file.get("pageIndexSource").asText();
+            assertEquals(expectedSource, source,
+                    testLabel + ": file " + i + " (" + file.get("path").asText()
+                    + ") should have pageIndexSource=" + expectedSource);
+        }
+    }
+
+    /**
+     * Assert pageIndexSource per file for mixed splits (some legacy, some modern).
+     */
+    private void assertMixedPageIndexSources(SplitSearcher searcher,
+                                              String[] expectedSources,
+                                              String testLabel) throws Exception {
+        String statsJson = searcher.getParquetRetrievalStats();
+        assertNotNull(statsJson, testLabel + ": stats should not be null");
+
+        JsonNode stats = MAPPER.readTree(statsJson);
+        JsonNode fileSizes = stats.get("fileSizes");
+        assertEquals(expectedSources.length, fileSizes.size(),
+                testLabel + ": file count mismatch");
+
+        for (int i = 0; i < expectedSources.length; i++) {
+            JsonNode file = fileSizes.get(i);
+            String source = file.get("pageIndexSource").asText();
+            assertEquals(expectedSources[i], source,
+                    testLabel + ": file " + i + " (" + file.get("path").asText()
+                    + ") should have pageIndexSource=" + expectedSources[i]);
+        }
+    }
+
+    /**
+     * Shared helper: create companion split, search, retrieve docs, verify correctness.
+     * Used by both legacy and modern tests to ensure identical behavior.
+     *
+     * @param expectedPageIndexSource expected pageIndexSource for all files ("manifest" or "native")
+     */
+    private void verifySearchAndRetrieval(
+            Path dir, Path splitFile, QuickwitSplit.SplitMetadata metadata,
+            int totalRows, String expectedPageIndexSource, String testLabel) throws Exception {
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl, metadata, dir.toString())) {
+
+            assertTrue(searcher.hasParquetCompanion(),
+                    testLabel + ": should be parquet companion");
+
+            // Assert page index source for all files
+            assertPageIndexSource(searcher, expectedPageIndexSource, testLabel);
+
+            // Match-all to confirm doc count
+            SplitQuery allQuery = searcher.parseQuery("*");
+            SearchResult allResults = searcher.search(allQuery, totalRows + 1);
+            assertEquals(totalRows, allResults.getHits().size(),
+                    testLabel + ": match-all should return all docs");
+
+            // Term query for first item
+            SplitQuery firstQuery = new SplitTermQuery("name", "item_0");
+            SearchResult firstResults = searcher.search(firstQuery, 5);
+            assertTrue(firstResults.getHits().size() >= 1,
+                    testLabel + ": should find item_0");
+            Document firstDoc = searcher.docProjected(
+                    firstResults.getHits().get(0).getDocAddress(),
+                    "id", "name", "score", "active", "category");
+            assertEquals(0L, ((Number) firstDoc.getFirst("id")).longValue(),
+                    testLabel + ": item_0 should have id=0");
+            assertEquals("item_0", firstDoc.getFirst("name"));
+            assertEquals(10.0, ((Number) firstDoc.getFirst("score")).doubleValue(), 0.01);
+            assertEquals(true, firstDoc.getFirst("active"));
+            assertEquals("cat_0", firstDoc.getFirst("category"));
+
+            // Term query for middle item
+            int midId = totalRows / 2;
+            SplitQuery midQuery = new SplitTermQuery("name", "item_" + midId);
+            SearchResult midResults = searcher.search(midQuery, 5);
+            assertTrue(midResults.getHits().size() >= 1,
+                    testLabel + ": should find item_" + midId);
+            Document midDoc = searcher.docProjected(
+                    midResults.getHits().get(0).getDocAddress(),
+                    "id", "name", "score");
+            assertEquals((long) midId, ((Number) midDoc.getFirst("id")).longValue());
+            assertEquals("item_" + midId, midDoc.getFirst("name"));
+            // score formula: i * 1.5 + 10.0 (i is relative to file offset)
+            assertNotNull(midDoc.getFirst("score"));
+
+            // Term query for last item
+            int lastId = totalRows - 1;
+            SplitQuery lastQuery = new SplitTermQuery("name", "item_" + lastId);
+            SearchResult lastResults = searcher.search(lastQuery, 5);
+            assertTrue(lastResults.getHits().size() >= 1,
+                    testLabel + ": should find item_" + lastId);
+            Document lastDoc = searcher.docProjected(
+                    lastResults.getHits().get(0).getDocAddress(),
+                    "id", "name");
+            assertEquals((long) lastId, ((Number) lastDoc.getFirst("id")).longValue());
+        }
+    }
+
+    // ===================================================================
+    // PATH 1: LEGACY FILES (no native offset index)
+    //   Page locations computed at indexing time, stored in manifest,
+    //   injected at read time.
+    // ===================================================================
+
+    @Test
+    @Order(1)
+    void testLegacySingleLargeFile(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("legacy_single.parquet");
+        Path splitFile = dir.resolve("legacy_single.split");
+
+        writeLegacyParquet(parquetFile.toString(), 20_000, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id", "score", "name");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(20_000, metadata.getNumDocs());
+        verifySearchAndRetrieval(dir, splitFile, metadata, 20_000, "manifest", "legacy-single");
+    }
+
+    @Test
+    @Order(2)
+    void testLegacyMultiFile(@TempDir Path dir) throws Exception {
+        int filesCount = 5;
+        int rowsPerFile = 10_000;
+        int totalRows = filesCount * rowsPerFile;
+
+        List<String> parquetPaths = new ArrayList<>();
+        for (int i = 0; i < filesCount; i++) {
+            Path pq = dir.resolve("legacy_part_" + i + ".parquet");
+            writeLegacyParquet(pq.toString(), rowsPerFile, (long) i * rowsPerFile);
+            parquetPaths.add(pq.toString());
+        }
+
+        Path splitFile = dir.resolve("legacy_multi.split");
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id", "score");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                parquetPaths, splitFile.toString(), config);
+
+        assertEquals(totalRows, metadata.getNumDocs());
+        verifySearchAndRetrieval(dir, splitFile, metadata, totalRows, "manifest", "legacy-multi");
+    }
+
+    @Test
+    @Order(3)
+    void testLegacyBatchRetrieval(@TempDir Path dir) throws Exception {
+        Path pq1 = dir.resolve("legacy_batch1.parquet");
+        Path pq2 = dir.resolve("legacy_batch2.parquet");
+        Path pq3 = dir.resolve("legacy_batch3.parquet");
+        Path splitFile = dir.resolve("legacy_batch.split");
+
+        writeLegacyParquet(pq1.toString(), 15_000, 0);
+        writeLegacyParquet(pq2.toString(), 15_000, 15_000);
+        writeLegacyParquet(pq3.toString(), 15_000, 30_000);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Arrays.asList(pq1.toString(), pq2.toString(), pq3.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(45_000, metadata.getNumDocs());
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl, metadata, dir.toString())) {
+
+            // Assert all files use manifest-based page index
+            assertPageIndexSource(searcher, "manifest", "legacy-batch");
+
+            // Search for items from each file (different page ranges)
+            String[] targets = {"item_5000", "item_20000", "item_40000"};
+            long[] expectedIds = {5000L, 20000L, 40000L};
+            io.indextables.tantivy4java.core.DocAddress[] addrs =
+                    new io.indextables.tantivy4java.core.DocAddress[targets.length];
+
+            for (int i = 0; i < targets.length; i++) {
+                SplitQuery query = new SplitTermQuery("name", targets[i]);
+                SearchResult results = searcher.search(query, 1);
+                assertTrue(results.getHits().size() >= 1,
+                        "legacy-batch: should find " + targets[i]);
+                addrs[i] = results.getHits().get(0).getDocAddress();
+            }
+
+            List<Document> batchDocs = searcher.docBatchProjected(addrs,
+                    "id", "name", "score");
+            assertEquals(targets.length, batchDocs.size());
+
+            for (int i = 0; i < targets.length; i++) {
+                assertEquals(expectedIds[i],
+                        ((Number) batchDocs.get(i).getFirst("id")).longValue());
+                assertEquals(targets[i], batchDocs.get(i).getFirst("name"));
+            }
+        }
+    }
+
+    // ===================================================================
+    // PATH 2: MODERN FILES (native offset index in footer)
+    //   No page locations stored in manifest. CachedParquetReader loads
+    //   the offset index from the parquet footer at read time.
+    // ===================================================================
+
+    @Test
+    @Order(4)
+    void testModernSingleLargeFile(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("modern_single.parquet");
+        Path splitFile = dir.resolve("modern_single.split");
+
+        writeModernParquet(parquetFile.toString(), 20_000, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id", "score", "name");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(20_000, metadata.getNumDocs());
+        verifySearchAndRetrieval(dir, splitFile, metadata, 20_000, "native", "modern-single");
+    }
+
+    @Test
+    @Order(5)
+    void testModernMultiFile(@TempDir Path dir) throws Exception {
+        int filesCount = 5;
+        int rowsPerFile = 10_000;
+        int totalRows = filesCount * rowsPerFile;
+
+        List<String> parquetPaths = new ArrayList<>();
+        for (int i = 0; i < filesCount; i++) {
+            Path pq = dir.resolve("modern_part_" + i + ".parquet");
+            writeModernParquet(pq.toString(), rowsPerFile, (long) i * rowsPerFile);
+            parquetPaths.add(pq.toString());
+        }
+
+        Path splitFile = dir.resolve("modern_multi.split");
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id", "score");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                parquetPaths, splitFile.toString(), config);
+
+        assertEquals(totalRows, metadata.getNumDocs());
+        verifySearchAndRetrieval(dir, splitFile, metadata, totalRows, "native", "modern-multi");
+    }
+
+    @Test
+    @Order(6)
+    void testModernBatchRetrieval(@TempDir Path dir) throws Exception {
+        Path pq1 = dir.resolve("modern_batch1.parquet");
+        Path pq2 = dir.resolve("modern_batch2.parquet");
+        Path pq3 = dir.resolve("modern_batch3.parquet");
+        Path splitFile = dir.resolve("modern_batch.split");
+
+        writeModernParquet(pq1.toString(), 15_000, 0);
+        writeModernParquet(pq2.toString(), 15_000, 15_000);
+        writeModernParquet(pq3.toString(), 15_000, 30_000);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Arrays.asList(pq1.toString(), pq2.toString(), pq3.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(45_000, metadata.getNumDocs());
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl, metadata, dir.toString())) {
+
+            // Assert all files use native page index from footer
+            assertPageIndexSource(searcher, "native", "modern-batch");
+
+            String[] targets = {"item_5000", "item_20000", "item_40000"};
+            long[] expectedIds = {5000L, 20000L, 40000L};
+            io.indextables.tantivy4java.core.DocAddress[] addrs =
+                    new io.indextables.tantivy4java.core.DocAddress[targets.length];
+
+            for (int i = 0; i < targets.length; i++) {
+                SplitQuery query = new SplitTermQuery("name", targets[i]);
+                SearchResult results = searcher.search(query, 1);
+                assertTrue(results.getHits().size() >= 1,
+                        "modern-batch: should find " + targets[i]);
+                addrs[i] = results.getHits().get(0).getDocAddress();
+            }
+
+            List<Document> batchDocs = searcher.docBatchProjected(addrs,
+                    "id", "name", "score");
+            assertEquals(targets.length, batchDocs.size());
+
+            for (int i = 0; i < targets.length; i++) {
+                assertEquals(expectedIds[i],
+                        ((Number) batchDocs.get(i).getFirst("id")).longValue());
+                assertEquals(targets[i], batchDocs.get(i).getFirst("name"));
+            }
+        }
+    }
+
+    // ===================================================================
+    // MIXED: Legacy + modern files in the same companion split
+    // ===================================================================
+
+    @Test
+    @Order(7)
+    void testMixedLegacyAndModernFiles(@TempDir Path dir) throws Exception {
+        // 2 legacy files (page locations computed, stored in manifest)
+        Path legacy1 = dir.resolve("mixed_legacy1.parquet");
+        Path legacy2 = dir.resolve("mixed_legacy2.parquet");
+        writeLegacyParquet(legacy1.toString(), 10_000, 0);
+        writeLegacyParquet(legacy2.toString(), 10_000, 10_000);
+
+        // 2 modern files (page locations from footer, nothing in manifest)
+        Path modern1 = dir.resolve("mixed_modern1.parquet");
+        Path modern2 = dir.resolve("mixed_modern2.parquet");
+        writeModernParquet(modern1.toString(), 10_000, 20_000);
+        writeModernParquet(modern2.toString(), 10_000, 30_000);
+
+        Path splitFile = dir.resolve("mixed.split");
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Arrays.asList(
+                        legacy1.toString(), legacy2.toString(),
+                        modern1.toString(), modern2.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(40_000, metadata.getNumDocs());
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl, metadata, dir.toString())) {
+
+            // Assert per-file page index sources: 2 legacy (manifest) + 2 modern (native)
+            assertMixedPageIndexSources(searcher,
+                    new String[]{"manifest", "manifest", "native", "native"},
+                    "mixed");
+
+            // Verify retrieval from each file:
+            // legacy1: items 0-9999
+            // legacy2: items 10000-19999
+            // modern1: items 20000-29999
+            // modern2: items 30000-39999
+            int[][] fileRanges = {{0, 5000}, {10000, 15000}, {20000, 25000}, {30000, 35000}};
+            String[] labels = {"legacy1", "legacy2", "modern1", "modern2"};
+
+            for (int f = 0; f < fileRanges.length; f++) {
+                int targetId = fileRanges[f][1];
+                String targetName = "item_" + targetId;
+
+                SplitQuery query = new SplitTermQuery("name", targetName);
+                SearchResult results = searcher.search(query, 1);
+                assertTrue(results.getHits().size() >= 1,
+                        "mixed: should find " + targetName + " from " + labels[f]);
+
+                Document doc = searcher.docProjected(
+                        results.getHits().get(0).getDocAddress(),
+                        "id", "name", "score", "active");
+                assertEquals((long) targetId,
+                        ((Number) doc.getFirst("id")).longValue(),
+                        "mixed: " + labels[f] + " should have correct id");
+                assertEquals(targetName, doc.getFirst("name"));
+                assertNotNull(doc.getFirst("score"));
+                assertNotNull(doc.getFirst("active"));
+            }
+
+            // Batch retrieval spanning all 4 files
+            io.indextables.tantivy4java.core.DocAddress[] addrs =
+                    new io.indextables.tantivy4java.core.DocAddress[4];
+            long[] ids = {5000L, 15000L, 25000L, 35000L};
+            for (int i = 0; i < ids.length; i++) {
+                SplitQuery query = new SplitTermQuery("name", "item_" + ids[i]);
+                SearchResult results = searcher.search(query, 1);
+                addrs[i] = results.getHits().get(0).getDocAddress();
+            }
+
+            List<Document> batchDocs = searcher.docBatchProjected(addrs,
+                    "id", "name");
+            assertEquals(4, batchDocs.size());
+
+            for (int i = 0; i < ids.length; i++) {
+                assertEquals(ids[i],
+                        ((Number) batchDocs.get(i).getFirst("id")).longValue(),
+                        "batch doc " + i + " should have correct id");
+            }
+        }
+    }
+
+    // ===================================================================
+    // HYBRID mode tests with both paths
+    // ===================================================================
+
+    @Test
+    @Order(8)
+    void testHybridModeLegacy(@TempDir Path dir) throws Exception {
+        Path pq1 = dir.resolve("hybrid_legacy1.parquet");
+        Path pq2 = dir.resolve("hybrid_legacy2.parquet");
+        Path splitFile = dir.resolve("hybrid_legacy.split");
+
+        writeLegacyParquet(pq1.toString(), 10_000, 0);
+        writeLegacyParquet(pq2.toString(), 10_000, 10_000);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID)
+                .withStatisticsFields("id", "score");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Arrays.asList(pq1.toString(), pq2.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(20_000, metadata.getNumDocs());
+        verifySearchAndRetrieval(dir, splitFile, metadata, 20_000, "manifest", "hybrid-legacy");
+    }
+
+    @Test
+    @Order(9)
+    void testHybridModeModern(@TempDir Path dir) throws Exception {
+        Path pq1 = dir.resolve("hybrid_modern1.parquet");
+        Path pq2 = dir.resolve("hybrid_modern2.parquet");
+        Path splitFile = dir.resolve("hybrid_modern.split");
+
+        writeModernParquet(pq1.toString(), 10_000, 0);
+        writeModernParquet(pq2.toString(), 10_000, 10_000);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID)
+                .withStatisticsFields("id", "score");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Arrays.asList(pq1.toString(), pq2.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(20_000, metadata.getNumDocs());
+        verifySearchAndRetrieval(dir, splitFile, metadata, 20_000, "native", "hybrid-modern");
+    }
+
+    // ===================================================================
+    // Retrieval stats validation
+    // ===================================================================
+
+    @Test
+    @Order(10)
+    void testRetrievalStatsLegacy(@TempDir Path dir) throws Exception {
+        Path pq1 = dir.resolve("stats_legacy1.parquet");
+        Path pq2 = dir.resolve("stats_legacy2.parquet");
+        Path pq3 = dir.resolve("stats_legacy3.parquet");
+        Path splitFile = dir.resolve("stats_legacy.split");
+
+        writeLegacyParquet(pq1.toString(), 10_000, 0);
+        writeLegacyParquet(pq2.toString(), 10_000, 10_000);
+        writeLegacyParquet(pq3.toString(), 10_000, 20_000);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Arrays.asList(pq1.toString(), pq2.toString(), pq3.toString()),
+                splitFile.toString(), config);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl, metadata, dir.toString())) {
+
+            // Assert all files use manifest-based page index
+            assertPageIndexSource(searcher, "manifest", "stats-legacy");
+
+            String statsJson = searcher.getParquetRetrievalStats();
+            assertNotNull(statsJson);
+            JsonNode stats = MAPPER.readTree(statsJson);
+            assertEquals(3, stats.get("totalFiles").asInt());
+            assertEquals(30_000, stats.get("totalRows").asInt());
+
+            // Retrieval from middle file
+            SplitQuery query = new SplitTermQuery("name", "item_15000");
+            SearchResult results = searcher.search(query, 1);
+            assertTrue(results.getHits().size() >= 1);
+            searcher.docProjected(results.getHits().get(0).getDocAddress(),
+                    "id", "name");
+        }
+    }
+
+    @Test
+    @Order(11)
+    void testRetrievalStatsModern(@TempDir Path dir) throws Exception {
+        Path pq1 = dir.resolve("stats_modern1.parquet");
+        Path pq2 = dir.resolve("stats_modern2.parquet");
+        Path pq3 = dir.resolve("stats_modern3.parquet");
+        Path splitFile = dir.resolve("stats_modern.split");
+
+        writeModernParquet(pq1.toString(), 10_000, 0);
+        writeModernParquet(pq2.toString(), 10_000, 10_000);
+        writeModernParquet(pq3.toString(), 10_000, 20_000);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Arrays.asList(pq1.toString(), pq2.toString(), pq3.toString()),
+                splitFile.toString(), config);
+
+        String splitUrl = "file://" + splitFile.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl, metadata, dir.toString())) {
+
+            // Assert all files use native page index from footer
+            assertPageIndexSource(searcher, "native", "stats-modern");
+
+            String statsJson = searcher.getParquetRetrievalStats();
+            assertNotNull(statsJson);
+            JsonNode stats = MAPPER.readTree(statsJson);
+            assertEquals(3, stats.get("totalFiles").asInt());
+            assertEquals(30_000, stats.get("totalRows").asInt());
+
+            // Retrieval from middle file
+            SplitQuery query = new SplitTermQuery("name", "item_15000");
+            SearchResult results = searcher.search(query, 1);
+            assertTrue(results.getHits().size() >= 1);
+            searcher.docProjected(results.getHits().get(0).getDocAddress(),
+                    "id", "name");
+        }
+    }
+
+    // ===================================================================
+    // MERGE TESTS: Verify page metadata survives split merges
+    // ===================================================================
+
+    @Test
+    @Order(12)
+    void testLegacyPageMetadataSurvivedMerge(@TempDir Path dir) throws Exception {
+        // Create 2 companion splits from legacy parquet files
+        Path pq1 = dir.resolve("merge_leg1.parquet");
+        Path pq2 = dir.resolve("merge_leg2.parquet");
+        Path split1 = dir.resolve("merge_leg1.split");
+        Path split2 = dir.resolve("merge_leg2.split");
+        Path mergedSplit = dir.resolve("merge_leg_merged.split");
+
+        writeLegacyParquet(pq1.toString(), 10_000, 0);
+        writeLegacyParquet(pq2.toString(), 10_000, 10_000);
+
+        ParquetCompanionConfig config1 = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+        ParquetCompanionConfig config2 = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+
+        QuickwitSplit.SplitMetadata meta1 = QuickwitSplit.createFromParquet(
+                Collections.singletonList(pq1.toString()), split1.toString(), config1);
+        QuickwitSplit.SplitMetadata meta2 = QuickwitSplit.createFromParquet(
+                Collections.singletonList(pq2.toString()), split2.toString(), config2);
+
+        assertEquals(10_000, meta1.getNumDocs());
+        assertEquals(10_000, meta2.getNumDocs());
+
+        // Verify pre-merge: both splits have manifest-based page index
+        String splitUrl1 = "file://" + split1.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl1, meta1, dir.toString())) {
+            assertPageIndexSource(searcher, "manifest", "pre-merge-split1");
+        }
+        String splitUrl2 = "file://" + split2.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                splitUrl2, meta2, dir.toString())) {
+            assertPageIndexSource(searcher, "manifest", "pre-merge-split2");
+        }
+
+        // Merge the two splits
+        QuickwitSplit.MergeConfig mergeConfig = new QuickwitSplit.MergeConfig(
+                "test-merge-idx", "test-source", "test-node");
+        QuickwitSplit.SplitMetadata mergedMeta = QuickwitSplit.mergeSplits(
+                Arrays.asList(split1.toString(), split2.toString()),
+                mergedSplit.toString(), mergeConfig);
+
+        assertEquals(20_000, mergedMeta.getNumDocs());
+
+        // Verify post-merge: merged split still has manifest-based page index
+        String mergedUrl = "file://" + mergedSplit.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                mergedUrl, mergedMeta, dir.toString())) {
+
+            assertTrue(searcher.hasParquetCompanion(), "merged split should be companion");
+
+            // Page index source should still be "manifest" after merge
+            assertPageIndexSource(searcher, "manifest", "post-merge");
+
+            // Verify retrieval works for docs from both original splits
+            SplitQuery q1 = new SplitTermQuery("name", "item_0");
+            SearchResult r1 = searcher.search(q1, 5);
+            assertTrue(r1.getHits().size() >= 1, "should find item_0 from split1");
+            Document d1 = searcher.docProjected(
+                    r1.getHits().get(0).getDocAddress(), "id", "name");
+            assertEquals(0L, ((Number) d1.getFirst("id")).longValue());
+
+            SplitQuery q2 = new SplitTermQuery("name", "item_15000");
+            SearchResult r2 = searcher.search(q2, 5);
+            assertTrue(r2.getHits().size() >= 1, "should find item_15000 from split2");
+            Document d2 = searcher.docProjected(
+                    r2.getHits().get(0).getDocAddress(), "id", "name");
+            assertEquals(15_000L, ((Number) d2.getFirst("id")).longValue());
+
+            // Match-all to confirm total doc count
+            SplitQuery allQuery = searcher.parseQuery("*");
+            SearchResult allResults = searcher.search(allQuery, 20_001);
+            assertEquals(20_000, allResults.getHits().size(),
+                    "merged split should have 20000 docs");
+        }
+    }
+
+    @Test
+    @Order(13)
+    void testModernPageMetadataSurvivedMerge(@TempDir Path dir) throws Exception {
+        // Create 2 companion splits from modern parquet files
+        Path pq1 = dir.resolve("merge_mod1.parquet");
+        Path pq2 = dir.resolve("merge_mod2.parquet");
+        Path split1 = dir.resolve("merge_mod1.split");
+        Path split2 = dir.resolve("merge_mod2.split");
+        Path mergedSplit = dir.resolve("merge_mod_merged.split");
+
+        writeModernParquet(pq1.toString(), 10_000, 0);
+        writeModernParquet(pq2.toString(), 10_000, 10_000);
+
+        ParquetCompanionConfig config1 = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+        ParquetCompanionConfig config2 = new ParquetCompanionConfig(dir.toString())
+                .withStatisticsFields("id");
+
+        QuickwitSplit.SplitMetadata meta1 = QuickwitSplit.createFromParquet(
+                Collections.singletonList(pq1.toString()), split1.toString(), config1);
+        QuickwitSplit.SplitMetadata meta2 = QuickwitSplit.createFromParquet(
+                Collections.singletonList(pq2.toString()), split2.toString(), config2);
+
+        // Merge the two splits
+        QuickwitSplit.MergeConfig mergeConfig = new QuickwitSplit.MergeConfig(
+                "test-merge-idx", "test-source", "test-node");
+        QuickwitSplit.SplitMetadata mergedMeta = QuickwitSplit.mergeSplits(
+                Arrays.asList(split1.toString(), split2.toString()),
+                mergedSplit.toString(), mergeConfig);
+
+        assertEquals(20_000, mergedMeta.getNumDocs());
+
+        // Verify post-merge: modern files should still use native page index
+        String mergedUrl = "file://" + mergedSplit.toAbsolutePath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                mergedUrl, mergedMeta, dir.toString())) {
+
+            assertTrue(searcher.hasParquetCompanion(), "merged split should be companion");
+
+            // Page index source should be "native" — modern files have offset index in footer
+            assertPageIndexSource(searcher, "native", "post-merge-modern");
+
+            // Verify retrieval works for docs from both original splits
+            SplitQuery q1 = new SplitTermQuery("name", "item_5000");
+            SearchResult r1 = searcher.search(q1, 5);
+            assertTrue(r1.getHits().size() >= 1, "should find item_5000 from split1");
+
+            SplitQuery q2 = new SplitTermQuery("name", "item_15000");
+            SearchResult r2 = searcher.search(q2, 5);
+            assertTrue(r2.getHits().size() >= 1, "should find item_15000 from split2");
+            Document d2 = searcher.docProjected(
+                    r2.getHits().get(0).getDocAddress(), "id", "name");
+            assertEquals(15_000L, ((Number) d2.getFirst("id")).longValue());
+        }
+    }
+}

--- a/src/test/java/io/indextables/tantivy4java/PrewarmGapReproTest.java
+++ b/src/test/java/io/indextables/tantivy4java/PrewarmGapReproTest.java
@@ -1,0 +1,587 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.indextables.tantivy4java;
+
+import io.indextables.tantivy4java.core.DocAddress;
+import io.indextables.tantivy4java.core.Document;
+import io.indextables.tantivy4java.result.*;
+import io.indextables.tantivy4java.split.*;
+import io.indextables.tantivy4java.split.merge.*;
+import io.indextables.tantivy4java.aggregation.*;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.*;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Reproduces three suspected gaps in the prewarm primitives for parquet companion splits.
+ *
+ * Each test follows the same pattern:
+ *   1. Create a companion split with a specific configuration
+ *   2. Prewarm using the relevant API
+ *   3. Reset download metrics
+ *   4. Execute an operation that needs the data
+ *   5. Assert zero downloads (if prewarm was complete, cache should serve everything)
+ *
+ * If the assertion fails, we've confirmed the gap — prewarm didn't cache what the
+ * query path subsequently needed.
+ *
+ * Run with: mvn test -pl . -Dtest=PrewarmGapReproTest
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class PrewarmGapReproTest {
+
+    private static final int NUM_ROWS = 30;
+
+    // ════════════════════════════════════════════════════════════════
+    //  GAP 1: _pq fields not prewarmed by ANY warming operation
+    //
+    //  The __pq_file_hash and __pq_row_in_file fast fields are used by
+    //  doc retrieval (ensure_pq_segment_loaded). They should be cached
+    //  after ANY prewarm operation on a companion split — not just
+    //  FASTFIELD. Even a TERM-only prewarm should trigger _pq caching
+    //  because the caller will inevitably need doc retrieval next.
+    //
+    //  Sub-test a: TERM-only prewarm (minimal — not even FASTFIELD)
+    //  Sub-test b: Full prewarm (all components)
+    // ════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(1)
+    @DisplayName("GAP 1a: _pq fields should be cached after TERM-only prewarm")
+    void gap1a_pqFieldsNotPrewarmedByTermOnly(@TempDir Path dir) throws Exception {
+        gap1_helper(dir, "gap1a",
+                new SplitSearcher.IndexComponent[] { SplitSearcher.IndexComponent.TERM },
+                "TERM-only");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("GAP 1b: _pq fields should be cached after full component prewarm")
+    void gap1b_pqFieldsNotPrewarmedByFullPrewarm(@TempDir Path dir) throws Exception {
+        gap1_helper(dir, "gap1b",
+                new SplitSearcher.IndexComponent[] {
+                        SplitSearcher.IndexComponent.TERM,
+                        SplitSearcher.IndexComponent.POSTINGS,
+                        SplitSearcher.IndexComponent.FASTFIELD,
+                        SplitSearcher.IndexComponent.FIELDNORM,
+                        SplitSearcher.IndexComponent.STORE
+                },
+                "full");
+    }
+
+    private void gap1_helper(Path dir, String tag, SplitSearcher.IndexComponent[] components,
+                             String label) throws Exception {
+        Path parquetFile = dir.resolve(tag + ".parquet");
+        Path splitFile = dir.resolve(tag + ".split");
+
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), NUM_ROWS, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(NUM_ROWS, metadata.getNumDocs());
+
+        Path diskCache = dir.resolve("disk-cache");
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCache.toString())
+                .withMaxDiskSize(100_000_000);
+
+        SplitCacheManager.CacheConfig cacheConfig =
+                new SplitCacheManager.CacheConfig(tag + "-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withParquetTableRoot(dir.toString())
+                        .withTieredCache(tiered);
+
+        try (SplitCacheManager cm = SplitCacheManager.getInstance(cacheConfig)) {
+            String splitUri = "file://" + splitFile.toAbsolutePath();
+            try (SplitSearcher searcher = cm.createSplitSearcher(splitUri, metadata)) {
+                assertTrue(searcher.hasParquetCompanion());
+
+                // PREWARM: only the specified components
+                SplitCacheManager.resetStorageDownloadMetrics();
+                searcher.preloadComponents(components).join();
+                // Also prewarm parquet columns for doc retrieval
+                searcher.preloadParquetColumns("id", "name", "score", "active").join();
+
+                Thread.sleep(3000);
+
+                var afterPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 1 " + label + "] Prewarm downloads: "
+                        + afterPrewarm.getTotalDownloads()
+                        + " (" + afterPrewarm.getTotalBytes() + " bytes)");
+                assertTrue(afterPrewarm.getTotalDownloads() > 0, "Prewarm should download something");
+
+                Thread.sleep(500);
+
+                // RESET — everything after this should be zero downloads
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                // DOC RETRIEVAL — triggers ensure_pq_segment_loaded() for _pq fields
+                SplitQuery query = searcher.parseQuery("*");
+                SearchResult results = searcher.search(query, 5);
+                assertTrue(results.getHits().size() >= 1);
+
+                DocAddress addr = results.getHits().get(0).getDocAddress();
+                Document doc = searcher.docProjected(addr, "id", "name");
+                assertNotNull(doc.getFirst("id"), "Should retrieve id field");
+
+                var afterDocRetrieval = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 1 " + label + "] Post-prewarm doc retrieval downloads: "
+                        + afterDocRetrieval.getTotalDownloads()
+                        + " (" + afterDocRetrieval.getTotalBytes() + " bytes)");
+
+                assertEquals(0, afterDocRetrieval.getTotalDownloads(),
+                        "GAP 1 (" + label + "): _pq field reads caused "
+                                + afterDocRetrieval.getTotalDownloads() + " downloads ("
+                                + afterDocRetrieval.getTotalBytes() + " bytes) after "
+                                + label + " prewarm. ensure_pq_segment_loaded() reads "
+                                + "__pq_file_hash/__pq_row_in_file via a path that bypasses "
+                                + "the prewarm cache.");
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  GAP 2: exact_only hash fields not prewarmed with parent field
+    //
+    //  When a string field uses exact_only mode, the field IS a U64
+    //  hash field. Prewarming FASTFIELD and TERM for the parent field
+    //  name should include this hash field's data, since it's a native
+    //  tantivy field. If the hash field is stored under a different
+    //  name in the index, field-specific prewarm might miss it.
+    // ════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(3)
+    @DisplayName("GAP 2a: exact_only hash fields prewarmed with parent field (all components)")
+    void gap2a_hashFieldsNotPrewarmed(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("gap2.parquet");
+        Path splitFile = dir.resolve("gap2.split");
+
+        // Use the string indexing test parquet: id, trace_id, message, error_log, category
+        QuickwitSplit.nativeWriteTestParquetForStringIndexing(parquetFile.toString(), NUM_ROWS, 0);
+
+        Map<String, String> tokenizers = new HashMap<>();
+        tokenizers.put("trace_id", ParquetCompanionConfig.StringIndexingMode.EXACT_ONLY);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID)
+                .withTokenizerOverrides(tokenizers);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(NUM_ROWS, metadata.getNumDocs());
+
+        Path diskCache = dir.resolve("disk-cache");
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCache.toString())
+                .withMaxDiskSize(100_000_000);
+
+        SplitCacheManager.CacheConfig cacheConfig =
+                new SplitCacheManager.CacheConfig("gap2-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withParquetTableRoot(dir.toString())
+                        .withTieredCache(tiered);
+
+        try (SplitCacheManager cm = SplitCacheManager.getInstance(cacheConfig)) {
+            String splitUri = "file://" + splitFile.toAbsolutePath();
+            try (SplitSearcher searcher = cm.createSplitSearcher(splitUri, metadata)) {
+                assertTrue(searcher.hasParquetCompanion());
+
+                // PREWARM: all components (FASTFIELD includes trace_id which IS the hash field)
+                // plus TERM for term dictionary lookups
+                SplitCacheManager.resetStorageDownloadMetrics();
+                searcher.preloadComponents(
+                        SplitSearcher.IndexComponent.TERM,
+                        SplitSearcher.IndexComponent.POSTINGS,
+                        SplitSearcher.IndexComponent.FASTFIELD,
+                        SplitSearcher.IndexComponent.FIELDNORM,
+                        SplitSearcher.IndexComponent.STORE
+                ).join();
+
+                // Also prewarm parquet fast fields for the string fields that need transcoding
+                searcher.preloadParquetFastFields("message", "error_log", "category").join();
+
+                Thread.sleep(3000);
+
+                var afterPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 2] Prewarm downloads: " + afterPrewarm.getTotalDownloads()
+                        + " (" + afterPrewarm.getTotalBytes() + " bytes)");
+
+                Thread.sleep(500);
+
+                // RESET
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                // QUERY: terms aggregation on trace_id (which is the hash U64 field)
+                // This requires the FASTFIELD data for trace_id to be cached
+                StatsAggregation traceStats = new StatsAggregation("trace_stats", "trace_id");
+                SearchResult aggResult = searcher.search(
+                        new SplitMatchAllQuery(), 0, "trace_stats", traceStats);
+                assertTrue(aggResult.hasAggregations(), "Should have aggregation results");
+                StatsResult sr = (StatsResult) aggResult.getAggregation("trace_stats");
+                assertNotNull(sr);
+                assertEquals(NUM_ROWS, sr.getCount(),
+                        "Stats on exact_only trace_id should count all docs");
+
+                var afterQuery = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 2] Post-prewarm query downloads: "
+                        + afterQuery.getTotalDownloads()
+                        + " (" + afterQuery.getTotalBytes() + " bytes)");
+
+                assertEquals(0, afterQuery.getTotalDownloads(),
+                        "GAP 2 CONFIRMED: exact_only hash field (trace_id) query caused "
+                                + afterQuery.getTotalDownloads() + " downloads ("
+                                + afterQuery.getTotalBytes() + " bytes) after full prewarm. "
+                                + "The _phash_* / exact_only field data was not cached by "
+                                + "preloadComponents(FASTFIELD).");
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  GAP 2b: text_uuid_exactonly companion field not prewarmed when
+    //          parent field is prewarmed with field-specific prewarm
+    //
+    //  When "message" uses text_uuid_exactonly, a companion U64 field
+    //  "message__uuids" is created for UUID hash lookups. Field-specific
+    //  prewarm on "message" should automatically include "message__uuids"
+    //  for FASTFIELD, TERM, and POSTINGS — because any query hitting
+    //  "message" with a UUID value gets rewritten to target the companion.
+    // ════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(4)
+    @DisplayName("GAP 2b: companion __uuids field should prewarm with parent field")
+    void gap2b_companionFieldNotPrewarmedWithParent(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("gap2b.parquet");
+        Path splitFile = dir.resolve("gap2b.split");
+
+        QuickwitSplit.nativeWriteTestParquetForStringIndexing(parquetFile.toString(), NUM_ROWS, 0);
+
+        Map<String, String> tokenizers = new HashMap<>();
+        tokenizers.put("message", ParquetCompanionConfig.StringIndexingMode.TEXT_UUID_EXACTONLY);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID)
+                .withTokenizerOverrides(tokenizers);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(NUM_ROWS, metadata.getNumDocs());
+
+        Path diskCache = dir.resolve("disk-cache");
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCache.toString())
+                .withMaxDiskSize(100_000_000);
+
+        SplitCacheManager.CacheConfig cacheConfig =
+                new SplitCacheManager.CacheConfig("gap2b-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withParquetTableRoot(dir.toString())
+                        .withTieredCache(tiered);
+
+        try (SplitCacheManager cm = SplitCacheManager.getInstance(cacheConfig)) {
+            String splitUri = "file://" + splitFile.toAbsolutePath();
+            try (SplitSearcher searcher = cm.createSplitSearcher(splitUri, metadata)) {
+                assertTrue(searcher.hasParquetCompanion());
+
+                // PREWARM: field-specific on "message" only — should also pull in
+                // "message__uuids" for all three component types
+                SplitCacheManager.resetStorageDownloadMetrics();
+                searcher.preloadFields(SplitSearcher.IndexComponent.FASTFIELD, "message").join();
+                searcher.preloadFields(SplitSearcher.IndexComponent.TERM, "message").join();
+                searcher.preloadFields(SplitSearcher.IndexComponent.POSTINGS, "message").join();
+
+                Thread.sleep(3000);
+
+                var afterPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 2b] Field-specific prewarm for 'message' downloads: "
+                        + afterPrewarm.getTotalDownloads()
+                        + " (" + afterPrewarm.getTotalBytes() + " bytes)");
+
+                Thread.sleep(500);
+
+                // RESET
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                // QUERY: stats aggregation on the companion field "message__uuids"
+                // Needs FASTFIELD data for message__uuids
+                StatsAggregation companionStats = new StatsAggregation("companion_stats", "message__uuids");
+                SearchResult aggResult = searcher.search(
+                        new SplitMatchAllQuery(), 0, "companion_stats", companionStats);
+                assertTrue(aggResult.hasAggregations(), "Should have aggregation results");
+                StatsResult sr = (StatsResult) aggResult.getAggregation("companion_stats");
+                assertNotNull(sr);
+                assertEquals(NUM_ROWS, sr.getCount(),
+                        "Stats on message__uuids should count all docs");
+
+                var afterAgg = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 2b] Post-prewarm companion agg downloads: "
+                        + afterAgg.getTotalDownloads()
+                        + " (" + afterAgg.getTotalBytes() + " bytes)");
+
+                assertEquals(0, afterAgg.getTotalDownloads(),
+                        "GAP 2b CONFIRMED (FASTFIELD): preloadFields(FASTFIELD, \"message\") "
+                                + "did not cache companion field \"message__uuids\". "
+                                + "Aggregation caused " + afterAgg.getTotalDownloads()
+                                + " downloads (" + afterAgg.getTotalBytes() + " bytes). "
+                                + "Field-specific FASTFIELD prewarm should automatically include "
+                                + "companion __uuids fields.");
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  GAP 3: preloadParquetColumns doesn't actually cache column data
+    //
+    //  preloadParquetColumns() reads column chunks via storage.get_slice()
+    //  but the data may not go through the same cache layer that doc
+    //  retrieval uses (ByteRangeCache for dictionary pages, etc.).
+    //  If the prewarm and retrieval use different cache keys or layers,
+    //  the first doc retrieval after prewarm will re-download.
+    // ════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(5)
+    @DisplayName("GAP 3: preloadParquetColumns should eliminate doc retrieval downloads")
+    void gap3_parquetColumnPrewarmIneffective(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("gap3.parquet");
+        Path splitFile = dir.resolve("gap3.split");
+
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), NUM_ROWS, 0);
+
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.HYBRID);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(NUM_ROWS, metadata.getNumDocs());
+
+        Path diskCache = dir.resolve("disk-cache");
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCache.toString())
+                .withMaxDiskSize(100_000_000);
+
+        SplitCacheManager.CacheConfig cacheConfig =
+                new SplitCacheManager.CacheConfig("gap3-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withParquetTableRoot(dir.toString())
+                        .withTieredCache(tiered);
+
+        try (SplitCacheManager cm = SplitCacheManager.getInstance(cacheConfig)) {
+            String splitUri = "file://" + splitFile.toAbsolutePath();
+            try (SplitSearcher searcher = cm.createSplitSearcher(splitUri, metadata)) {
+                assertTrue(searcher.hasParquetCompanion());
+
+                // PREWARM: all split components first (for search + _pq field resolution)
+                SplitCacheManager.resetStorageDownloadMetrics();
+                searcher.preloadComponents(
+                        SplitSearcher.IndexComponent.TERM,
+                        SplitSearcher.IndexComponent.POSTINGS,
+                        SplitSearcher.IndexComponent.FASTFIELD,
+                        SplitSearcher.IndexComponent.FIELDNORM,
+                        SplitSearcher.IndexComponent.STORE
+                ).join();
+
+                Thread.sleep(3000);
+
+                var afterSplitPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 3] Split prewarm downloads: "
+                        + afterSplitPrewarm.getTotalDownloads()
+                        + " (" + afterSplitPrewarm.getTotalBytes() + " bytes)");
+
+                // PREWARM: parquet columns specifically for doc retrieval
+                SplitCacheManager.resetStorageDownloadMetrics();
+                searcher.preloadParquetColumns("id", "name", "score", "active").join();
+
+                Thread.sleep(3000);
+
+                var afterPqPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 3] Parquet column prewarm downloads: "
+                        + afterPqPrewarm.getTotalDownloads()
+                        + " (" + afterPqPrewarm.getTotalBytes() + " bytes)");
+
+                // Check if parquet column prewarm actually downloaded anything
+                // If it downloaded 0 bytes, that alone confirms the gap
+                if (afterPqPrewarm.getTotalDownloads() == 0) {
+                    System.out.println("[GAP 3] WARNING: preloadParquetColumns downloaded NOTHING — "
+                            + "the prewarm call is a no-op or the storage path is wrong.");
+                }
+
+                Thread.sleep(500);
+
+                // RESET
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                // DOC RETRIEVAL: single doc + batch
+                SplitQuery query = searcher.parseQuery("*");
+                SearchResult results = searcher.search(query, 5);
+                assertTrue(results.getHits().size() >= 3);
+
+                // Single doc retrieval with projection
+                Document singleDoc = searcher.docProjected(
+                        results.getHits().get(0).getDocAddress(), "id", "name");
+                assertNotNull(singleDoc.getFirst("id"));
+
+                // Batch doc retrieval
+                DocAddress[] addrs = new DocAddress[3];
+                for (int i = 0; i < 3; i++) {
+                    addrs[i] = results.getHits().get(i).getDocAddress();
+                }
+                List<Document> batchDocs = searcher.docBatchProjected(addrs, "id", "name");
+                assertEquals(3, batchDocs.size());
+
+                var afterRetrieval = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 3] Post-prewarm doc retrieval downloads: "
+                        + afterRetrieval.getTotalDownloads()
+                        + " (" + afterRetrieval.getTotalBytes() + " bytes)");
+
+                assertEquals(0, afterRetrieval.getTotalDownloads(),
+                        "GAP 3 CONFIRMED: doc retrieval caused " + afterRetrieval.getTotalDownloads()
+                                + " downloads (" + afterRetrieval.getTotalBytes()
+                                + " bytes) after preloadParquetColumns(). "
+                                + "The parquet column prewarm either didn't download data or used "
+                                + "a different cache path than doc retrieval.");
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  GAP 4: preloadParquetFastFields should eliminate aggregation downloads
+    //
+    //  preloadParquetFastFields() transcodes parquet columns into tantivy
+    //  columnar format and caches them in the ParquetAugmentedDirectory.
+    //  After prewarm, aggregations on those fields should be served
+    //  entirely from the transcoded cache — zero storage downloads.
+    // ════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(6)
+    @DisplayName("GAP 4: preloadParquetFastFields should eliminate aggregation downloads")
+    void gap4_parquetFastFieldPrewarmEliminatesAggDownloads(@TempDir Path dir) throws Exception {
+        Path parquetFile = dir.resolve("gap4.parquet");
+        Path splitFile = dir.resolve("gap4.split");
+
+        QuickwitSplit.nativeWriteTestParquet(parquetFile.toString(), NUM_ROWS, 0);
+
+        // Use PARQUET_ONLY mode so ALL fast field reads go through parquet transcoding
+        // (in HYBRID mode, numeric fields are native fast fields and don't need transcoding)
+        ParquetCompanionConfig config = new ParquetCompanionConfig(dir.toString())
+                .withFastFieldMode(ParquetCompanionConfig.FastFieldMode.PARQUET_ONLY);
+
+        QuickwitSplit.SplitMetadata metadata = QuickwitSplit.createFromParquet(
+                Collections.singletonList(parquetFile.toString()),
+                splitFile.toString(), config);
+
+        assertEquals(NUM_ROWS, metadata.getNumDocs());
+
+        Path diskCache = dir.resolve("disk-cache");
+        SplitCacheManager.TieredCacheConfig tiered = new SplitCacheManager.TieredCacheConfig()
+                .withDiskCachePath(diskCache.toString())
+                .withMaxDiskSize(100_000_000);
+
+        SplitCacheManager.CacheConfig cacheConfig =
+                new SplitCacheManager.CacheConfig("gap4-" + System.nanoTime())
+                        .withMaxCacheSize(50_000_000)
+                        .withParquetTableRoot(dir.toString())
+                        .withTieredCache(tiered);
+
+        try (SplitCacheManager cm = SplitCacheManager.getInstance(cacheConfig)) {
+            String splitUri = "file://" + splitFile.toAbsolutePath();
+            try (SplitSearcher searcher = cm.createSplitSearcher(splitUri, metadata)) {
+                assertTrue(searcher.hasParquetCompanion());
+
+                // PREWARM: split components first (for search infrastructure)
+                SplitCacheManager.resetStorageDownloadMetrics();
+                searcher.preloadComponents(
+                        SplitSearcher.IndexComponent.TERM,
+                        SplitSearcher.IndexComponent.POSTINGS,
+                        SplitSearcher.IndexComponent.FASTFIELD,
+                        SplitSearcher.IndexComponent.FIELDNORM,
+                        SplitSearcher.IndexComponent.STORE
+                ).join();
+
+                Thread.sleep(3000);
+
+                var afterSplitPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 4] Split prewarm downloads: "
+                        + afterSplitPrewarm.getTotalDownloads()
+                        + " (" + afterSplitPrewarm.getTotalBytes() + " bytes)");
+
+                // PREWARM: parquet fast fields for aggregation columns
+                // In PARQUET_ONLY mode, score requires parquet→tantivy transcoding
+                SplitCacheManager.resetStorageDownloadMetrics();
+                searcher.preloadParquetFastFields("score", "active").join();
+
+                Thread.sleep(3000);
+
+                var afterFfPrewarm = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 4] Parquet fast field prewarm downloads: "
+                        + afterFfPrewarm.getTotalDownloads()
+                        + " (" + afterFfPrewarm.getTotalBytes() + " bytes)");
+                assertTrue(afterFfPrewarm.getTotalDownloads() > 0,
+                        "Parquet fast field prewarm should download parquet data for transcoding");
+
+                Thread.sleep(500);
+
+                // RESET — everything after this should be zero downloads
+                SplitCacheManager.resetStorageDownloadMetrics();
+
+                // AGGREGATION: stats on "score" — needs transcoded fast field data
+                StatsAggregation scoreStats = new StatsAggregation("score_stats", "score");
+                SearchResult aggResult = searcher.search(
+                        new SplitMatchAllQuery(), 0, "score_stats", scoreStats);
+                assertTrue(aggResult.hasAggregations(), "Should have aggregation results");
+                StatsResult sr = (StatsResult) aggResult.getAggregation("score_stats");
+                assertNotNull(sr);
+                assertEquals(NUM_ROWS, sr.getCount(),
+                        "Stats on score should count all docs");
+
+                var afterAgg = SplitCacheManager.getStorageDownloadMetrics();
+                System.out.println("[GAP 4] Post-prewarm aggregation downloads: "
+                        + afterAgg.getTotalDownloads()
+                        + " (" + afterAgg.getTotalBytes() + " bytes)");
+
+                assertEquals(0, afterAgg.getTotalDownloads(),
+                        "GAP 4: aggregation on prewarmed parquet fast field caused "
+                                + afterAgg.getTotalDownloads() + " downloads ("
+                                + afterAgg.getTotalBytes() + " bytes) after "
+                                + "preloadParquetFastFields(). Transcoded fast field data "
+                                + "should be fully cached.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# PR: Performance Optimizations, Instrumentation, Prewarm Gap Fixes & Parquet Page Index

**Branch:** `035_perf_debugging`
**Version:** 0.30.5 → 0.30.6
**Files changed:** 17+ (900+ insertions, 320+ deletions) plus page index additions

## Summary

Four categories of improvements to companion split performance:

1. **Performance optimizations** — O(1) doc retrieval via `Column<u64>` random access, selective __pq column reads instead of full .fast file downloads, zero-copy disk cache reads, zero-copy SplitOverrides
2. **Performance instrumentation** — opt-in `perf_println!` macro gated behind `TANTIVY4JAVA_PERFLOG=1` with zero overhead when disabled, covering search, doc retrieval, transcoding, and cache paths
3. **Prewarm gap fixes** — four confirmed gaps where prewarm operations left data uncached, causing unnecessary storage downloads on the first query or doc retrieval after prewarm
4. **Parquet page index** — compute and store page-level offset indexes for legacy parquet files that lack one, inject at read time for page-level byte range reads instead of full column chunk downloads

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| First `__pq` column load (per segment) | ~23,712ms (full .fast download) | ~500-1000ms (2 column byte ranges) |
| `_phash` column scan in hash_touchup | Full .fast per segment | SSTable + column bytes only |
| Doc location lookup (`get_pq_location`) | O(n) Vec index + 290ms materialization | O(1) `values_for_doc()` random access |
| L2 disk cache reads | `mmap.to_vec()` copy per hit | Zero-copy via `StableMmap` |
| SplitOverrides on each search | `bytes.to_vec()` deep copy | `bytes.clone()` O(1) Arc clone |
| Post-prewarm doc retrieval downloads | 2-5 downloads (3KB) | 0 downloads |
| Post-prewarm companion field agg downloads | 1 download (267B) | 0 downloads |
| Post-prewarm parquet doc retrieval downloads | 2 downloads (page data) | 0 downloads |
| Legacy parquet doc retrieval (no offset index) | Full column chunk download | Page-level byte range reads |

## Dependency: Quickwit Fork Change

The `SplitOverrides` zero-copy optimization requires a companion change in the quickwit fork:

- **File**: `quickwit/quickwit-search/src/leaf.rs`
- **Change**: `SplitOverrides.fast_field_data` and `OverlayDirectory.file_overrides` change from `HashMap<PathBuf, Vec<u8>>` to `HashMap<PathBuf, OwnedBytes>`

## Detailed Changes

### 1. Selective Fast Field Column Reads (`types.rs`, `hash_touchup.rs`, `jni_lifecycle.rs`)

**Problem**: `ensure_pq_segment_loaded` and `build_hash_resolution_map` downloaded the *entire* `.fast` file per segment (100MB+ for 179 columns) just to read 2-3 small columns.

**Solution**: Use tantivy's `FastFieldReaders` async API:
```
list_dynamic_column_handles(name).await  →  read_bytes_async()  →  open_u64_lenient()
```
This fetches only the SSTable index (~1-10KB) and the specific column byte ranges. The async read populates the `CachingDirectory` cache, and the subsequent sync `open_u64_lenient()` call hits the cache with no additional I/O.

**Prerequisite**: `CachingDirectory` must always be in the directory stack. Changed `jni_lifecycle.rs` to always create a `ByteRangeCache` for `open_index_with_caches`, even when L1 cache is disabled by the user. The L1 disable flag still controls prewarm/prefetch behavior — this only ensures the async→sync bridging layer exists.

### 2. O(1) Doc Location Lookup (`types.rs`)

**Problem**: `pq_doc_locations` stored `Vec<Option<Vec<(u64, u64)>>>` — materializing all values for 11M docs took 290ms and consumed memory proportional to segment size.

**Solution**: Store `Column<u64>` handles instead:
```rust
// Before: Vec<Option<Vec<(u64, u64)>>>  — materialized, O(n) to build
pub(crate) pq_doc_locations: Arc<RwLock<Vec<Option<Vec<(u64, u64)>>>>>,

// After: Column<u64> handles — O(1) random access via values_for_doc()
pub(crate) pq_columns: Arc<RwLock<Vec<Option<(Column<u64>, Column<u64>)>>>>,
```

`get_pq_location(seg_ord, doc_id)` now calls `values_for_doc(doc_id)` directly on the column handle — O(1) with no materialization.

### 3. Zero-Copy Disk Cache (`mmap_cache.rs`, `get_ops.rs`)

**Problem**: Every L2 disk cache hit called `mmap.to_vec()`, copying the entire memory-mapped region into a heap allocation before wrapping in `OwnedBytes`.

**Solution**: `StableMmap` and `StableMmapSlice` wrapper types implement `StableDeref`, allowing `OwnedBytes::new(stable_mmap)` which borrows the mmap directly:
```rust
// Before: copies entire mmap to heap
mmap.to_vec()  // → Vec<u8> → OwnedBytes::new(vec)

// After: zero-copy, keeps Arc<Mmap> alive
StableMmap(mmap).into_owned_bytes()  // → OwnedBytes backed by mmap pointer
```

Sub-range reads also benefit via `StableMmapSlice`, which keeps the parent `Arc<Mmap>` alive while exposing only the requested byte slice.

### 4. Zero-Copy SplitOverrides (`async_impl.rs`)

**Problem**: `ensure_fast_fields_for_query` built `SplitOverrides` with `bytes.to_vec()` for every transcoded column on every search/aggregation call. For splits with many transcoded columns, this meant megabytes of unnecessary deep copies per query.

**Solution**: With the quickwit fork's `OwnedBytes` type in `SplitOverrides.fast_field_data`, the copy becomes `bytes.clone()` — an O(1) Arc reference count increment.

### 5. Minor Allocation Reductions

- **`arrow_to_tant.rs`, `doc_retrieval.rs`**: `projected_fields` changed from `Vec<String>` (cloned per parallel task) to `Arc<[String]>` (shared across all tasks)
- **`hash_field_rewriter.rs`, `string_indexing.rs`**: Eliminated `.collect::<Vec<_>>().join(" ")` pattern — iterators joined directly

### 6. Performance Logging (`debug.rs`, 7+ files)

`TANTIVY4JAVA_PERFLOG=1` environment variable enables `perf_println!` macro — detailed timing across:
- JNI search entry points (searchWithQueryAst, searchWithSplitQuery, searchWithAggregations)
- Query rewriting, fast field transcoding, leaf search execution
- DocMapper creation, search permit acquisition
- Parquet doc retrieval (file I/O, row group selection, stream reads)
- `__pq` column loading (cache hit/miss, async reads, total)
- Parquet byte range cache statistics (hit/miss per request)

All 80+ diagnostic log lines are completely silent in production (zero overhead when env var is unset).

### 7. Prewarm Gap Fixes (`jni_prewarm.rs`, `field_specific.rs`)

Four gaps where prewarm left data uncached, confirmed by `PrewarmGapReproTest`:

**GAP 1: `__pq_file_hash` / `__pq_row_in_file` not cached by any prewarm**

After `preloadComponents()` or `preloadFields()`, the first doc retrieval still triggered 2-5 storage downloads (~3KB) to load the `__pq` fast field columns used for parquet row resolution.

*Fix*: Added an eager-load step at the end of both `preloadComponentsNative` and `preloadFieldsNative` that calls `ensure_pq_segment_loaded()` for all segments on companion splits (guarded by `has_merge_safe_tracking && parquet_manifest.is_some()`).

**GAP 2b: Companion fields not included in field-specific prewarm**

`preloadFields(FASTFIELD, "message")` only prewarmed "message" — not its companion "message__uuids" (text_uuid_exactonly mode) or "_phash_message" (string hash optimization). Aggregations on companion fields caused additional downloads.

*Fix*: Added `expand_companion_fields()` helper in `field_specific.rs` that automatically includes `{field}__uuids` and `_phash_{field}` companions if they exist in the schema. Called at the top of all 5 field-specific prewarm functions (`prewarm_term_dictionaries_for_fields`, `prewarm_postings_for_fields`, `prewarm_positions_for_fields`, `prewarm_fieldnorms_for_fields`, `prewarm_fastfields_for_fields`). Safe for non-companion splits since it only adds fields that exist in the schema.

**GAP 3: `preloadParquetColumns()` didn't populate L1 ByteRangeCache**

`nativePrewarmParquetColumns` read column data via raw `storage.get_slice()` and discarded it (`let _data = ...`). This populated the L2 disk cache but NOT the L1 `ByteRangeCache` that `CachedParquetReader` uses during doc retrieval — so the first doc retrieval re-downloaded dictionary pages and data pages.

*Fix*: Rewrote the function to use `CachedParquetReader` with the context's `parquet_byte_range_cache` and `parquet_coalesce_config`. Builds a projected `ParquetRecordBatchStream` and reads all batches through it (data is discarded but L1 gets populated with dictionary/data pages). Also stores footers in `parquet_metadata_cache` so doc retrieval skips the footer download.

### 8. Parquet Page Index — Compute & Store for Companion Splits

**Problem**: Many parquet files (especially those written by Spark, older writers, or explicit `set_offset_index_disabled(true)`) do not include a column offset index in their footer. Without an offset index, the parquet reader must fetch **entire column chunks** when retrieving specific rows — even if only a single page within the chunk is needed. For large files on S3/Azure, this causes massive over-fetching (e.g. downloading a 50MB column chunk to read a 500KB page).

**Solution**: Two-path design covering both legacy and modern parquet files:

**At indexing time:**
1. **Detect** whether each parquet file has a native offset index (via `col_meta.offset_index_offset()` in the footer)
2. **Legacy files** (no offset index): Compute page locations by scanning Thrift-encoded page headers, store them compactly in the manifest's `ColumnChunkInfo.page_locations`
3. **Modern files** (native offset index): Leave `page_locations` empty — no work to do

**At read time:**
1. `CachedParquetReader` loads metadata with `PageIndexPolicy::Optional` (attempts to load native offset index from footer)
2. **Modern files**: Native offset index loaded from footer → used directly
3. **Legacy files**: `offset_index().is_none()` → manifest page locations are injected via `metadata.into_builder().set_offset_index().build()`
4. Both paths result in `InMemoryRowGroup::fetch_ranges()` using `scan_ranges()` for page-level byte range requests

**Design details:**

- **Thrift Parser**: Self-contained ~300-line Thrift compact protocol parser handles the `PageHeader` format. No dependency on internal parquet crate types. Per the Parquet spec, the computed offset index contains **data pages only** — dictionary pages are excluded (the reader handles them separately via the column chunk's `dictionary_page_offset` metadata).
- **`pageIndexSource` Stats**: Each file in retrieval stats reports its page index source: `"manifest"` (computed at index time, injected at read time), `"native"` (loaded from parquet footer), or `"none"` (no page index available). Enables programmatic verification that page-level reads are active.
- **Storage Format**: Page locations are packed as 20 bytes per entry (i64 offset + i32 compressed_page_size + i64 first_row_index, little-endian) and base64-encoded for JSON serialization. For 200 pages: ~5.3KB vs ~14KB for a JSON array (62% reduction).
- **Backward Compatibility**: `#[serde(default)]` ensures old manifests without `page_locations` deserialize cleanly. `skip_serializing_if = "Vec::is_empty"` means files with native offset index add zero overhead.
- **Merge Support**: Page locations in `ColumnChunkInfo` are automatically carried through `combine_parquet_manifests()` since it clones `ParquetFileEntry` structures. Validated by merge survival tests.

## Files Modified

| File | Change |
|------|--------|
| `native/src/debug.rs` | `PERFLOG_ENABLED` static + `perf_println!` macro |
| `native/src/disk_cache/mmap_cache.rs` | `StableMmap`, `StableMmapSlice` zero-copy wrappers |
| `native/src/disk_cache/get_ops.rs` | Use `StableMmap`/`StableMmapSlice` instead of `.to_vec()` |
| `native/src/split_searcher/types.rs` | `pq_columns` (Column handles), selective reads, O(1) lookup |
| `native/src/split_searcher/jni_lifecycle.rs` | Always create ByteRangeCache for CachingDirectory |
| `native/src/split_searcher/jni_search.rs` | PROJ_DIAG timing, pass `cached_searcher` to hash_touchup |
| `native/src/split_searcher/jni_prewarm.rs` | GAP 1: __pq eager-load; GAP 3: rewrite parquet column prewarm; `pageIndexSource` in stats |
| `native/src/split_searcher/async_impl.rs` | Search timing, `bytes.clone()` for SplitOverrides |
| `native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs` | Use `get_pq_location()` O(1) access; perf timing |
| `native/src/prewarm/field_specific.rs` | GAP 2b: `expand_companion_fields()` in all 5 prewarm functions |
| `native/src/parquet_companion/manifest.rs` | `PageLocationEntry` struct, binary pack/unpack, base64 serde, `page_locations` on `ColumnChunkInfo` |
| `native/src/parquet_companion/page_index.rs` | **NEW**: Thrift compact protocol parser + `compute_page_locations_from_column_chunk()` |
| `native/src/parquet_companion/mod.rs` | `pub(crate) mod page_index` declaration and `PageLocationEntry` re-export |
| `native/src/parquet_companion/indexing.rs` | Detect native offset index via `offset_index_offset()`, compute page locations for legacy files |
| `native/src/parquet_companion/cached_reader.rs` | `manifest_page_locations` field, builder method, inject offset index in `get_metadata()` |
| `native/src/parquet_companion/doc_retrieval.rs` | `attach_page_locations()` (pub(crate)), `Arc<[String]>` projected_fields, PROJ_DIAG timing |
| `native/src/parquet_companion/arrow_to_tant.rs` | Wire `attach_page_locations()` into batch path, `Arc<[String]>` projected_fields, PROJ_DIAG timing |
| `native/src/parquet_companion/hash_touchup.rs` | Selective reads via `cached_searcher`, `pq_columns` type |
| `native/src/parquet_companion/hash_field_rewriter.rs` | Remove intermediate Vec in join |
| `native/src/parquet_companion/string_indexing.rs` | Remove intermediate Vec in join |
| `native/src/quickwit_split/jni_functions.rs` | `nativeWriteTestParquetNoPageIndex()` for legacy test files |
| `QuickwitSplit.java` | `nativeWriteTestParquetNoPageIndex()` native method declaration |
| `pom.xml` | Version 0.30.5 → 0.30.6 |
| `ParquetCompanionPageIndexTest.java` | **NEW**: 13 Java integration tests (legacy/modern/mixed/hybrid/merge) |
| `PrewarmGapReproTest.java` | **NEW**: 6 prewarm gap regression tests |

## Test Plan

- [x] `cargo check` — clean compile (125 pre-existing warnings, 0 errors)
- [x] `cargo test --lib parquet_companion` — 267 Rust unit tests pass (including 4 page_index tests)
- [x] `cargo test --lib split_searcher` — 2 tests pass
- [x] `cargo test --lib disk_cache` — 15 tests pass
- [x] `mvn test -Dtest=PrewarmGapReproTest` — 6/6 pass (0 post-prewarm downloads)
- [x] `mvn test -Dtest=ParquetCompanionPageIndexTest` — 13/13 pass:
  - **Legacy path** (3 tests): Single large file (20K rows), multi-file (5x10K), batch retrieval (3x15K)
  - **Modern path** (3 tests): Single large file (20K rows), multi-file (5x10K), batch retrieval (3x15K)
  - **Mixed** (1 test): 2 legacy + 2 modern files (40K total), single + batch retrieval
  - **Hybrid mode** (2 tests): Legacy and modern files with fast field mode
  - **Retrieval stats** (2 tests): Legacy and modern with `pageIndexSource` assertion
  - **Merge survival** (2 tests): Legacy and modern page metadata survives `mergeSplits()`, retrieval + stats validated post-merge
- [x] `mvn test -Dtest=ParquetCompanionTest` — 23 existing integration tests pass
- [ ] `mvn test -Dtest=FieldSpecificPrewarmRegressionTest` — field-specific regression tests
