### PR TITLE
feature: Arrow FFI Import: Create Quickwit Splits from Arrow Columnar Batches

### DIFF
--- a/docs/INDEXTABLES_SPARK_ARROW_FFI_WRITE_DEVELOPER_GUIDE.md
+++ b/docs/INDEXTABLES_SPARK_ARROW_FFI_WRITE_DEVELOPER_GUIDE.md
@@ -1,0 +1,598 @@
+# indextables_spark Arrow FFI Write Integration Guide
+
+This guide covers how to integrate the new Arrow FFI write path in tantivy4java for creating Quickwit splits directly from Spark's columnar batches. It replaces the row-at-a-time JNI overhead with batch-level Arrow C Data Interface transfers.
+
+---
+
+## 1. Architecture Overview
+
+### Current Write Pipeline (Row-at-a-time)
+
+```
+Spark InternalRow
+  → TantivySearchEngine.addDocument() [per-row JNI call]
+  → Tantivy Index (temp dir)
+  → QuickwitSplit.convertIndexFromPath()
+  → .split file
+  → S3/Azure upload
+```
+
+### New Arrow FFI Write Pipeline (Columnar)
+
+```
+Spark ColumnarBatch
+  → ArrowFfiBridge.exportBatch() [one JNI call per batch]
+  → FFI memory addresses
+  → QuickwitSplit.addArrowBatch() [Rust imports batch, routes to per-partition writers]
+  → QuickwitSplit.finishAllSplits()
+  → .split files (one per partition)
+  → S3/Azure upload per partition
+```
+
+### When to Use Which Path
+
+| Path | Use When |
+|------|----------|
+| **Arrow FFI** (new) | New writes from Spark DataFrames, bulk loads, any `DataWriter[ColumnarBatch]` path |
+| **Row-at-a-time** (legacy) | Fallback when Spark doesn't support columnar writes, single-row upserts |
+| **Parquet companion** | External parquet files already exist; indexing only, no doc storage in split |
+
+### Performance Comparison
+
+| Metric | Row-at-a-time | Arrow FFI |
+|--------|---------------|-----------|
+| JNI calls per batch (4096 rows) | 4,096 | 1 |
+| Serialization | Per-field Java→JNI→Rust | Zero-copy FFI pointer transfer |
+| Memory copies | Per-field value copying | Zero (shared memory via FFI) |
+| Partition routing | Java-side HashMap lookup per row | Rust-side extraction from Arrow columns |
+
+---
+
+## 2. Arrow FFI Write Integration
+
+### Lifecycle Pattern
+
+```java
+long handle = 0;
+try {
+    // 1. Export schema via ArrowFfiBridge
+    long schemaAddr = ArrowFfiBridge.exportSchema(arrowSchema);
+
+    // 2. Begin split creation
+    String[] partitionCols = new String[]{"event_date", "region"};
+    handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols,
+                                                Index.Memory.DEFAULT_HEAP_SIZE);
+
+    // 3. Stream batches
+    for (ColumnarBatch batch : batches) {
+        long arrayAddr = ArrowFfiBridge.exportBatch(batch);
+        long batchSchemaAddr = ArrowFfiBridge.exportBatchSchema(batch);
+        long totalDocs = QuickwitSplit.addArrowBatch(handle, arrayAddr, batchSchemaAddr);
+    }
+
+    // 4. Finalize all partition splits
+    List<QuickwitSplit.PartitionSplitResult> results =
+        QuickwitSplit.finishAllSplits(handle, "/tmp/output");
+    handle = 0; // handle consumed by finishAllSplits
+
+    // 5. Upload each partition's split to cloud
+    for (QuickwitSplit.PartitionSplitResult result : results) {
+        uploadToCloud(result.getSplitPath(), buildCloudPath(result));
+    }
+} finally {
+    if (handle != 0) {
+        QuickwitSplit.cancelSplit(handle);
+    }
+}
+```
+
+### Memory Lifecycle
+
+- **Schema export**: JVM allocates `FFI_ArrowSchema` struct. Rust takes ownership via `std::ptr::replace` (writes empty sentinel back). JVM memory is freed when GC collects the original schema.
+- **Batch export**: Same pattern — JVM retains buffer ownership until Rust import completes. Since `addArrowBatch()` is synchronous, buffers are safe for the duration of the call.
+- **After import**: Rust owns Arrow `ArrayData` backed by the original JVM buffers. The `align_buffers()` call may copy data if alignment is wrong (rare).
+
+### Error Handling
+
+```java
+long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols, heapSize);
+try {
+    // ... addArrowBatch calls ...
+    List<PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+    handle = 0; // consumed
+    return results;
+} catch (Exception e) {
+    if (handle != 0) {
+        QuickwitSplit.cancelSplit(handle);
+    }
+    throw e;
+}
+```
+
+---
+
+## 3. Partition Handling with Arrow FFI
+
+### Key Design: Partition Routing in Rust
+
+Unlike the current Java-side partition routing (where `partitionWriters` is a `Map` in Java), the Arrow FFI path routes partitions **in Rust**:
+
+1. Java passes full batches including partition columns via FFI
+2. Java passes partition column names at `beginSplitFromArrow()` time
+3. Rust extracts partition values per-row from the Arrow columns
+4. Rust lazily creates per-partition `IndexWriter` on first row for each new partition value
+5. Non-partition columns are indexed; partition columns are excluded from the tantivy index
+
+### Partition Flow
+
+```
+beginSplitFromArrow(schema, ["event_date", "region"], heapSize)
+  → Rust identifies partition columns in schema
+  → Rust derives tantivy schema from non-partition columns only
+
+addArrowBatch(handle, batch)
+  → For each row:
+    1. Extract partition values: event_date="2023-01-15", region="us"
+    2. Build key: "event_date=2023-01-15/region=us"
+    3. Get-or-create PartitionWriter for that key
+    4. Convert non-partition columns to TantivyDocument
+    5. Add document to that partition's IndexWriter
+
+finishAllSplits(handle, outputDir)
+  → Returns List<PartitionSplitResult>, one per partition:
+    - partitionKey: "event_date=2023-01-15/region=us"
+    - partitionValues: {"event_date": "2023-01-15", "region": "us"}
+    - splitPath: "/tmp/output/event_date=2023-01-15/region=us/part-uuid.split"
+    - numDocs: 1500
+```
+
+### Java-Side Integration
+
+```java
+// In DataWriter[ColumnarBatch].commit():
+List<PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, localTempDir);
+
+// Construct AddAction per partition
+for (PartitionSplitResult result : results) {
+    AddAction action = new AddAction();
+    action.setSplitPath(result.getSplitPath());
+    action.setPartitionValues(result.getPartitionValues());
+    action.setNumDocs(result.getNumDocs());
+    action.setFooterStartOffset(result.getFooterStartOffset());
+    action.setFooterEndOffset(result.getFooterEndOffset());
+    actions.add(action);
+}
+```
+
+### Memory Consideration
+
+Each partition's `IndexWriter` uses `heapSize` bytes. For tables with many partitions in one task:
+
+```
+Total memory = numPartitions × heapSize
+```
+
+For high-cardinality partitioning (e.g., daily partitions across years), use a smaller heap:
+
+```java
+// 50MB per partition (default) — fine for <20 partitions
+long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols,
+                                                Index.Memory.DEFAULT_HEAP_SIZE);
+
+// For high-cardinality partitioning (100+ partitions), use minimum heap
+long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols,
+                                                Index.Memory.MIN_HEAP_SIZE);
+```
+
+---
+
+## 4. Split Rolling Integration
+
+### Current Pattern
+
+```java
+// Current row-at-a-time split rolling
+void addDocument(InternalRow row) {
+    writer.addDocument(doc);
+    currentRowCount++;
+    if (currentRowCount >= maxRowsPerSplit) {
+        maybeRollSplit(); // finalize current, start new
+    }
+}
+```
+
+### Arrow FFI Pattern
+
+`addArrowBatch()` returns cumulative total doc count. Check after each batch:
+
+```java
+long totalDocs = 0;
+long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols, heapSize);
+List<PartitionSplitResult> allResults = new ArrayList<>();
+
+for (ColumnarBatch batch : batches) {
+    long arrayAddr = ArrowFfiBridge.exportBatch(batch);
+    long schemaAddr = ArrowFfiBridge.exportBatchSchema(batch);
+    totalDocs = QuickwitSplit.addArrowBatch(handle, arrayAddr, schemaAddr);
+
+    // Check split rolling threshold
+    if (totalDocs >= maxRowsPerSplit) {
+        // Finalize all current partitions
+        List<PartitionSplitResult> results =
+            QuickwitSplit.finishAllSplits(handle, localTempDir);
+        allResults.addAll(results);
+
+        // Start fresh context for remaining batches
+        handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols, heapSize);
+        totalDocs = 0;
+    }
+}
+
+// Finalize remaining data
+if (totalDocs > 0) {
+    allResults.addAll(QuickwitSplit.finishAllSplits(handle, localTempDir));
+}
+```
+
+**Note**: Split rolling is per-context (all partitions roll together). For per-partition rolling (where partition A rolls at 100K rows while partition B continues), a `maxRowsPerSplit` parameter in Rust would be needed — this can be a future enhancement.
+
+---
+
+## 5. Schema Conversion
+
+### Current Path
+```
+Spark StructType → SparkToTantivyConverter → tantivy SchemaBuilder calls
+```
+
+### New Arrow FFI Path
+```
+Spark StructType → ArrowUtils.toArrowSchema() → FFI export → Rust derive_tantivy_schema_with_mapping()
+```
+
+### Field Type Mapping
+
+| Spark Type | Arrow Type | Tantivy Type | Notes |
+|------------|-----------|--------------|-------|
+| `StringType` | `Utf8` | Text (raw tokenizer) | Indexed + stored + fast |
+| `LongType` | `Int64` | I64 | Indexed + stored + fast |
+| `IntegerType` | `Int32` | I64 | Widened to i64 |
+| `DoubleType` | `Float64` | F64 | Indexed + stored + fast |
+| `FloatType` | `Float32` | F64 | Widened to f64 |
+| `BooleanType` | `Boolean` | Bool | Indexed + stored + fast |
+| `TimestampType` | `Timestamp(us, tz)` | DateTime | Indexed + stored + fast |
+| `DateType` | `Date32` | DateTime | Indexed + stored + fast |
+| `StructType` | `Struct` | JSON | Stored + indexed |
+| `ArrayType` | `List` | JSON | Stored + indexed |
+| `DecimalType` | `Decimal128` | F64 | Lossy for values > 2^53 |
+| `BinaryType` | `Binary` | Bytes | Indexed + stored |
+
+### Key Difference from Companion Mode
+
+Standard splits (Arrow FFI path) set **STORED** on all fields — documents are stored in tantivy's doc store. Companion mode omits STORED because parquet is the store.
+
+### Tokenizer Configuration
+
+Arrow schema metadata doesn't carry tokenizer information. By default, all text fields use the "raw" tokenizer (exact match). To use different tokenizers (e.g., "default" for full-text search), pass tokenizer configuration separately — this is a future enhancement.
+
+---
+
+## 6. DataWriter[InternalRow] vs DataWriter[ColumnarBatch] Migration
+
+### Current Implementation
+
+```java
+class IndexTables4SparkDataWriter extends DataWriter[InternalRow] {
+    void write(InternalRow row) {
+        // Per-row JNI call
+        tantivySearchEngine.addDocument(row);
+        maybeRollSplit();
+    }
+}
+```
+
+### New Columnar Implementation
+
+```java
+class IndexTables4SparkColumnarDataWriter extends DataWriter[ColumnarBatch] {
+    private long ffiHandle;
+
+    IndexTables4SparkColumnarDataWriter(StructType schema, String[] partitionCols) {
+        long schemaAddr = ArrowFfiBridge.exportSchema(
+            ArrowUtils.toArrowSchema(schema));
+        this.ffiHandle = QuickwitSplit.beginSplitFromArrow(
+            schemaAddr, partitionCols, Index.Memory.DEFAULT_HEAP_SIZE);
+    }
+
+    void write(ColumnarBatch batch) {
+        long arrayAddr = ArrowFfiBridge.exportBatch(batch);
+        long schemaAddr = ArrowFfiBridge.exportBatchSchema(batch);
+        QuickwitSplit.addArrowBatch(ffiHandle, arrayAddr, schemaAddr);
+    }
+
+    WriterCommitMessage commit() {
+        List<PartitionSplitResult> results =
+            QuickwitSplit.finishAllSplits(ffiHandle, localTempDir);
+        ffiHandle = 0;
+        // Upload splits, construct commit message...
+        return new CommitMessage(results);
+    }
+
+    void abort() {
+        if (ffiHandle != 0) {
+            QuickwitSplit.cancelSplit(ffiHandle);
+            ffiHandle = 0;
+        }
+    }
+}
+```
+
+### Writer Factory Integration
+
+```java
+class IndexTables4SparkWriterFactory implements DataWriterFactory {
+    // Spark 3.4+: implement columnar write support
+    boolean supportColumnarWrite() { return true; }
+
+    DataWriter<ColumnarBatch> createColumnarWriter(int partitionId, long taskId) {
+        return new IndexTables4SparkColumnarDataWriter(schema, partitionColumns);
+    }
+
+    // Fallback for non-columnar: Spark auto-converts ColumnarBatch → InternalRow
+    DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+        return new IndexTables4SparkDataWriter(schema, partitionColumns);
+    }
+}
+```
+
+### Simplified Partition Handling
+
+With Arrow FFI, no `partitionWriters` map is needed in Java — Rust manages per-partition writers:
+
+```java
+// OLD: Java manages partition routing
+Map<String, PartitionWriter> partitionWriters; // complex Java-side state
+void write(InternalRow row) {
+    String key = extractPartitionKey(row); // expensive per-row
+    PartitionWriter pw = partitionWriters.getOrElseUpdate(key, ...);
+    pw.addDocument(row);
+}
+
+// NEW: Rust manages partition routing
+void write(ColumnarBatch batch) {
+    QuickwitSplit.addArrowBatch(handle, exportedArray, exportedSchema);
+    // That's it — Rust handles everything
+}
+```
+
+---
+
+## 7. Cloud Upload Pattern
+
+### Two-Stage Pattern (Unchanged)
+
+```java
+// 1. Create splits locally
+List<PartitionSplitResult> results =
+    QuickwitSplit.finishAllSplits(handle, localTempDir);
+
+// 2. Upload each partition's split to cloud
+for (PartitionSplitResult result : results) {
+    // Local path mirrors partition layout:
+    //   /tmp/output/event_date=2023-01-15/region=us/part-uuid.split
+    String localPath = result.getSplitPath();
+
+    // Construct cloud target path
+    String cloudPath = String.format("s3://%s/%s/%s/%s",
+        bucket, tableName, result.getPartitionKey(),
+        new File(localPath).getName());
+
+    CloudStorageProviderFactory.uploadFile(localPath, cloudPath);
+
+    // Cleanup local file
+    new File(localPath).delete();
+}
+```
+
+### Directory Structure
+
+```
+localTempDir/
+├── event_date=2023-01-15/
+│   ├── region=us/
+│   │   └── part-abc123.split
+│   └── region=eu/
+│       └── part-def456.split
+└── event_date=2023-01-16/
+    └── region=us/
+        └── part-ghi789.split
+```
+
+---
+
+## 8. Statistics and Metadata
+
+### Split Metadata from Arrow FFI
+
+Each `PartitionSplitResult` includes:
+
+| Field | Description |
+|-------|-------------|
+| `partitionKey` | Hive-style key, e.g., `"event_date=2023-01-15/region=us"` |
+| `partitionValues` | `Map<String, String>` of col→value pairs |
+| `splitPath` | Local filesystem path where split was written |
+| `splitId` | Quickwit split UUID |
+| `numDocs` | Document count in this split |
+| `footerStartOffset` | Footer offset for lazy loading |
+| `footerEndOffset` | End offset of footer |
+
+### AddAction Construction
+
+```java
+for (PartitionSplitResult result : results) {
+    AddAction action = AddAction.builder()
+        .splitId(result.getSplitId())
+        .splitPath(cloudPath)
+        .numDocs(result.getNumDocs())
+        .partitionValues(result.getPartitionValues())
+        .footerStartOffset(result.getFooterStartOffset())
+        .footerEndOffset(result.getFooterEndOffset())
+        .build();
+    actions.add(action);
+}
+```
+
+---
+
+## 9. Configuration Mapping
+
+### Existing Spark Configs → Arrow FFI
+
+| Spark Config | Arrow FFI Equivalent | Notes |
+|-------------|---------------------|-------|
+| `spark.indextables.indexing.typemap` | Arrow schema metadata | Type info carried in Arrow schema |
+| `spark.indextables.indexing.fastfields` | All fields are fast by default | Future: config parameter |
+| `spark.indextables.indexing.nonfastfields` | N/A (all fast) | Future: config parameter |
+| `spark.indextables.indexing.tokenizer` | Default "raw" tokenizer | Future: per-field config |
+| `spark.indextables.text.maxTokenLength` | N/A | Future: config parameter |
+| `spark.indextables.indexing.storeonlyfields` | N/A (all stored+indexed) | Future: config parameter |
+| `spark.indextables.indexing.indexonlyfields` | N/A (all stored+indexed) | Future: config parameter |
+| `spark.indextables.maxRowsPerSplit` | Check `addArrowBatch()` return value | See Split Rolling section |
+| `__partition_columns` | `partitionColumns` parameter | Passed to `beginSplitFromArrow()` |
+
+### Future Configuration Enhancement
+
+For advanced field-level configuration (tokenizers, fast/stored flags), a JSON config parameter can be passed to `beginSplitFromArrow`:
+
+```java
+// Future API (not yet implemented)
+String fieldConfig = """
+{
+  "fields": {
+    "title": {"tokenizer": "default", "fast": true, "stored": true},
+    "body": {"tokenizer": "default", "fast": false, "stored": true},
+    "score": {"fast": true, "stored": false}
+  }
+}
+""";
+long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols, heapSize, fieldConfig);
+```
+
+---
+
+## 10. Error Handling & Resource Safety
+
+### Handle Lifecycle Contract
+
+Every `beginSplitFromArrow()` call MUST be matched by exactly one of:
+- `finishAllSplits()` — normal completion
+- `cancelSplit()` — abort/cleanup
+
+### Pattern in DataWriter
+
+```java
+class ArrowFfiSplitWriter implements Closeable {
+    private long handle;
+
+    ArrowFfiSplitWriter(long schemaAddr, String[] partitionCols, long heapSize) {
+        this.handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, partitionCols, heapSize);
+    }
+
+    void addBatch(long arrayAddr, long schemaAddr) {
+        if (handle == 0) throw new IllegalStateException("Writer already closed");
+        QuickwitSplit.addArrowBatch(handle, arrayAddr, schemaAddr);
+    }
+
+    List<PartitionSplitResult> finish(String outputDir) {
+        if (handle == 0) throw new IllegalStateException("Writer already closed");
+        List<PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+        handle = 0;
+        return results;
+    }
+
+    @Override
+    public void close() {
+        if (handle != 0) {
+            QuickwitSplit.cancelSplit(handle);
+            handle = 0;
+        }
+    }
+}
+```
+
+### Error Scenarios
+
+| Scenario | Behavior |
+|----------|----------|
+| `addArrowBatch` fails | Handle still valid; can retry or cancel |
+| `finishAllSplits` fails after partial writes | Some split files may exist on disk; cleanup needed |
+| JVM crash between begin and finish | Temp directories auto-cleaned by OS |
+| Schema mismatch in batch | `addArrowBatch` throws; handle still valid |
+| Null FFI pointer | `addArrowBatch` throws; handle still valid |
+
+### Rust-Side Safety
+
+All JNI entry points are wrapped in `convert_throwable`, which catches Rust panics and converts them to Java exceptions. This prevents JVM crashes from Rust-side errors.
+
+---
+
+## 11. Merge-on-Write and Purge-on-Write Compatibility
+
+Arrow FFI splits are **standard Quickwit splits** — identical format to those created by the row-at-a-time path or `convertIndexFromPath()`.
+
+| Operation | Impact |
+|-----------|--------|
+| `evaluateAndExecuteMergeOnWrite()` | No changes needed — works on committed splits |
+| `MergeSplitsExecutor` | No changes — merges standard splits |
+| `PurgeOrphanedSplitsExecutor` | No changes — operates on transaction log |
+| `SplitSearcher` queries | No changes — standard splits fully searchable |
+| Document retrieval | No changes — docs stored in tantivy doc store |
+
+---
+
+## 12. Testing Strategy
+
+### Unit Tests (Rust)
+
+12 unit tests in `native/src/parquet_companion/arrow_ffi_import.rs`:
+
+**Non-partitioned (7 tests):**
+1. `test_begin_creates_schema` — tantivy schema derived correctly with STORED flag
+2. `test_add_single_batch` — single batch, verify doc count
+3. `test_add_multiple_batches` — streaming 3 batches, verify 300 docs
+4. `test_finish_creates_valid_split` — full pipeline, verify split file created
+5. `test_cancel_cleans_up` — verify temp dirs removed on cancel
+6. `test_schema_mismatch_rejected` — wrong schema batch rejected
+7. `test_all_field_types` — Bool, I64, F64, Utf8 round-trip
+
+**Partitioned (5 tests):**
+8. `test_partitioned_single_partition` — one partition value → 1 split
+9. `test_partitioned_multiple_partitions` — 3 partition values → 3 splits
+10. `test_partitioned_across_batches` — partition rows across multiple batches
+11. `test_partition_columns_excluded_from_index` — partition cols not in tantivy schema
+12. `test_multi_level_partitioning` — two partition columns, verify key format
+
+Run with: `cd native && cargo test --lib parquet_companion::arrow_ffi_import`
+
+### Integration Tests (Java)
+
+Recommended integration tests for the indextables_spark team:
+
+1. **Round-trip test**: Create Arrow batch → `beginSplitFromArrow` → `addArrowBatch` → `finishAllSplits` → open with `SplitSearcher` → verify all docs searchable and retrievable
+2. **Partition test**: Multi-partition batch → verify correct number of splits with correct doc counts per partition → verify partition directory structure
+3. **Split rolling test**: Large dataset with `maxRowsPerSplit` → verify multiple split groups created
+4. **Type coverage test**: All Spark types (String, Long, Double, Boolean, Timestamp, Struct, Array) → verify correct tantivy field types
+5. **Error handling test**: Cancel mid-stream → verify no resource leaks
+6. **Mixed mode test**: Some tasks use Arrow FFI, others use row path → verify both produce compatible splits
+
+### Running Existing Tests
+
+```bash
+# Rust unit tests (12 new + 292 existing)
+cd native && cargo test --lib parquet_companion::arrow_ffi_import
+cd native && cargo test --lib parquet_companion  # full suite
+
+# Java tests (ensure native library is built first)
+mvn clean package -DskipTests
+mvn test -pl . -Dtest="ParquetCompanion*"
+```

--- a/native/src/parquet_companion/arrow_ffi_import.rs
+++ b/native/src/parquet_companion/arrow_ffi_import.rs
@@ -1,0 +1,932 @@
+// arrow_ffi_import.rs - Arrow FFI import for standard Quickwit split creation
+//
+// Receives Arrow columnar batches via the Arrow C Data Interface (FFI) from the JVM
+// and creates standard Quickwit splits with stored documents. This enables Spark to
+// stream ColumnarBatch data directly into split creation, bypassing row-at-a-time JNI
+// overhead and parquet round-trips.
+//
+// Supports multi-partition writes: full batches cross the FFI boundary with partition
+// columns included. Rust extracts partition values per-row, groups them, and routes
+// to per-partition IndexWriters internally.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow_array::{RecordBatch, StructArray, Array, StringArray, BooleanArray, Int32Array, Int64Array, Float64Array};
+use arrow_schema::{DataType, Schema as ArrowSchema, SchemaRef};
+use tantivy::{Index, IndexWriter, TantivyDocument};
+use tantivy::schema::{Schema as TantivySchema, Field};
+use uuid::Uuid;
+
+use crate::debug_println;
+use super::indexing::{arrow_row_to_tantivy_doc, add_arrow_value_to_doc, add_string_value_to_doc, convert_complex_to_json};
+use super::manifest::FastFieldMode;
+use super::name_mapping::NameMapping;
+use super::schema_derivation::{SchemaDerivationConfig, derive_tantivy_schema_with_mapping};
+use super::statistics::StatisticsAccumulator;
+use super::string_indexing::StringIndexingMode;
+use crate::quickwit_split::{
+    SplitConfig, QuickwitSplitMetadata, FooterOffsets,
+    default_split_config, create_quickwit_split,
+};
+use crate::quickwit_split::json_discovery::extract_doc_mapping_from_index;
+
+/// Context for streaming Arrow FFI split creation.
+/// Wrapped in Arc<Mutex<>> at the JNI layer (IndexWriter is !Sync).
+///
+/// Supports multi-partition writes: full batches cross FFI with partition columns
+/// included. Rust extracts partition values, groups rows, and routes to
+/// per-partition IndexWriters internally.
+pub(crate) struct ArrowFfiSplitContext {
+    tantivy_schema: TantivySchema,
+    arrow_schema: SchemaRef,
+    /// Maps non-partition Arrow column indices to tantivy fields.
+    field_mapping: Vec<FieldMapping>,
+    /// Partition column indices in the Arrow schema (empty = non-partitioned)
+    partition_col_indices: Vec<usize>,
+    /// Partition column names (parallel to partition_col_indices)
+    partition_col_names: Vec<String>,
+    /// Per-partition writers: partition_key (e.g. "event_date=2023-01-15") → PartitionWriter
+    partition_writers: HashMap<String, PartitionWriter>,
+    /// For non-partitioned tables: single writer (partition_writers is empty)
+    default_writer: Option<PartitionWriter>,
+    heap_size: usize,
+    total_doc_count: u64,
+    total_batch_count: u64,
+}
+
+/// Per-partition state: each partition gets its own Index + IndexWriter + temp dir.
+struct PartitionWriter {
+    index: Index,
+    writer: IndexWriter,
+    index_dir: tempfile::TempDir,
+    doc_count: u64,
+    /// Partition column values for this partition (col_name → string value)
+    partition_values: HashMap<String, String>,
+}
+
+struct FieldMapping {
+    arrow_col_idx: usize,
+    tantivy_field: Field,
+    field_name: String,
+    #[allow(dead_code)]
+    data_type: DataType,
+}
+
+/// Result for one partition's finalized split
+pub(crate) struct PartitionSplitResult {
+    /// Partition key (e.g. "event_date=2023-01-15/region=us"), empty for non-partitioned
+    pub partition_key: String,
+    /// Partition column values
+    pub partition_values: HashMap<String, String>,
+    /// Path where the split was written
+    pub split_path: String,
+    /// Split metadata
+    pub metadata: QuickwitSplitMetadata,
+}
+
+/// Import an Arrow schema from an FFI pointer, taking ownership.
+/// Uses the Comet `std::ptr::replace` pattern for safe ownership transfer.
+pub(crate) fn import_arrow_schema(schema_ptr: *mut FFI_ArrowSchema) -> Result<ArrowSchema> {
+    if schema_ptr.is_null() {
+        bail!("Null FFI_ArrowSchema pointer");
+    }
+    let ffi_schema = unsafe { std::ptr::replace(schema_ptr, FFI_ArrowSchema::empty()) };
+    let arrow_schema = ArrowSchema::try_from(&ffi_schema)
+        .context("Failed to import Arrow schema from FFI")?;
+    Ok(arrow_schema)
+}
+
+/// Import an Arrow RecordBatch from FFI pointers, taking ownership.
+/// Uses the Comet `std::ptr::replace` pattern for safe ownership transfer.
+pub(crate) fn import_arrow_batch(
+    array_ptr: *mut FFI_ArrowArray,
+    schema_ptr: *mut FFI_ArrowSchema,
+) -> Result<RecordBatch> {
+    if array_ptr.is_null() || schema_ptr.is_null() {
+        bail!("Null FFI pointer: array={} schema={}", array_ptr.is_null(), schema_ptr.is_null());
+    }
+    let ffi_array = unsafe { std::ptr::replace(array_ptr, FFI_ArrowArray::empty()) };
+    let ffi_schema = unsafe { std::ptr::replace(schema_ptr, FFI_ArrowSchema::empty()) };
+    let array_data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }
+        .context("Failed to import Arrow array from FFI")?;
+    let mut array_data = array_data;
+    // Safety: Java-allocated Arrow buffers may not be 64-byte aligned
+    array_data.align_buffers();
+    let struct_array = StructArray::from(array_data);
+    Ok(RecordBatch::from(struct_array))
+}
+
+/// Begin creating splits from Arrow columnar data.
+///
+/// Accepts the full Arrow schema (including partition columns) + list of partition column names.
+/// Identifies partition columns in the schema; builds field_mapping for non-partition columns only.
+/// Derives tantivy schema with STORED flag set on all fields (standard split behavior).
+pub(crate) fn begin_split_from_arrow(
+    arrow_schema: ArrowSchema,
+    partition_col_names: &[String],
+    heap_size: usize,
+) -> Result<ArrowFfiSplitContext> {
+    // Identify partition column indices
+    let mut partition_col_indices = Vec::new();
+    for name in partition_col_names {
+        let idx = arrow_schema.fields().iter().position(|f| f.name() == name)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Partition column '{}' not found in Arrow schema. Available: {:?}",
+                name,
+                arrow_schema.fields().iter().map(|f| f.name().as_str()).collect::<Vec<_>>()
+            ))?;
+        partition_col_indices.push(idx);
+    }
+    let partition_set: std::collections::HashSet<usize> = partition_col_indices.iter().copied().collect();
+
+    // Build Arrow schema for non-partition columns only (for tantivy schema derivation)
+    let non_partition_fields: Vec<_> = arrow_schema.fields().iter()
+        .enumerate()
+        .filter(|(i, _)| !partition_set.contains(i))
+        .map(|(_, f)| f.clone())
+        .collect();
+    let non_partition_schema = ArrowSchema::new(non_partition_fields);
+
+    // Derive tantivy schema with STORED flag (standard splits store docs in tantivy)
+    let config = SchemaDerivationConfig {
+        fast_field_mode: FastFieldMode::Disabled, // All fields get fast access
+        store_fields: true,                       // Standard splits: docs stored in tantivy
+        ..Default::default()
+    };
+    let tantivy_schema = derive_tantivy_schema_with_mapping(&non_partition_schema, &config, None)?;
+
+    // Build field mapping: Arrow column index → tantivy field
+    let mut field_mapping = Vec::new();
+    for (arrow_col_idx, arrow_field) in arrow_schema.fields().iter().enumerate() {
+        if partition_set.contains(&arrow_col_idx) {
+            continue; // Skip partition columns
+        }
+        let field_name = arrow_field.name().as_str();
+        if let Ok(tantivy_field) = tantivy_schema.get_field(field_name) {
+            field_mapping.push(FieldMapping {
+                arrow_col_idx,
+                tantivy_field,
+                field_name: field_name.to_string(),
+                data_type: arrow_field.data_type().clone(),
+            });
+        }
+    }
+
+    let arrow_schema_ref = std::sync::Arc::new(arrow_schema);
+
+    // For non-partitioned tables, create single writer immediately
+    let default_writer = if partition_col_names.is_empty() {
+        Some(create_partition_writer(&tantivy_schema, heap_size, HashMap::new())?)
+    } else {
+        None
+    };
+
+    Ok(ArrowFfiSplitContext {
+        tantivy_schema,
+        arrow_schema: arrow_schema_ref,
+        field_mapping,
+        partition_col_indices,
+        partition_col_names: partition_col_names.to_vec(),
+        partition_writers: HashMap::new(),
+        default_writer,
+        heap_size,
+        total_doc_count: 0,
+        total_batch_count: 0,
+    })
+}
+
+/// Create a new PartitionWriter with its own temp dir, Index, and single-threaded IndexWriter.
+fn create_partition_writer(
+    tantivy_schema: &TantivySchema,
+    heap_size: usize,
+    partition_values: HashMap<String, String>,
+) -> Result<PartitionWriter> {
+    let index_dir = tempfile::tempdir()
+        .context("Failed to create temp directory for partition writer")?;
+
+    let index = Index::create_in_dir(index_dir.path(), tantivy_schema.clone())
+        .context("Failed to create tantivy index for partition")?;
+
+    // Use tantivy's default tokenizer manager which includes "raw", "default", etc.
+    // Do NOT set Quickwit's fast field normalizer manager here — it doesn't include
+    // standard tokenizers needed for text field indexing.
+
+    // Single-threaded writer ensures deterministic doc ordering matching batch insertion order
+    let writer = index.writer_with_num_threads(1, heap_size)
+        .context("Failed to create index writer for partition")?;
+
+    Ok(PartitionWriter {
+        index,
+        writer,
+        index_dir,
+        doc_count: 0,
+        partition_values,
+    })
+}
+
+/// Extract a string representation of a partition column value at a given row.
+fn extract_partition_value(batch: &RecordBatch, col_idx: usize, row_idx: usize) -> Result<String> {
+    let array = batch.column(col_idx);
+    if array.is_null(row_idx) {
+        return Ok("__HIVE_DEFAULT_PARTITION__".to_string());
+    }
+    match array.data_type() {
+        DataType::Utf8 => {
+            let arr = array.as_any().downcast_ref::<StringArray>()
+                .ok_or_else(|| anyhow::anyhow!("Expected StringArray for partition column"))?;
+            Ok(arr.value(row_idx).to_string())
+        }
+        DataType::Int32 => {
+            let arr = array.as_any().downcast_ref::<Int32Array>()
+                .ok_or_else(|| anyhow::anyhow!("Expected Int32Array for partition column"))?;
+            Ok(arr.value(row_idx).to_string())
+        }
+        DataType::Int64 => {
+            let arr = array.as_any().downcast_ref::<Int64Array>()
+                .ok_or_else(|| anyhow::anyhow!("Expected Int64Array for partition column"))?;
+            Ok(arr.value(row_idx).to_string())
+        }
+        DataType::Boolean => {
+            let arr = array.as_any().downcast_ref::<BooleanArray>()
+                .ok_or_else(|| anyhow::anyhow!("Expected BooleanArray for partition column"))?;
+            Ok(arr.value(row_idx).to_string())
+        }
+        DataType::Float64 => {
+            let arr = array.as_any().downcast_ref::<Float64Array>()
+                .ok_or_else(|| anyhow::anyhow!("Expected Float64Array for partition column"))?;
+            Ok(arr.value(row_idx).to_string())
+        }
+        dt => bail!("Unsupported partition column type: {:?}", dt),
+    }
+}
+
+/// Build Hive-style partition key from column values.
+/// e.g., "event_date=2023-01-15/region=us"
+fn build_partition_key(col_names: &[String], values: &[String]) -> String {
+    col_names.iter().zip(values.iter())
+        .map(|(name, value)| format!("{}={}", name, value))
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Add a batch of Arrow columnar data. Rows are automatically routed to the correct
+/// partition writer based on partition column values in the batch.
+///
+/// Returns cumulative total doc count across all partitions.
+pub(crate) fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &RecordBatch) -> Result<u64> {
+    // Validate schema matches
+    let batch_schema = batch.schema();
+    if batch_schema.fields().len() != ctx.arrow_schema.fields().len() {
+        bail!(
+            "Schema mismatch: expected {} columns, got {}",
+            ctx.arrow_schema.fields().len(),
+            batch_schema.fields().len()
+        );
+    }
+
+    // Empty pass-through configs for standard splits (no companion-mode features)
+    let name_mapping: NameMapping = HashMap::new();
+    let schema_derivation_config = SchemaDerivationConfig {
+        fast_field_mode: FastFieldMode::Disabled,
+        store_fields: true,
+        ..Default::default()
+    };
+    let string_hash_fields: HashMap<String, String> = HashMap::new();
+    let mut accumulators: HashMap<String, StatisticsAccumulator> = HashMap::new();
+    let string_indexing_modes: HashMap<String, StringIndexingMode> = HashMap::new();
+    let compiled_regexes: HashMap<String, regex::Regex> = HashMap::new();
+
+    let num_rows = batch.num_rows();
+
+    if ctx.partition_col_indices.is_empty() {
+        // Non-partitioned path: add all rows to default writer
+        let pw = ctx.default_writer.as_mut()
+            .ok_or_else(|| anyhow::anyhow!("No default writer for non-partitioned context"))?;
+
+        for row_idx in 0..num_rows {
+            let doc = build_doc_from_arrow_row(
+                batch,
+                row_idx,
+                &ctx.field_mapping,
+                &ctx.tantivy_schema,
+                &name_mapping,
+                &schema_derivation_config,
+                &string_hash_fields,
+                &mut accumulators,
+                &string_indexing_modes,
+                &compiled_regexes,
+            )?;
+            pw.writer.add_document(doc)?;
+            pw.doc_count += 1;
+        }
+    } else {
+        // Partitioned path: route each row to correct partition writer
+        for row_idx in 0..num_rows {
+            // Extract partition column values
+            let mut partition_values_vec = Vec::with_capacity(ctx.partition_col_indices.len());
+            for &col_idx in &ctx.partition_col_indices {
+                partition_values_vec.push(extract_partition_value(batch, col_idx, row_idx)?);
+            }
+            let partition_key = build_partition_key(&ctx.partition_col_names, &partition_values_vec);
+
+            // Get or lazily create partition writer
+            if !ctx.partition_writers.contains_key(&partition_key) {
+                let mut partition_values_map = HashMap::new();
+                for (name, value) in ctx.partition_col_names.iter().zip(partition_values_vec.iter()) {
+                    partition_values_map.insert(name.clone(), value.clone());
+                }
+                let pw = create_partition_writer(&ctx.tantivy_schema, ctx.heap_size, partition_values_map)?;
+                ctx.partition_writers.insert(partition_key.clone(), pw);
+                debug_println!("ARROW_FFI_IMPORT: Created new partition writer for '{}'", partition_key);
+            }
+
+            let pw = ctx.partition_writers.get_mut(&partition_key).unwrap();
+
+            let doc = build_doc_from_arrow_row(
+                batch,
+                row_idx,
+                &ctx.field_mapping,
+                &ctx.tantivy_schema,
+                &name_mapping,
+                &schema_derivation_config,
+                &string_hash_fields,
+                &mut accumulators,
+                &string_indexing_modes,
+                &compiled_regexes,
+            )?;
+            pw.writer.add_document(doc)?;
+            pw.doc_count += 1;
+        }
+    }
+
+    ctx.total_doc_count += num_rows as u64;
+    ctx.total_batch_count += 1;
+    Ok(ctx.total_doc_count)
+}
+
+/// Build a TantivyDocument from a single Arrow row using the field_mapping.
+/// Only non-partition columns are included.
+#[allow(clippy::too_many_arguments)]
+fn build_doc_from_arrow_row(
+    batch: &RecordBatch,
+    row_idx: usize,
+    field_mapping: &[FieldMapping],
+    tantivy_schema: &TantivySchema,
+    _name_mapping: &NameMapping,
+    config: &SchemaDerivationConfig,
+    string_hash_fields: &HashMap<String, String>,
+    accumulators: &mut HashMap<String, StatisticsAccumulator>,
+    string_indexing_modes: &HashMap<String, StringIndexingMode>,
+    compiled_regexes: &HashMap<String, regex::Regex>,
+) -> Result<TantivyDocument> {
+    let mut doc = TantivyDocument::new();
+
+    for mapping in field_mapping {
+        let array = batch.column(mapping.arrow_col_idx);
+        if array.is_null(row_idx) {
+            continue; // Skip null values — tantivy handles absent fields natively
+        }
+
+        add_arrow_value_to_doc(
+            &mut doc,
+            mapping.tantivy_field,
+            array,
+            array.data_type(),
+            row_idx,
+            &mapping.field_name,
+            config,
+            string_hash_fields,
+            tantivy_schema,
+            accumulators,
+            string_indexing_modes,
+            compiled_regexes,
+        )?;
+    }
+
+    Ok(doc)
+}
+
+/// Finalize ALL partition splits, writing each to output_dir.
+/// For partitioned tables, creates output_dir/partition_key/part-uuid.split for each partition.
+/// For non-partitioned, creates output_dir/part-uuid.split.
+///
+/// Returns a vector of results — one per partition (or one for non-partitioned).
+pub(crate) async fn finish_all_splits(
+    mut ctx: ArrowFfiSplitContext,
+    output_dir: &str,
+    split_config: &SplitConfig,
+) -> Result<Vec<PartitionSplitResult>> {
+    let mut results = Vec::new();
+    let output_base = PathBuf::from(output_dir);
+
+    // Collect all writers to finalize
+    let writers: Vec<(String, HashMap<String, String>, PartitionWriter)> = if let Some(pw) = ctx.default_writer.take() {
+        vec![("".to_string(), HashMap::new(), pw)]
+    } else {
+        ctx.partition_writers.drain()
+            .map(|(key, pw)| {
+                let values = pw.partition_values.clone();
+                (key, values, pw)
+            })
+            .collect()
+    };
+
+    for (partition_key, partition_values, mut pw) in writers {
+        // Commit and finalize the writer
+        pw.writer.commit()
+            .context("Failed to commit index writer")?;
+        pw.writer.wait_merging_threads()
+            .map_err(|e| anyhow::anyhow!("Failed waiting for merge threads: {}", e))?;
+
+        // Construct output path
+        let split_filename = format!("part-{}.split", Uuid::new_v4());
+        let output_path = if partition_key.is_empty() {
+            output_base.join(&split_filename)
+        } else {
+            let partition_dir = output_base.join(&partition_key);
+            std::fs::create_dir_all(&partition_dir)
+                .context("Failed to create partition output directory")?;
+            partition_dir.join(&split_filename)
+        };
+
+        // Get doc count from the index
+        let reader = pw.index.reader()
+            .map_err(|e| anyhow::anyhow!("Failed to create index reader: {}", e))?;
+        reader.reload()
+            .map_err(|e| anyhow::anyhow!("Failed to reload index reader: {}", e))?;
+        let num_docs = reader.searcher().num_docs() as usize;
+
+        // Calculate uncompressed size
+        let index_dir_path = pw.index_dir.path().to_path_buf();
+        let mut total_size = 0u64;
+        if let Ok(entries) = std::fs::read_dir(&index_dir_path) {
+            for entry in entries.flatten() {
+                if let Ok(meta) = entry.metadata() {
+                    if meta.is_file() {
+                        total_size += meta.len();
+                    }
+                }
+            }
+        }
+
+        // Create split metadata
+        let mut metadata = QuickwitSplitMetadata {
+            split_id: Uuid::new_v4().to_string(),
+            index_uid: split_config.index_uid.clone(),
+            source_id: split_config.source_id.clone(),
+            node_id: split_config.node_id.clone(),
+            doc_mapping_uid: split_config.doc_mapping_uid.clone(),
+            partition_id: split_config.partition_id,
+            num_docs,
+            uncompressed_docs_size_in_bytes: total_size,
+            time_range: None,
+            create_timestamp: chrono::Utc::now().timestamp(),
+            maturity: "Mature".to_string(),
+            tags: split_config.tags.clone(),
+            delete_opstamp: 0,
+            num_merge_ops: 0,
+            footer_start_offset: None,
+            footer_end_offset: None,
+            hotcache_start_offset: None,
+            hotcache_length: None,
+            doc_mapping_json: None,
+            skipped_splits: Vec::new(),
+        };
+
+        // Extract doc_mapping from the index for SplitSearcher compatibility
+        if let Ok(doc_mapping_json) = extract_doc_mapping_from_index(&pw.index) {
+            metadata.doc_mapping_json = Some(doc_mapping_json);
+        }
+
+        // Create the Quickwit split file
+        let footer = create_quickwit_split(
+            &pw.index,
+            &index_dir_path,
+            &output_path,
+            &metadata,
+            split_config,
+            None, // No parquet manifest for standard splits
+        ).await?;
+
+        metadata.footer_start_offset = Some(footer.footer_start_offset);
+        metadata.footer_end_offset = Some(footer.footer_end_offset);
+        metadata.hotcache_start_offset = Some(footer.hotcache_start_offset);
+        metadata.hotcache_length = Some(footer.hotcache_length);
+
+        debug_println!(
+            "ARROW_FFI_IMPORT: Finalized partition '{}' with {} docs → {}",
+            partition_key, num_docs, output_path.display()
+        );
+
+        results.push(PartitionSplitResult {
+            partition_key,
+            partition_values,
+            split_path: output_path.to_string_lossy().to_string(),
+            metadata,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Cancel an in-progress split creation, releasing ALL resources across all partitions.
+/// Drops the context — cleans up ALL partition writers' temp dirs and indices.
+pub(crate) fn cancel_split(ctx: ArrowFfiSplitContext) {
+    // Simply dropping the context cleans up:
+    // - All PartitionWriter temp dirs (via TempDir drop)
+    // - All IndexWriter resources
+    // - All Index resources
+    drop(ctx);
+    debug_println!("ARROW_FFI_IMPORT: Cancelled split creation, all resources released");
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int64Array, Float64Array, StringArray, BooleanArray, RecordBatch};
+    use arrow_schema::{Field as ArrowField, Schema as ArrowSchema, DataType};
+    use std::sync::Arc;
+
+    /// Helper: create a simple Arrow schema with id, name, score, active fields.
+    fn test_schema() -> ArrowSchema {
+        ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int64, false),
+            ArrowField::new("name", DataType::Utf8, false),
+            ArrowField::new("score", DataType::Float64, true),
+            ArrowField::new("active", DataType::Boolean, true),
+        ])
+    }
+
+    /// Helper: create a RecordBatch with test data.
+    fn test_batch(num_rows: usize, id_offset: i64) -> RecordBatch {
+        let ids: Vec<i64> = (id_offset..id_offset + num_rows as i64).collect();
+        let names: Vec<String> = (0..num_rows).map(|i| format!("name_{}", i + id_offset as usize)).collect();
+        let scores: Vec<f64> = (0..num_rows).map(|i| (i as f64) * 1.5 + id_offset as f64).collect();
+        let actives: Vec<bool> = (0..num_rows).map(|i| i % 2 == 0).collect();
+
+        RecordBatch::try_new(
+            Arc::new(test_schema()),
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(StringArray::from(names.iter().map(|s| s.as_str()).collect::<Vec<_>>())),
+                Arc::new(Float64Array::from(scores)),
+                Arc::new(BooleanArray::from(actives)),
+            ],
+        ).unwrap()
+    }
+
+    /// Helper: create a partitioned Arrow schema with event_date as partition column.
+    fn partitioned_schema() -> ArrowSchema {
+        ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int64, false),
+            ArrowField::new("name", DataType::Utf8, false),
+            ArrowField::new("event_date", DataType::Utf8, false), // partition column
+        ])
+    }
+
+    /// Helper: create a partitioned batch with event_date values.
+    fn partitioned_batch(ids: Vec<i64>, names: Vec<&str>, dates: Vec<&str>) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(partitioned_schema()),
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(StringArray::from(names)),
+                Arc::new(StringArray::from(dates)),
+            ],
+        ).unwrap()
+    }
+
+    // --- Non-partitioned tests ---
+
+    #[test]
+    fn test_begin_creates_schema() {
+        let schema = test_schema();
+        let ctx = begin_split_from_arrow(schema, &[], 50_000_000).unwrap();
+
+        // Verify tantivy schema has all 4 fields
+        assert!(ctx.tantivy_schema.get_field("id").is_ok());
+        assert!(ctx.tantivy_schema.get_field("name").is_ok());
+        assert!(ctx.tantivy_schema.get_field("score").is_ok());
+        assert!(ctx.tantivy_schema.get_field("active").is_ok());
+
+        // Verify field_mapping has 4 entries (no partition columns)
+        assert_eq!(ctx.field_mapping.len(), 4);
+
+        // Verify STORED flag is set (check via schema introspection)
+        let id_field = ctx.tantivy_schema.get_field("id").unwrap();
+        let id_entry = ctx.tantivy_schema.get_field_entry(id_field);
+        assert!(id_entry.is_stored(), "id field should be stored for standard splits");
+
+        // Verify default writer exists (non-partitioned)
+        assert!(ctx.default_writer.is_some());
+        assert!(ctx.partition_writers.is_empty());
+
+        cancel_split(ctx);
+    }
+
+    #[test]
+    fn test_add_single_batch() {
+        let schema = test_schema();
+        let mut ctx = begin_split_from_arrow(schema, &[], 50_000_000).unwrap();
+
+        let batch = test_batch(10, 0);
+        let count = add_arrow_batch(&mut ctx, &batch).unwrap();
+        assert_eq!(count, 10);
+        assert_eq!(ctx.total_batch_count, 1);
+
+        cancel_split(ctx);
+    }
+
+    #[test]
+    fn test_add_multiple_batches() {
+        let schema = test_schema();
+        let mut ctx = begin_split_from_arrow(schema, &[], 50_000_000).unwrap();
+
+        let batch1 = test_batch(100, 0);
+        let batch2 = test_batch(100, 100);
+        let batch3 = test_batch(100, 200);
+
+        let count1 = add_arrow_batch(&mut ctx, &batch1).unwrap();
+        assert_eq!(count1, 100);
+
+        let count2 = add_arrow_batch(&mut ctx, &batch2).unwrap();
+        assert_eq!(count2, 200);
+
+        let count3 = add_arrow_batch(&mut ctx, &batch3).unwrap();
+        assert_eq!(count3, 300);
+
+        assert_eq!(ctx.total_batch_count, 3);
+
+        cancel_split(ctx);
+    }
+
+    #[test]
+    fn test_finish_creates_valid_split() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let schema = test_schema();
+            let mut ctx = begin_split_from_arrow(schema, &[], 50_000_000).unwrap();
+
+            let batch = test_batch(50, 0);
+            add_arrow_batch(&mut ctx, &batch).unwrap();
+
+            let output_dir = tempfile::tempdir().unwrap();
+            let split_config = default_split_config("test-index", "test-source", "test-node");
+
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+
+            assert_eq!(results.len(), 1);
+            let result = &results[0];
+            assert!(result.partition_key.is_empty());
+            assert_eq!(result.metadata.num_docs, 50);
+            assert!(std::path::Path::new(&result.split_path).exists());
+        });
+    }
+
+    #[test]
+    fn test_cancel_cleans_up() {
+        let schema = test_schema();
+        let mut ctx = begin_split_from_arrow(schema, &[], 50_000_000).unwrap();
+
+        // Record the temp dir path before cancel
+        let temp_path = ctx.default_writer.as_ref().unwrap().index_dir.path().to_path_buf();
+        assert!(temp_path.exists());
+
+        let batch = test_batch(10, 0);
+        add_arrow_batch(&mut ctx, &batch).unwrap();
+
+        cancel_split(ctx);
+
+        // Temp dir should be cleaned up
+        assert!(!temp_path.exists());
+    }
+
+    #[test]
+    fn test_schema_mismatch_rejected() {
+        let schema = test_schema();
+        let mut ctx = begin_split_from_arrow(schema, &[], 50_000_000).unwrap();
+
+        // Create a batch with different number of columns
+        let wrong_schema = ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int64, false),
+            ArrowField::new("name", DataType::Utf8, false),
+        ]);
+        let wrong_batch = RecordBatch::try_new(
+            Arc::new(wrong_schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1])),
+                Arc::new(StringArray::from(vec!["test"])),
+            ],
+        ).unwrap();
+
+        let result = add_arrow_batch(&mut ctx, &wrong_batch);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Schema mismatch"));
+
+        cancel_split(ctx);
+    }
+
+    #[test]
+    fn test_all_field_types() {
+        let schema = test_schema();
+        let mut ctx = begin_split_from_arrow(schema, &[], 50_000_000).unwrap();
+
+        // Create batch with all supported types
+        let batch = RecordBatch::try_new(
+            Arc::new(test_schema()),
+            vec![
+                Arc::new(Int64Array::from(vec![42i64])),
+                Arc::new(StringArray::from(vec!["hello world"])),
+                Arc::new(Float64Array::from(vec![3.14])),
+                Arc::new(BooleanArray::from(vec![true])),
+            ],
+        ).unwrap();
+
+        let count = add_arrow_batch(&mut ctx, &batch).unwrap();
+        assert_eq!(count, 1);
+
+        cancel_split(ctx);
+    }
+
+    // --- Partitioned tests ---
+
+    #[test]
+    fn test_partitioned_single_partition() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let schema = partitioned_schema();
+            let partition_cols = vec!["event_date".to_string()];
+            let mut ctx = begin_split_from_arrow(schema, &partition_cols, 50_000_000).unwrap();
+
+            // All rows have same partition value
+            let batch = partitioned_batch(
+                vec![1, 2, 3],
+                vec!["a", "b", "c"],
+                vec!["2023-01-15", "2023-01-15", "2023-01-15"],
+            );
+
+            add_arrow_batch(&mut ctx, &batch).unwrap();
+
+            let output_dir = tempfile::tempdir().unwrap();
+            let split_config = default_split_config("test-index", "test-source", "test-node");
+
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].partition_key, "event_date=2023-01-15");
+            assert_eq!(results[0].metadata.num_docs, 3);
+            assert_eq!(results[0].partition_values.get("event_date").unwrap(), "2023-01-15");
+        });
+    }
+
+    #[test]
+    fn test_partitioned_multiple_partitions() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let schema = partitioned_schema();
+            let partition_cols = vec!["event_date".to_string()];
+            let mut ctx = begin_split_from_arrow(schema, &partition_cols, 50_000_000).unwrap();
+
+            // 3 distinct partition values
+            let batch = partitioned_batch(
+                vec![1, 2, 3, 4, 5, 6],
+                vec!["a", "b", "c", "d", "e", "f"],
+                vec!["2023-01-15", "2023-01-16", "2023-01-17", "2023-01-15", "2023-01-16", "2023-01-17"],
+            );
+
+            add_arrow_batch(&mut ctx, &batch).unwrap();
+
+            let output_dir = tempfile::tempdir().unwrap();
+            let split_config = default_split_config("test-index", "test-source", "test-node");
+
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+
+            assert_eq!(results.len(), 3);
+
+            // Each partition should have 2 docs
+            for result in &results {
+                assert_eq!(result.metadata.num_docs, 2);
+            }
+        });
+    }
+
+    #[test]
+    fn test_partitioned_across_batches() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let schema = partitioned_schema();
+            let partition_cols = vec!["event_date".to_string()];
+            let mut ctx = begin_split_from_arrow(schema, &partition_cols, 50_000_000).unwrap();
+
+            // Batch 1: partition A rows
+            let batch1 = partitioned_batch(
+                vec![1, 2],
+                vec!["a", "b"],
+                vec!["2023-01-15", "2023-01-15"],
+            );
+            add_arrow_batch(&mut ctx, &batch1).unwrap();
+
+            // Batch 2: partition B rows
+            let batch2 = partitioned_batch(
+                vec![3, 4],
+                vec!["c", "d"],
+                vec!["2023-01-16", "2023-01-16"],
+            );
+            add_arrow_batch(&mut ctx, &batch2).unwrap();
+
+            // Batch 3: more partition A rows
+            let batch3 = partitioned_batch(
+                vec![5],
+                vec!["e"],
+                vec!["2023-01-15"],
+            );
+            add_arrow_batch(&mut ctx, &batch3).unwrap();
+
+            let output_dir = tempfile::tempdir().unwrap();
+            let split_config = default_split_config("test-index", "test-source", "test-node");
+
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+
+            assert_eq!(results.len(), 2);
+
+            let mut doc_counts: HashMap<String, usize> = HashMap::new();
+            for result in &results {
+                doc_counts.insert(result.partition_key.clone(), result.metadata.num_docs);
+            }
+
+            // Partition A (2023-01-15) should have 3 docs (from batches 1 and 3)
+            assert_eq!(doc_counts.get("event_date=2023-01-15"), Some(&3));
+            // Partition B (2023-01-16) should have 2 docs (from batch 2)
+            assert_eq!(doc_counts.get("event_date=2023-01-16"), Some(&2));
+        });
+    }
+
+    #[test]
+    fn test_partition_columns_excluded_from_index() {
+        let schema = partitioned_schema();
+        let partition_cols = vec!["event_date".to_string()];
+        let ctx = begin_split_from_arrow(schema, &partition_cols, 50_000_000).unwrap();
+
+        // event_date should NOT be in the tantivy schema (it's a partition column)
+        assert!(ctx.tantivy_schema.get_field("event_date").is_err());
+
+        // id and name should be in the tantivy schema
+        assert!(ctx.tantivy_schema.get_field("id").is_ok());
+        assert!(ctx.tantivy_schema.get_field("name").is_ok());
+
+        // field_mapping should have 2 entries (excluding event_date)
+        assert_eq!(ctx.field_mapping.len(), 2);
+
+        // partition_col_indices should have 1 entry
+        assert_eq!(ctx.partition_col_indices.len(), 1);
+        assert_eq!(ctx.partition_col_indices[0], 2); // event_date is at index 2
+
+        cancel_split(ctx);
+    }
+
+    #[test]
+    fn test_multi_level_partitioning() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let schema = ArrowSchema::new(vec![
+                ArrowField::new("id", DataType::Int64, false),
+                ArrowField::new("event_date", DataType::Utf8, false),
+                ArrowField::new("region", DataType::Utf8, false),
+            ]);
+            let partition_cols = vec!["event_date".to_string(), "region".to_string()];
+            let mut ctx = begin_split_from_arrow(schema, &partition_cols, 50_000_000).unwrap();
+
+            let batch = RecordBatch::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    ArrowField::new("id", DataType::Int64, false),
+                    ArrowField::new("event_date", DataType::Utf8, false),
+                    ArrowField::new("region", DataType::Utf8, false),
+                ])),
+                vec![
+                    Arc::new(Int64Array::from(vec![1, 2, 3])),
+                    Arc::new(StringArray::from(vec!["2023-01-15", "2023-01-15", "2023-01-16"])),
+                    Arc::new(StringArray::from(vec!["us", "eu", "us"])),
+                ],
+            ).unwrap();
+
+            add_arrow_batch(&mut ctx, &batch).unwrap();
+
+            let output_dir = tempfile::tempdir().unwrap();
+            let split_config = default_split_config("test-index", "test-source", "test-node");
+
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+
+            // 3 distinct partition combinations
+            assert_eq!(results.len(), 3);
+
+            let keys: Vec<&str> = results.iter().map(|r| r.partition_key.as_str()).collect();
+            assert!(keys.contains(&"event_date=2023-01-15/region=us"));
+            assert!(keys.contains(&"event_date=2023-01-15/region=eu"));
+            assert!(keys.contains(&"event_date=2023-01-16/region=us"));
+        });
+    }
+}

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -200,6 +200,7 @@ pub async fn create_split_from_parquet(
         ip_address_fields: parquet_config.schema_config.ip_address_fields.clone(),
         json_fields: parquet_config.schema_config.json_fields.clone(),
         fieldnorms_enabled: parquet_config.schema_config.fieldnorms_enabled,
+        store_fields: false, // Companion mode: parquet is the store
     };
 
     let derived_schema = derive_tantivy_schema_with_mapping(&arrow_schema, &config, Some(&name_mapping))?;
@@ -706,7 +707,7 @@ pub async fn create_split_from_parquet(
 }
 
 /// Convert a single Arrow row into a tantivy Document.
-fn arrow_row_to_tantivy_doc(
+pub(crate) fn arrow_row_to_tantivy_doc(
     batch: &RecordBatch,
     batch_schema: &ArrowSchema,
     row_idx: usize,
@@ -764,7 +765,7 @@ fn arrow_row_to_tantivy_doc(
 /// If the field has a hash counterpart (`string_hash_fields`), also stores the xxHash64
 /// of the string value in the corresponding U64 fast field.
 #[allow(clippy::too_many_arguments)]
-fn add_arrow_value_to_doc(
+pub(crate) fn add_arrow_value_to_doc(
     doc: &mut TantivyDocument,
     field: Field,
     array: &ArrayRef,
@@ -1004,7 +1005,7 @@ fn add_arrow_value_to_doc(
 
 /// Handle string value indexing for all modes (standard, IP, JSON, compact indexing).
 #[allow(clippy::too_many_arguments)]
-fn add_string_value_to_doc(
+pub(crate) fn add_string_value_to_doc(
     doc: &mut TantivyDocument,
     field: Field,
     val: &str,
@@ -1129,7 +1130,7 @@ fn add_json_string_value(
 }
 
 /// Convert a complex Arrow type (List, Map, Struct) at a given row to a JSON value.
-fn convert_complex_to_json(array: &ArrayRef, row_idx: usize) -> Result<serde_json::Value> {
+pub(crate) fn convert_complex_to_json(array: &ArrayRef, row_idx: usize) -> Result<serde_json::Value> {
     use arrow_array::*;
     use arrow_schema::DataType;
 

--- a/native/src/parquet_companion/mod.rs
+++ b/native/src/parquet_companion/mod.rs
@@ -22,6 +22,7 @@ pub mod coalescing;
 pub mod field_extraction;
 pub mod arrow_to_tant;
 pub mod arrow_ffi_export;
+pub mod arrow_ffi_import;
 pub mod hash_field_rewriter;
 pub mod hash_touchup;
 pub mod string_indexing;

--- a/native/src/quickwit_split/mod.rs
+++ b/native/src/quickwit_split/mod.rs
@@ -89,19 +89,19 @@ use split_utils::create_quickwit_tokenizer_manager;
 /// Configuration for split conversion passed from Java
 #[derive(Debug, Clone)]
 pub(crate) struct SplitConfig {
-    index_uid: String,
-    source_id: String,
-    node_id: String,
-    doc_mapping_uid: String,
-    partition_id: u64,
-    time_range_start: Option<DateTime<Utc>>,
-    time_range_end: Option<DateTime<Utc>>,
-    tags: BTreeSet<String>,
-    metadata: HashMap<String, String>,
+    pub(crate) index_uid: String,
+    pub(crate) source_id: String,
+    pub(crate) node_id: String,
+    pub(crate) doc_mapping_uid: String,
+    pub(crate) partition_id: u64,
+    pub(crate) time_range_start: Option<DateTime<Utc>>,
+    pub(crate) time_range_end: Option<DateTime<Utc>>,
+    pub(crate) tags: BTreeSet<String>,
+    pub(crate) metadata: HashMap<String, String>,
     // New streaming configuration fields
-    streaming_chunk_size: u64,        // 64MB default for optimal I/O
-    enable_progress_tracking: bool,   // Enable detailed progress logging
-    enable_streaming_io: bool,        // Use streaming I/O instead of read_all()
+    pub(crate) streaming_chunk_size: u64,        // 64MB default for optimal I/O
+    pub(crate) enable_progress_tracking: bool,   // Enable detailed progress logging
+    pub(crate) enable_streaming_io: bool,        // Use streaming I/O instead of read_all()
 }
 
 /// Split metadata structure compatible with Quickwit format
@@ -213,7 +213,7 @@ pub(crate) fn default_split_config(index_uid: &str, source_id: &str, node_id: &s
     }
 }
 
-fn create_split_metadata(config: &SplitConfig, num_docs: usize, uncompressed_docs_size: u64) -> QuickwitSplitMetadata {
+pub(crate) fn create_split_metadata(config: &SplitConfig, num_docs: usize, uncompressed_docs_size: u64) -> QuickwitSplitMetadata {
     let split_id = Uuid::new_v4().to_string();
     let current_timestamp = Utc::now().timestamp();
     

--- a/src/test/java/io/indextables/tantivy4java/ArrowFfiImportTest.java
+++ b/src/test/java/io/indextables/tantivy4java/ArrowFfiImportTest.java
@@ -1,0 +1,531 @@
+package io.indextables.tantivy4java;
+
+import io.indextables.tantivy4java.core.*;
+import io.indextables.tantivy4java.result.SearchResult;
+import io.indextables.tantivy4java.split.*;
+import io.indextables.tantivy4java.split.merge.*;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Arrow FFI import path — creating Quickwit splits from
+ * Arrow columnar batches via the Arrow C Data Interface.
+ *
+ * Tests the begin/addBatch/finish/cancel lifecycle exposed through:
+ *   QuickwitSplit.beginSplitFromArrow()
+ *   QuickwitSplit.addArrowBatch()
+ *   QuickwitSplit.finishAllSplits()
+ *   QuickwitSplit.cancelSplit()
+ *
+ * Uses Rust-side test helpers (nativeTestExport*Ffi) to create valid FFI structs
+ * with proper release callbacks, since tantivy4java has zero Arrow Java dependencies.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ArrowFfiImportTest {
+
+    private static SplitCacheManager cacheManager;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void setUp() {
+        SplitCacheManager.CacheConfig config = new SplitCacheManager.CacheConfig("arrow-ffi-import-test")
+                .withMaxCacheSize(100_000_000);
+        cacheManager = SplitCacheManager.getInstance(config);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (cacheManager != null) {
+            try {
+                cacheManager.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    // ====================================================================
+    // Non-partitioned tests
+    // ====================================================================
+
+    @Test
+    @Order(1)
+    void testNonPartitionedSingleBatch() throws Exception {
+        // Schema: id:Int64, name:Utf8, score:Float64, active:Boolean
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "score", "active"},
+                new String[]{"int64", "utf8", "float64", "boolean"});
+        assertTrue(schemaAddr != 0, "Schema FFI export should return non-zero address");
+
+        // Begin split (non-partitioned)
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, new String[]{},
+                Index.Memory.DEFAULT_HEAP_SIZE);
+        assertTrue(handle != 0, "beginSplitFromArrow should return non-zero handle");
+
+        // Add a batch of 10 rows
+        long[] batchAddrs = QuickwitSplit.nativeTestExportStandardBatchFfi(10, 0);
+        assertNotNull(batchAddrs);
+        assertEquals(2, batchAddrs.length);
+
+        long docCount = QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+        assertEquals(10, docCount, "Should have 10 docs after first batch");
+
+        // Finish
+        String outputDir = tempDir.resolve("single_batch").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        // Verify results
+        assertNotNull(results);
+        assertEquals(1, results.size(), "Non-partitioned should produce exactly 1 split");
+
+        QuickwitSplit.PartitionSplitResult result = results.get(0);
+        assertEquals("", result.getPartitionKey(), "Non-partitioned should have empty partition key");
+        assertEquals(10, result.getNumDocs(), "Split should contain 10 docs");
+        assertTrue(result.getSplitPath().endsWith(".split"), "Split path should end with .split");
+        assertTrue(Files.exists(Path.of(result.getSplitPath())), "Split file should exist");
+        assertNotNull(result.getSplitId(), "Split ID should not be null");
+        assertTrue(result.getFooterStartOffset() > 0, "Footer start offset should be positive");
+        assertTrue(result.getFooterEndOffset() > result.getFooterStartOffset(),
+                "Footer end offset should be after start offset");
+
+        System.out.println("testNonPartitionedSingleBatch PASSED: " + result);
+    }
+
+    @Test
+    @Order(2)
+    void testNonPartitionedMultipleBatches() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "score", "active"},
+                new String[]{"int64", "utf8", "float64", "boolean"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, new String[]{},
+                Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // Add 3 batches of 100 rows each
+        for (int i = 0; i < 3; i++) {
+            long[] batchAddrs = QuickwitSplit.nativeTestExportStandardBatchFfi(100, i * 100);
+            long docCount = QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+            assertEquals((i + 1) * 100, docCount,
+                    "Cumulative doc count should be " + ((i + 1) * 100) + " after batch " + (i + 1));
+        }
+
+        String outputDir = tempDir.resolve("multi_batch").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(1, results.size());
+        assertEquals(300, results.get(0).getNumDocs(), "Split should contain 300 docs total");
+
+        System.out.println("testNonPartitionedMultipleBatches PASSED: 300 docs in 1 split");
+    }
+
+    @Test
+    @Order(3)
+    void testNonPartitionedSplitSearchable() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "score", "active"},
+                new String[]{"int64", "utf8", "float64", "boolean"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, new String[]{},
+                Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // Add 50 rows
+        long[] batchAddrs = QuickwitSplit.nativeTestExportStandardBatchFfi(50, 0);
+        QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+
+        String outputDir = tempDir.resolve("searchable").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(1, results.size());
+        QuickwitSplit.PartitionSplitResult result = results.get(0);
+
+        // Open the split with SplitSearcher and verify searchability
+        QuickwitSplit.SplitMetadata metadata = new QuickwitSplit.SplitMetadata(
+                result.getFooterStartOffset(), result.getFooterEndOffset(), 0, 0);
+
+        String splitUri = "file://" + result.getSplitPath();
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUri, metadata)) {
+            // Verify schema
+            Schema schema = searcher.getSchema();
+            assertNotNull(schema);
+            assertTrue(schema.getFieldNames().contains("id"), "Schema should have 'id' field");
+            assertTrue(schema.getFieldNames().contains("name"), "Schema should have 'name' field");
+            assertTrue(schema.getFieldNames().contains("score"), "Schema should have 'score' field");
+
+            // Search for all documents
+            SplitQuery allQuery = searcher.parseQuery("*");
+            SearchResult allResults = searcher.search(allQuery, 100);
+            assertEquals(50, allResults.getHits().size(), "Should find all 50 documents");
+
+            // Search for specific document by name
+            SplitQuery nameQuery = new SplitTermQuery("name", "name_0");
+            SearchResult nameResults = searcher.search(nameQuery, 10);
+            assertTrue(nameResults.getHits().size() > 0,
+                    "Should find document with name 'name_0'");
+
+            // Verify document retrieval
+            for (SearchResult.Hit hit : nameResults.getHits()) {
+                try (Document doc = searcher.doc(hit.getDocAddress())) {
+                    assertNotNull(doc, "Document should not be null");
+                    // Verify stored fields are accessible
+                    Object nameVal = doc.getFirst("name");
+                    assertNotNull(nameVal, "name field should be stored and retrievable");
+                }
+            }
+        }
+
+        System.out.println("testNonPartitionedSplitSearchable PASSED: split searchable with SplitSearcher");
+    }
+
+    @Test
+    @Order(4)
+    void testCancelCleansUp() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "score", "active"},
+                new String[]{"int64", "utf8", "float64", "boolean"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, new String[]{},
+                Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // Add some data
+        long[] batchAddrs = QuickwitSplit.nativeTestExportStandardBatchFfi(10, 0);
+        QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+
+        // Cancel — should not throw
+        assertDoesNotThrow(() -> QuickwitSplit.cancelSplit(handle),
+                "cancelSplit should not throw");
+
+        System.out.println("testCancelCleansUp PASSED");
+    }
+
+    @Test
+    @Order(5)
+    void testEmptyBatch() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "score", "active"},
+                new String[]{"int64", "utf8", "float64", "boolean"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, new String[]{},
+                Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // Add a batch of 0 rows
+        long[] batchAddrs = QuickwitSplit.nativeTestExportStandardBatchFfi(0, 0);
+        long docCount = QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+        assertEquals(0, docCount, "Empty batch should have 0 docs");
+
+        // Finish with 0 docs — should still create a valid split
+        String outputDir = tempDir.resolve("empty_batch").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(1, results.size());
+        assertEquals(0, results.get(0).getNumDocs(), "Empty split should have 0 docs");
+
+        System.out.println("testEmptyBatch PASSED: empty split created successfully");
+    }
+
+    // ====================================================================
+    // Partitioned tests
+    // ====================================================================
+
+    @Test
+    @Order(10)
+    void testPartitionedSinglePartition() throws Exception {
+        // Schema: id:Int64, name:Utf8, event_date:Utf8 (partition column)
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "event_date"},
+                new String[]{"int64", "utf8", "utf8"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr,
+                new String[]{"event_date"}, Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // All rows have the same partition value
+        long[] batchAddrs = QuickwitSplit.nativeTestExportPartitionBatchFfi(
+                new long[]{1, 2, 3},
+                new String[]{"alice", "bob", "charlie"},
+                "event_date",
+                new String[]{"2023-01-15", "2023-01-15", "2023-01-15"});
+        QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+
+        String outputDir = tempDir.resolve("single_partition").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(1, results.size(), "Single partition value should produce 1 split");
+
+        QuickwitSplit.PartitionSplitResult result = results.get(0);
+        assertEquals("event_date=2023-01-15", result.getPartitionKey());
+        assertEquals(3, result.getNumDocs());
+        assertEquals("2023-01-15", result.getPartitionValues().get("event_date"));
+        assertTrue(Files.exists(Path.of(result.getSplitPath())));
+
+        System.out.println("testPartitionedSinglePartition PASSED: " + result);
+    }
+
+    @Test
+    @Order(11)
+    void testPartitionedMultiplePartitions() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "event_date"},
+                new String[]{"int64", "utf8", "utf8"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr,
+                new String[]{"event_date"}, Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // 6 rows with 3 distinct partition values (2 rows each)
+        long[] batchAddrs = QuickwitSplit.nativeTestExportPartitionBatchFfi(
+                new long[]{1, 2, 3, 4, 5, 6},
+                new String[]{"a", "b", "c", "d", "e", "f"},
+                "event_date",
+                new String[]{"2023-01-15", "2023-01-16", "2023-01-17",
+                             "2023-01-15", "2023-01-16", "2023-01-17"});
+        QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+
+        String outputDir = tempDir.resolve("multi_partition").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(3, results.size(), "3 distinct partition values should produce 3 splits");
+
+        // Verify each partition has 2 docs
+        Map<String, Long> docCounts = new HashMap<>();
+        for (QuickwitSplit.PartitionSplitResult r : results) {
+            docCounts.put(r.getPartitionKey(), r.getNumDocs());
+            assertTrue(Files.exists(Path.of(r.getSplitPath())),
+                    "Split file should exist for partition: " + r.getPartitionKey());
+        }
+        assertEquals(2, docCounts.get("event_date=2023-01-15"));
+        assertEquals(2, docCounts.get("event_date=2023-01-16"));
+        assertEquals(2, docCounts.get("event_date=2023-01-17"));
+
+        System.out.println("testPartitionedMultiplePartitions PASSED: 3 partitions, 2 docs each");
+    }
+
+    @Test
+    @Order(12)
+    void testPartitionedAcrossBatches() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "event_date"},
+                new String[]{"int64", "utf8", "utf8"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr,
+                new String[]{"event_date"}, Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // Batch 1: partition A rows
+        long[] batch1 = QuickwitSplit.nativeTestExportPartitionBatchFfi(
+                new long[]{1, 2},
+                new String[]{"a", "b"},
+                "event_date",
+                new String[]{"2023-01-15", "2023-01-15"});
+        QuickwitSplit.addArrowBatch(handle, batch1[0], batch1[1]);
+
+        // Batch 2: partition B rows
+        long[] batch2 = QuickwitSplit.nativeTestExportPartitionBatchFfi(
+                new long[]{3, 4},
+                new String[]{"c", "d"},
+                "event_date",
+                new String[]{"2023-01-16", "2023-01-16"});
+        QuickwitSplit.addArrowBatch(handle, batch2[0], batch2[1]);
+
+        // Batch 3: more partition A rows
+        long[] batch3 = QuickwitSplit.nativeTestExportPartitionBatchFfi(
+                new long[]{5},
+                new String[]{"e"},
+                "event_date",
+                new String[]{"2023-01-15"});
+        QuickwitSplit.addArrowBatch(handle, batch3[0], batch3[1]);
+
+        String outputDir = tempDir.resolve("across_batches").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(2, results.size(), "Should produce 2 partitions");
+
+        Map<String, Long> docCounts = new HashMap<>();
+        for (QuickwitSplit.PartitionSplitResult r : results) {
+            docCounts.put(r.getPartitionKey(), r.getNumDocs());
+        }
+        // Partition A (2023-01-15): 2 from batch 1 + 1 from batch 3 = 3
+        assertEquals(3, docCounts.get("event_date=2023-01-15"),
+                "Partition A should accumulate docs across batches 1 and 3");
+        // Partition B (2023-01-16): 2 from batch 2
+        assertEquals(2, docCounts.get("event_date=2023-01-16"));
+
+        System.out.println("testPartitionedAcrossBatches PASSED: partition A accumulated across batches");
+    }
+
+    @Test
+    @Order(13)
+    void testPartitionedSplitSearchable() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "event_date"},
+                new String[]{"int64", "utf8", "utf8"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr,
+                new String[]{"event_date"}, Index.Memory.DEFAULT_HEAP_SIZE);
+
+        long[] batchAddrs = QuickwitSplit.nativeTestExportPartitionBatchFfi(
+                new long[]{100, 200, 300},
+                new String[]{"alice", "bob", "charlie"},
+                "event_date",
+                new String[]{"2023-01-15", "2023-01-16", "2023-01-15"});
+        QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+
+        String outputDir = tempDir.resolve("partition_searchable").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(2, results.size());
+
+        // Find the partition with 2 docs (2023-01-15)
+        QuickwitSplit.PartitionSplitResult partition15 = results.stream()
+                .filter(r -> r.getPartitionKey().equals("event_date=2023-01-15"))
+                .findFirst().orElseThrow();
+
+        assertEquals(2, partition15.getNumDocs());
+
+        // Open partition's split with SplitSearcher
+        QuickwitSplit.SplitMetadata metadata = new QuickwitSplit.SplitMetadata(
+                partition15.getFooterStartOffset(), partition15.getFooterEndOffset(), 0, 0);
+        String splitUri = "file://" + partition15.getSplitPath();
+
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(splitUri, metadata)) {
+            // Verify partition column is NOT in the index
+            Schema schema = searcher.getSchema();
+            assertFalse(schema.getFieldNames().contains("event_date"),
+                    "Partition column 'event_date' should NOT be in the tantivy index");
+            assertTrue(schema.getFieldNames().contains("id"), "Data column 'id' should be in index");
+            assertTrue(schema.getFieldNames().contains("name"), "Data column 'name' should be in index");
+
+            // Search all docs in this partition
+            SplitQuery allQuery = searcher.parseQuery("*");
+            SearchResult allResults = searcher.search(allQuery, 10);
+            assertEquals(2, allResults.getHits().size(),
+                    "Partition 2023-01-15 should have exactly 2 docs");
+
+            // Search for specific name
+            SplitQuery nameQuery = new SplitTermQuery("name", "alice");
+            SearchResult nameResults = searcher.search(nameQuery, 10);
+            assertTrue(nameResults.getHits().size() > 0,
+                    "Should find 'alice' in partition 2023-01-15");
+        }
+
+        System.out.println("testPartitionedSplitSearchable PASSED");
+    }
+
+    @Test
+    @Order(14)
+    void testPartitionedCancel() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "event_date"},
+                new String[]{"int64", "utf8", "utf8"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr,
+                new String[]{"event_date"}, Index.Memory.DEFAULT_HEAP_SIZE);
+
+        long[] batchAddrs = QuickwitSplit.nativeTestExportPartitionBatchFfi(
+                new long[]{1, 2, 3},
+                new String[]{"a", "b", "c"},
+                "event_date",
+                new String[]{"2023-01-15", "2023-01-16", "2023-01-17"});
+        QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+
+        // Cancel should not throw even with active partition writers
+        assertDoesNotThrow(() -> QuickwitSplit.cancelSplit(handle),
+                "cancelSplit should not throw with active partitions");
+
+        System.out.println("testPartitionedCancel PASSED");
+    }
+
+    // ====================================================================
+    // Metadata and lifecycle tests
+    // ====================================================================
+
+    @Test
+    @Order(20)
+    void testPartitionSplitResultMetadata() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "score", "active"},
+                new String[]{"int64", "utf8", "float64", "boolean"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, new String[]{},
+                Index.Memory.DEFAULT_HEAP_SIZE);
+
+        long[] batchAddrs = QuickwitSplit.nativeTestExportStandardBatchFfi(25, 0);
+        QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+
+        String outputDir = tempDir.resolve("metadata_test").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(1, results.size());
+        QuickwitSplit.PartitionSplitResult result = results.get(0);
+
+        // Verify all metadata fields
+        assertNotNull(result.getSplitId(), "splitId should not be null");
+        assertFalse(result.getSplitId().isEmpty(), "splitId should not be empty");
+        assertEquals(25, result.getNumDocs());
+        assertTrue(result.getFooterStartOffset() > 0);
+        assertTrue(result.getFooterEndOffset() > result.getFooterStartOffset());
+        assertEquals("", result.getPartitionKey(), "Non-partitioned partition key should be empty");
+        assertTrue(result.getPartitionValues().isEmpty(), "Non-partitioned should have empty partition values");
+
+        // Verify split file size is reasonable
+        long fileSize = Files.size(Path.of(result.getSplitPath()));
+        assertTrue(fileSize > 0, "Split file should have non-zero size");
+        assertTrue(fileSize >= result.getFooterEndOffset(),
+                "File size should be at least as large as footer end offset");
+
+        System.out.println("testPartitionSplitResultMetadata PASSED: splitId=" + result.getSplitId() +
+                ", fileSize=" + fileSize);
+    }
+
+    @Test
+    @Order(21)
+    void testLargerBatch() throws Exception {
+        long schemaAddr = QuickwitSplit.nativeTestExportSchemaFfi(
+                new String[]{"id", "name", "score", "active"},
+                new String[]{"int64", "utf8", "float64", "boolean"});
+
+        long handle = QuickwitSplit.beginSplitFromArrow(schemaAddr, new String[]{},
+                Index.Memory.DEFAULT_HEAP_SIZE);
+
+        // Add 1000 rows in 10 batches of 100
+        for (int i = 0; i < 10; i++) {
+            long[] batchAddrs = QuickwitSplit.nativeTestExportStandardBatchFfi(100, i * 100);
+            long docCount = QuickwitSplit.addArrowBatch(handle, batchAddrs[0], batchAddrs[1]);
+            assertEquals((i + 1) * 100, docCount);
+        }
+
+        String outputDir = tempDir.resolve("larger_batch").toString();
+        Files.createDirectories(Path.of(outputDir));
+        List<QuickwitSplit.PartitionSplitResult> results = QuickwitSplit.finishAllSplits(handle, outputDir);
+
+        assertEquals(1, results.size());
+        assertEquals(1000, results.get(0).getNumDocs(), "Should have 1000 docs");
+
+        // Verify searchable
+        QuickwitSplit.PartitionSplitResult result = results.get(0);
+        QuickwitSplit.SplitMetadata metadata = new QuickwitSplit.SplitMetadata(
+                result.getFooterStartOffset(), result.getFooterEndOffset(), 0, 0);
+        try (SplitSearcher searcher = cacheManager.createSplitSearcher(
+                "file://" + result.getSplitPath(), metadata)) {
+            SplitQuery allQuery = searcher.parseQuery("*");
+            SearchResult allResults = searcher.search(allQuery, 1001);
+            assertEquals(1000, allResults.getHits().size(), "Should find all 1000 docs");
+        }
+
+        System.out.println("testLargerBatch PASSED: 1000 docs across 10 batches");
+    }
+}


### PR DESCRIPTION
# Arrow FFI Import: Create Quickwit Splits from Arrow Columnar Batches

## Summary

Adds a streaming Arrow FFI import path that creates standard Quickwit splits directly from Arrow columnar batches received via the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html). This is the write-path counterpart to the FFI export added in PR #98.

The new API enables Spark to stream `ColumnarBatch` data into Quickwit split creation with zero serialization, bypassing both the row-at-a-time JNI overhead of `TantivySearchEngine.addDocument()` and the parquet round-trip of `create_split_from_parquet()`.

**New write pipeline:**
```
Spark ColumnarBatch → ArrowFfiBridge.exportBatch() → FFI addresses
  → QuickwitSplit.addArrowBatch() → Rust per-partition IndexWriters
  → QuickwitSplit.finishAllSplits() → .split files (one per partition)
```

Supports multi-partition writes: full batches cross the FFI boundary with partition columns included. Rust extracts partition values per-row, groups them, and routes to per-partition IndexWriters internally. This eliminates the need for Java-side partition routing.

## Changes

### New Rust Module

| File | Lines | Description |
|------|-------|-------------|
| `arrow_ffi_import.rs` | 932 | Streaming 3-phase split creation from Arrow FFI batches. `ArrowFfiSplitContext` manages per-partition `PartitionWriter` instances (lazy creation). Uses Comet's `std::ptr::replace` pattern for safe FFI ownership transfer with `align_buffers()` for Java-allocated memory. Includes 12 Rust unit tests (7 non-partitioned + 5 partitioned). |

### Modified Rust Files

| File | Description |
|------|-------------|
| `indexing.rs` | Made 4 functions `pub(crate)` for reuse by FFI import: `arrow_row_to_tantivy_doc`, `add_arrow_value_to_doc`, `add_string_value_to_doc`, `convert_complex_to_json` |
| `schema_derivation.rs` | Added `store_fields: bool` to `SchemaDerivationConfig` — standard splits set STORED on all fields (unlike companion mode where parquet is the store) |
| `jni_functions.rs` | Added 4 FFI import JNI entry points (`nativeBeginSplitFromArrow`, `nativeAddArrowBatch`, `nativeFinishAllSplits`, `nativeCancelSplit`) + 3 test helper entry points for creating valid FFI structs from Rust |
| `mod.rs` (quickwit_split) | Made `SplitConfig` fields and `create_split_metadata` `pub(crate)` for FFI import module |
| `mod.rs` (parquet_companion) | Registered `arrow_ffi_import` module |

### Java API

| File | Description |
|------|-------------|
| `QuickwitSplit.java` | Added streaming FFI import API: `beginSplitFromArrow()`, `addArrowBatch()`, `finishAllSplits()`, `cancelSplit()`, `PartitionSplitResult` class, and 3 test helper native methods |

### New Tests

| File | Lines | Description |
|------|-------|-------------|
| `ArrowFfiImportTest.java` | 331 | 12 Java integration tests covering: non-partitioned end-to-end (single batch, multiple batches, SplitSearcher verification, cancel/cleanup, empty batch), partitioned writes (single partition, multiple partitions, accumulation across batches, partition split searchable, partition cancel), metadata validation, and a 1000-doc stress test |

### Documentation

| File | Description |
|------|-------------|
| `docs/INDEXTABLES_SPARK_ARROW_FFI_WRITE_DEVELOPER_GUIDE.md` | 12-section developer guide for the indextables_spark team covering: architecture overview, Arrow FFI write integration, partition handling, split rolling, schema conversion, `DataWriter[ColumnarBatch]` migration, cloud upload pattern, statistics/metadata, configuration mapping, error handling, merge-on-write compatibility, and testing strategy |

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| Comet `std::ptr::replace` for FFI import | Atomically takes ownership of FFI structs, prevents double-free, writes empty sentinel. Proven pattern from Apache DataFusion Comet. |
| `ArrayData::align_buffers()` on import | Java-allocated Arrow buffers may not be 64-byte aligned; required for safe Rust access |
| Partition routing in Rust | Full batches cross FFI boundary; Rust extracts partition values per-row and routes to per-partition IndexWriters. Avoids expensive column-level batch splitting in Java. Aligns with Spark's `DataWriter[ColumnarBatch]` which delivers whole batches. |
| Lazy `PartitionWriter` creation | New partition values create new writers on demand (temp dir + Index + IndexWriter per partition). Handles arbitrary partition fan-out without upfront knowledge of partition values. |
| STORED flag on all fields | Standard splits store docs in tantivy's doc store, unlike companion mode where parquet is the store. Controlled by new `store_fields` config flag in schema derivation. |
| Single-threaded `IndexWriter` per partition | `index.writer_with_num_threads(1, heap)` ensures deterministic doc ordering matching batch insertion order |
| `Arc<Mutex<>>` for JNI context | `IndexWriter` is `!Sync`; Mutex required for safe access; Arc for registry storage via `arc_to_jlong()` |
| Reuse existing conversion functions | `arrow_row_to_tantivy_doc` and friends from `indexing.rs` handle all Arrow-to-tantivy type conversions. Just needed visibility change to `pub(crate)`. |
| `finishAllSplits` returns `Vec<PartitionSplitResult>` | Java needs per-partition metadata for `AddAction` construction and cloud upload. Returning a list gives Java full control over output path construction and upload strategy. |

## API

```java
// 1. Begin split creation with Arrow schema (FFI address from Spark's ArrowFfiBridge)
long handle = QuickwitSplit.beginSplitFromArrow(
    schemaAddr,          // FFI_ArrowSchema address (full schema including partition cols)
    partitionColumns,    // e.g. new String[]{"event_date", "region"} or empty array
    heapSize);           // e.g. Index.Memory.DEFAULT_HEAP_SIZE

// 2. Stream batches (one per Spark ColumnarBatch)
for (ColumnarBatch batch : batches) {
    long[] addrs = ArrowFfiBridge.exportBatch(batch);  // [arrayAddr, schemaAddr]
    long docCount = QuickwitSplit.addArrowBatch(handle, addrs[0], addrs[1]);
    // docCount is cumulative across all partitions
}

// 3. Finalize — creates one .split file per partition
List<PartitionSplitResult> results =
    QuickwitSplit.finishAllSplits(handle, outputDir);

// 4. Each result has: partitionKey, partitionValues, splitPath, splitId,
//    numDocs, footerStartOffset, footerEndOffset
for (PartitionSplitResult r : results) {
    // r.getPartitionKey()    → "event_date=2023-01-15/region=us"
    // r.getPartitionValues() → {event_date=2023-01-15, region=us}
    // r.getSplitPath()       → /tmp/output/event_date=2023-01-15/region=us/part-uuid.split
    uploadToCloud(r.getSplitPath(), targetPath);
}

// Or cancel to release all resources on error:
QuickwitSplit.cancelSplit(handle);
```

## Test Results

```
Rust unit tests (arrow_ffi_import):          12/12 passed
Rust parquet companion suite (full):        304/304 passed (zero regressions)
Java integration tests (ArrowFfiImportTest):  12/12 passed
```

### Java Integration Test Coverage

| Test | Description |
|------|-------------|
| `testNonPartitionedSingleBatch` | 10 docs → 1 split, verify metadata |
| `testNonPartitionedMultipleBatches` | 3 batches × 100 rows → 300 docs in 1 split |
| `testNonPartitionedSplitSearchable` | 50 docs → open with SplitSearcher → `parseQuery("*")` finds all, term query works, stored fields retrievable |
| `testCancelCleansUp` | begin → add → cancel lifecycle |
| `testEmptyBatch` | 0 rows handled correctly |
| `testPartitionedSinglePartition` | 3 rows same partition → 1 split with correct partition key/values |
| `testPartitionedMultiplePartitions` | 6 rows / 3 dates → 3 splits (2 docs each) |
| `testPartitionedAcrossBatches` | Partition A in batches 1+3, B in batch 2 → accumulation verified (3+2 docs) |
| `testPartitionedSplitSearchable` | Partition split opened with SplitSearcher, partition column excluded from index, data columns searchable |
| `testPartitionedCancel` | Cancel with active partition writers |
| `testPartitionSplitResultMetadata` | Verify splitId, footer offsets, file size consistency |
| `testLargerBatch` | 10 batches × 100 rows → 1000 docs, all searchable via SplitSearcher |
