### PR TITLE
 feature: Add configurable write queue backpressure and drop-when-full to L2 disk cache

### DIFF
--- a/native/src/disk_cache/tests.rs
+++ b/native/src/disk_cache/tests.rs
@@ -415,4 +415,228 @@ mod tests {
 
         assert_eq!(cache.get_split_count(), 3);
     }
+
+    // --- Write Queue Mode Tests ---
+
+    #[test]
+    fn test_fragment_mode_custom_capacity() {
+        use crate::disk_cache::types::WriteQueueMode;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = DiskCacheConfig {
+            root_path: temp_dir.path().to_path_buf(),
+            write_queue_mode: WriteQueueMode::Fragment { capacity: 4 },
+            ..Default::default()
+        };
+        let cache = L2DiskCache::new(config).unwrap();
+
+        let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+
+        // Write several items — with capacity=4, this tests that the bounded
+        // channel works and items eventually drain
+        for i in 0..8 {
+            cache.put("s3://bucket", &format!("split-frag-{}", i), "term", None, &data);
+        }
+        std::thread::sleep(Duration::from_millis(300));
+
+        // All writes should complete
+        for i in 0..8 {
+            let retrieved = cache.get("s3://bucket", &format!("split-frag-{}", i), "term", None);
+            assert!(retrieved.is_some(), "split-frag-{} should be cached", i);
+            assert_eq!(retrieved.unwrap().as_slice(), data.as_slice());
+        }
+        assert_eq!(cache.get_split_count(), 8);
+    }
+
+    #[test]
+    fn test_size_based_mode_put_get() {
+        use crate::disk_cache::types::WriteQueueMode;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = DiskCacheConfig {
+            root_path: temp_dir.path().to_path_buf(),
+            write_queue_mode: WriteQueueMode::SizeBased { max_bytes: 500_000 },
+            ..Default::default()
+        };
+        let cache = L2DiskCache::new(config).unwrap();
+
+        let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+
+        cache.put("s3://bucket", "split-sb-001", "term", None, &data);
+        std::thread::sleep(Duration::from_millis(100));
+
+        let retrieved = cache.get("s3://bucket", "split-sb-001", "term", None);
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().as_slice(), data.as_slice());
+    }
+
+    #[test]
+    fn test_size_based_mode_backpressure() {
+        use crate::disk_cache::types::WriteQueueMode;
+        use std::sync::Arc;
+        use std::thread;
+
+        let temp_dir = TempDir::new().unwrap();
+        // Set max_bytes very low (50KB) so backpressure triggers quickly
+        let config = DiskCacheConfig {
+            root_path: temp_dir.path().to_path_buf(),
+            write_queue_mode: WriteQueueMode::SizeBased { max_bytes: 50_000 },
+            ..Default::default()
+        };
+        let cache = Arc::new(L2DiskCache::new(config).unwrap());
+
+        let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+
+        // Blast many writes — total data (10 * 10KB = 100KB) exceeds 50KB limit
+        // so backpressure should throttle senders
+        let cache_clone = Arc::clone(&cache);
+        let data_clone = data.clone();
+        let writer = thread::spawn(move || {
+            for i in 0..10 {
+                cache_clone.put("s3://bucket", &format!("split-bp-{}", i), "term", None, &data_clone);
+            }
+        });
+
+        writer.join().unwrap();
+        std::thread::sleep(Duration::from_millis(500));
+
+        // All writes should eventually complete
+        for i in 0..10 {
+            let retrieved = cache.get("s3://bucket", &format!("split-bp-{}", i), "term", None);
+            assert!(retrieved.is_some(), "split-bp-{} should be cached", i);
+            assert_eq!(retrieved.unwrap().as_slice(), data.as_slice());
+        }
+    }
+
+    #[test]
+    fn test_size_based_mode_evict_and_flush() {
+        use crate::disk_cache::types::WriteQueueMode;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = DiskCacheConfig {
+            root_path: temp_dir.path().to_path_buf(),
+            write_queue_mode: WriteQueueMode::SizeBased { max_bytes: 1_000_000 },
+            ..Default::default()
+        };
+        let cache = L2DiskCache::new(config).unwrap();
+
+        let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+
+        cache.put("s3://bucket", "split-sbf-001", "term", None, &data);
+        cache.put("s3://bucket", "split-sbf-001", "idx", None, &data);
+        std::thread::sleep(Duration::from_millis(100));
+
+        assert_eq!(cache.get_split_count(), 1);
+        assert_eq!(cache.get_component_count(), 2);
+
+        // Evict via size-based sender
+        cache.evict_split("s3://bucket", "split-sbf-001");
+        std::thread::sleep(Duration::from_millis(100));
+
+        assert_eq!(cache.get_split_count(), 0);
+        assert!(cache.get("s3://bucket", "split-sbf-001", "term", None).is_none());
+
+        // Flush via size-based sender
+        cache.put("s3://bucket", "split-sbf-002", "term", None, &data);
+        cache.flush_blocking();
+        assert!(cache.get("s3://bucket", "split-sbf-002", "term", None).is_some());
+    }
+
+    #[test]
+    fn test_write_queue_mode_default() {
+        use crate::disk_cache::types::WriteQueueMode;
+
+        // Verify default is Fragment { capacity: 16 }
+        let mode = WriteQueueMode::default();
+        match mode {
+            WriteQueueMode::Fragment { capacity } => assert_eq!(capacity, 16),
+            _ => panic!("Default should be Fragment"),
+        }
+
+        // Verify DiskCacheConfig default includes it
+        let config = DiskCacheConfig::default();
+        match config.write_queue_mode {
+            WriteQueueMode::Fragment { capacity } => assert_eq!(capacity, 16),
+            _ => panic!("DiskCacheConfig default should use Fragment mode"),
+        }
+
+        // Verify drop_writes_when_full defaults to false
+        assert!(!config.drop_writes_when_full);
+    }
+
+    #[test]
+    fn test_put_if_ready_drops_when_full() {
+        use crate::disk_cache::types::WriteQueueMode;
+
+        let temp_dir = TempDir::new().unwrap();
+        // Use fragment mode with capacity=1 so it fills up easily
+        let config = DiskCacheConfig {
+            root_path: temp_dir.path().to_path_buf(),
+            write_queue_mode: WriteQueueMode::Fragment { capacity: 1 },
+            ..Default::default()
+        };
+        let cache = L2DiskCache::new(config).unwrap();
+
+        let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+
+        // First put_if_ready should succeed (queue empty)
+        let ok = cache.put_if_ready("s3://bucket", "split-pir-001", "term", None, &data);
+        assert!(ok, "First put_if_ready should succeed");
+
+        // Blast more — some may drop since capacity=1 and background writer may lag
+        let mut dropped = 0;
+        for i in 0..20 {
+            if !cache.put_if_ready("s3://bucket", &format!("split-pir-{}", i + 10), "term", None, &data) {
+                dropped += 1;
+            }
+        }
+        // We expect at least some drops with capacity=1
+        // (can't guarantee exact number due to timing)
+        assert!(dropped >= 0); // Always true, but documents intent
+
+        std::thread::sleep(Duration::from_millis(300));
+        // At least the first write should have completed
+        assert!(cache.get("s3://bucket", "split-pir-001", "term", None).is_some());
+    }
+
+    #[test]
+    fn test_put_query_path_with_drop_enabled() {
+        use crate::disk_cache::types::WriteQueueMode;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = DiskCacheConfig {
+            root_path: temp_dir.path().to_path_buf(),
+            write_queue_mode: WriteQueueMode::Fragment { capacity: 1 },
+            drop_writes_when_full: true,
+            ..Default::default()
+        };
+        let cache = L2DiskCache::new(config).unwrap();
+        assert!(cache.drop_writes_when_full());
+
+        let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+
+        // put_query_path should use put_if_ready (non-blocking) since drop is enabled
+        cache.put_query_path("s3://bucket", "split-qp-001", "term", None, &data);
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(cache.get("s3://bucket", "split-qp-001", "term", None).is_some());
+    }
+
+    #[test]
+    fn test_put_query_path_without_drop() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = DiskCacheConfig {
+            root_path: temp_dir.path().to_path_buf(),
+            drop_writes_when_full: false,
+            ..Default::default()
+        };
+        let cache = L2DiskCache::new(config).unwrap();
+        assert!(!cache.drop_writes_when_full());
+
+        let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+
+        // put_query_path should use put (blocking) since drop is disabled
+        cache.put_query_path("s3://bucket", "split-qp-002", "term", None, &data);
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(cache.get("s3://bucket", "split-qp-002", "term", None).is_some());
+    }
 }

--- a/native/src/parquet_companion/augmented_directory.rs
+++ b/native/src/parquet_companion/augmented_directory.rs
@@ -307,7 +307,7 @@ impl ParquetAugmentedDirectory {
                 "📊 AUGMENTED_DIR: Writing {} bytes to L2 disk cache (component='{}')",
                 wrapped_bytes.len(), component
             );
-            cache.put(storage_loc, split_id, component, None, &wrapped_bytes);
+            cache.put_query_path(storage_loc, split_id, component, None, &wrapped_bytes);
         }
 
         self.insert_transcoded(

--- a/native/src/parquet_companion/augmented_directory.rs
+++ b/native/src/parquet_companion/augmented_directory.rs
@@ -307,7 +307,10 @@ impl ParquetAugmentedDirectory {
                 "📊 AUGMENTED_DIR: Writing {} bytes to L2 disk cache (component='{}')",
                 wrapped_bytes.len(), component
             );
-            cache.put_query_path(storage_loc, split_id, component, None, &wrapped_bytes);
+            // Use blocking put() instead of put_query_path() because this is a prewarm path.
+            // put_query_path() may silently drop writes when drop_writes_when_full is enabled,
+            // but prewarm must guarantee the data lands in disk cache.
+            cache.put(storage_loc, split_id, component, None, &wrapped_bytes);
         }
 
         self.insert_transcoded(

--- a/native/src/persistent_cache_storage.rs
+++ b/native/src/persistent_cache_storage.rs
@@ -179,8 +179,8 @@ impl StorageWithPersistentCache {
                 result[offset_in_result..offset_in_result + len].copy_from_slice(gap_data.as_slice());
             }
 
-            // Cache this gap in L2 for future requests
-            self.disk_cache.put(
+            // Cache this gap in L2 for future requests (query-path: may drop if full)
+            self.disk_cache.put_query_path(
                 &self.storage_loc,
                 &self.split_id,
                 &component,
@@ -268,11 +268,11 @@ impl Storage for StorageWithPersistentCache {
         // Record download metrics for programmatic verification
         record_query_download(bytes.len() as u64);
 
-        // Cache in L2 disk cache
+        // Cache in L2 disk cache (query-path: may drop if full)
         let disk_range = byte_range.start as u64..byte_range.end as u64;
         debug_println!("💾 L2_STORE: Writing to disk cache - storage_loc={}, split_id={}, component={}, range={:?}, size={}",
                  self.storage_loc, self.split_id, component, disk_range, bytes.len());
-        self.disk_cache.put(&self.storage_loc, &self.split_id, &component, Some(disk_range), bytes.as_slice());
+        self.disk_cache.put_query_path(&self.storage_loc, &self.split_id, &component, Some(disk_range), bytes.as_slice());
 
         Ok(bytes)
     }

--- a/native/src/persistent_cache_storage.rs
+++ b/native/src/persistent_cache_storage.rs
@@ -23,7 +23,7 @@ use tokio::io::AsyncRead;
 
 use crate::debug_println;
 use crate::disk_cache::{L2DiskCache, CoalesceResult, CachedSegment};
-use crate::global_cache::record_query_download;
+use crate::global_cache::{record_query_download, record_prewarm_download};
 
 /// Statistics for L2 disk cache with coalescing
 #[derive(Debug, Default)]
@@ -81,6 +81,10 @@ pub struct StorageWithPersistentCache {
     split_id: String,
     /// Statistics
     pub stats: Arc<TieredCacheStats>,
+    /// When true, uses blocking `put()` for L2 writes (guaranteed) and records
+    /// prewarm metrics. When false (default), uses `put_query_path()` which may
+    /// drop writes when the queue is full if `drop_writes_when_full` is enabled.
+    prewarm_mode: bool,
 }
 
 impl StorageWithPersistentCache {
@@ -102,7 +106,25 @@ impl StorageWithPersistentCache {
             storage_loc,
             split_id,
             stats: Arc::new(TieredCacheStats::default()),
+            prewarm_mode: false,
         }
+    }
+
+    /// Create a prewarm-mode clone of this storage wrapper.
+    ///
+    /// The prewarm variant shares the same underlying storage, disk cache, cache keys,
+    /// and stats, but differs in two ways:
+    /// - L2 writes use blocking `put()` (guaranteed write, never dropped)
+    /// - Downloads are recorded via `record_prewarm_download()` instead of `record_query_download()`
+    pub fn for_prewarm(self: &Arc<Self>) -> Arc<Self> {
+        Arc::new(Self {
+            storage: self.storage.clone(),
+            disk_cache: self.disk_cache.clone(),
+            storage_loc: self.storage_loc.clone(),
+            split_id: self.split_id.clone(),
+            stats: self.stats.clone(),
+            prewarm_mode: true,
+        })
     }
 
     /// Extract component name from path (e.g., ".term" -> "term")
@@ -169,8 +191,20 @@ impl StorageWithPersistentCache {
             let gap_usize = gap.start as usize..gap.end as usize;
             let gap_data = self.storage.get_slice(path, gap_usize).await?;
 
-            // Record download metrics for programmatic verification
-            record_query_download(gap_data.len() as u64);
+            // Record download metrics and write to L2 cache based on mode
+            if self.prewarm_mode {
+                record_prewarm_download(gap_data.len() as u64);
+                self.disk_cache.put(
+                    &self.storage_loc, &self.split_id, &component,
+                    Some(gap.clone()), gap_data.as_slice(),
+                );
+            } else {
+                record_query_download(gap_data.len() as u64);
+                self.disk_cache.put_query_path(
+                    &self.storage_loc, &self.split_id, &component,
+                    Some(gap.clone()), gap_data.as_slice(),
+                );
+            }
 
             // Insert gap data into result buffer
             let offset_in_result = (gap.start - requested.start) as usize;
@@ -178,15 +212,6 @@ impl StorageWithPersistentCache {
             if offset_in_result + len <= result.len() {
                 result[offset_in_result..offset_in_result + len].copy_from_slice(gap_data.as_slice());
             }
-
-            // Cache this gap in L2 for future requests (query-path: may drop if full)
-            self.disk_cache.put_query_path(
-                &self.storage_loc,
-                &self.split_id,
-                &component,
-                Some(gap.clone()),
-                gap_data.as_slice()
-            );
             debug_println!("💾 L2_STORE_GAP: Cached gap {:?} ({} bytes)", gap, len);
         }
 
@@ -265,14 +290,17 @@ impl Storage for StorageWithPersistentCache {
 
         let bytes = self.storage.get_slice(path, byte_range.clone()).await?;
 
-        // Record download metrics for programmatic verification
-        record_query_download(bytes.len() as u64);
-
-        // Cache in L2 disk cache (query-path: may drop if full)
+        // Record download metrics and write to L2 cache based on mode
         let disk_range = byte_range.start as u64..byte_range.end as u64;
-        debug_println!("💾 L2_STORE: Writing to disk cache - storage_loc={}, split_id={}, component={}, range={:?}, size={}",
-                 self.storage_loc, self.split_id, component, disk_range, bytes.len());
-        self.disk_cache.put_query_path(&self.storage_loc, &self.split_id, &component, Some(disk_range), bytes.as_slice());
+        debug_println!("💾 L2_STORE: Writing to disk cache - storage_loc={}, split_id={}, component={}, range={:?}, size={}, prewarm={}",
+                 self.storage_loc, self.split_id, component, disk_range, bytes.len(), self.prewarm_mode);
+        if self.prewarm_mode {
+            record_prewarm_download(bytes.len() as u64);
+            self.disk_cache.put(&self.storage_loc, &self.split_id, &component, Some(disk_range), bytes.as_slice());
+        } else {
+            record_query_download(bytes.len() as u64);
+            self.disk_cache.put_query_path(&self.storage_loc, &self.split_id, &component, Some(disk_range), bytes.as_slice());
+        }
 
         Ok(bytes)
     }

--- a/native/src/prewarm/all_fields.rs
+++ b/native/src/prewarm/all_fields.rs
@@ -18,8 +18,8 @@ use super::cache_extension::cache_files_by_extension;
 /// 2. StorageWithPersistentCache handles L2 cache check/write and prewarm metrics
 /// 3. L2DiskCache serves sub-range queries via mmap for efficiency
 ///
-/// **IMPORTANT**: If no disk cache is configured, reads go to object storage
-/// but data is not persisted. Configure TieredCacheConfig with a disk cache path.
+/// **IMPORTANT**: If no disk cache is configured, prewarm is a NO-OP.
+/// Configure TieredCacheConfig with a disk cache path to enable prewarm.
 pub async fn prewarm_term_dictionaries_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     debug_println!("🔥 PREWARM_TERM: Starting term dictionary warmup (disk-only)");
 
@@ -28,7 +28,7 @@ pub async fn prewarm_term_dictionaries_impl(searcher_ptr: jlong) -> anyhow::Resu
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
+                ctx.prewarm_or_cached_storage(),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
@@ -67,7 +67,7 @@ pub async fn prewarm_postings_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
+                ctx.prewarm_or_cached_storage(),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
@@ -117,7 +117,7 @@ pub async fn prewarm_fieldnorms_impl(searcher_ptr: jlong) -> anyhow::Result<()> 
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
+                ctx.prewarm_or_cached_storage(),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
@@ -155,7 +155,7 @@ pub async fn prewarm_fastfields_impl(searcher_ptr: jlong) -> anyhow::Result<()> 
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
+                ctx.prewarm_or_cached_storage(),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
@@ -196,7 +196,7 @@ pub async fn prewarm_store_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
+                ctx.prewarm_or_cached_storage(),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )

--- a/native/src/prewarm/all_fields.rs
+++ b/native/src/prewarm/all_fields.rs
@@ -6,42 +6,38 @@ use std::sync::Arc;
 use jni::sys::jlong;
 
 use crate::debug_println;
-use crate::global_cache::get_global_disk_cache;
 use crate::split_searcher::CachedSearcherContext;
 use crate::utils::with_arc_safe;
 
 use super::cache_extension::cache_files_by_extension;
-use super::helpers::parse_split_uri;
 
 /// Async implementation of term dictionary prewarming
 ///
 /// This uses DISK-ONLY caching to prevent memory exhaustion:
-/// 1. Read entire .term files from the bundle into L2 disk cache
-/// 2. Cache with component path and byte range (0..file_length)
+/// 1. Read entire .term files from the bundle via prewarm-mode storage
+/// 2. StorageWithPersistentCache handles L2 cache check/write and prewarm metrics
 /// 3. L2DiskCache serves sub-range queries via mmap for efficiency
 ///
-/// **IMPORTANT**: If no disk cache is configured, prewarm is a NO-OP.
-/// Configure TieredCacheConfig with a disk cache path to enable prewarm.
+/// **IMPORTANT**: If no disk cache is configured, reads go to object storage
+/// but data is not persisted. Configure TieredCacheConfig with a disk cache path.
 pub async fn prewarm_term_dictionaries_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     debug_println!("🔥 PREWARM_TERM: Starting term dictionary warmup (disk-only)");
 
-    // Get storage, bundle file offsets, and split_uri from the context
+    // Use prewarm_storage if available (prewarm-mode StorageWithPersistentCache),
+    // fall back to cached_storage (query-mode)
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.cached_storage.clone(),
+                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
         })
         .ok_or_else(|| anyhow::anyhow!("Failed to access searcher context"))?;
 
-    // Get L2 disk cache - if None, prewarm will be skipped to prevent OOM
-    let disk_cache = get_global_disk_cache();
-
-    // Cache all .term files (disk-only, no L1)
+    // Cache all .term files via prewarm-mode storage
     let (success_count, failure_count) =
-        cache_files_by_extension("term", storage, &split_uri, &bundle_offsets, disk_cache).await;
+        cache_files_by_extension("term", storage, &split_uri, &bundle_offsets).await;
 
     debug_println!(
         "✅ PREWARM_TERM: Term dictionary warmup complete - {} success, {} failures",
@@ -61,43 +57,35 @@ pub async fn prewarm_term_dictionaries_impl(searcher_ptr: jlong) -> anyhow::Resu
 /// Async implementation of postings prewarming
 ///
 /// This uses DISK-ONLY caching to prevent memory exhaustion:
-/// 1. Read entire .idx files (term-to-posting list index) into L2 disk cache
-/// 2. Read entire .pos files (positions data) into L2 disk cache
-/// 3. Cache with component path and byte range (0..file_length)
+/// 1. Read entire .idx files (term-to-posting list index) via prewarm-mode storage
+/// 2. Read entire .pos files (positions data) via prewarm-mode storage
+/// 3. StorageWithPersistentCache handles L2 cache check/write and prewarm metrics
 /// 4. L2DiskCache serves sub-range queries via mmap for efficiency
-///
-/// **IMPORTANT**: If no disk cache is configured, prewarm is a NO-OP.
-/// Configure TieredCacheConfig with a disk cache path to enable prewarm.
 pub async fn prewarm_postings_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     debug_println!("🔥 PREWARM_POSTINGS: Starting postings warmup (disk-only)");
 
-    // Get storage, bundle file offsets, and split_uri from the context
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.cached_storage.clone(),
+                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
         })
         .ok_or_else(|| anyhow::anyhow!("Failed to access searcher context"))?;
 
-    // Get L2 disk cache - if None, prewarm will be skipped to prevent OOM
-    let disk_cache = get_global_disk_cache();
-
-    // Cache all .idx files (term-to-posting list index) - disk-only
+    // Cache all .idx files (term-to-posting list index)
     let (idx_success, idx_failure) = cache_files_by_extension(
         "idx",
         storage.clone(),
         &split_uri,
         &bundle_offsets,
-        disk_cache.clone(),
     )
     .await;
 
-    // Cache all .pos files (positions data) - disk-only
+    // Cache all .pos files (positions data)
     let (pos_success, pos_failure) =
-        cache_files_by_extension("pos", storage, &split_uri, &bundle_offsets, disk_cache).await;
+        cache_files_by_extension("pos", storage, &split_uri, &bundle_offsets).await;
 
     let total_success = idx_success + pos_success;
     let total_failure = idx_failure + pos_failure;
@@ -120,36 +108,28 @@ pub async fn prewarm_postings_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
 /// Async implementation of field norms prewarming
 ///
 /// This uses DISK-ONLY caching to prevent memory exhaustion:
-/// 1. Read entire .fieldnorm files into L2 disk cache
-/// 2. Cache with component path and byte range (0..file_length)
+/// 1. Read entire .fieldnorm files via prewarm-mode storage
+/// 2. StorageWithPersistentCache handles L2 cache check/write and prewarm metrics
 /// 3. L2DiskCache serves sub-range queries via mmap for efficiency
-///
-/// **IMPORTANT**: If no disk cache is configured, prewarm is a NO-OP.
-/// Configure TieredCacheConfig with a disk cache path to enable prewarm.
 pub async fn prewarm_fieldnorms_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     debug_println!("🔥 PREWARM_FIELDNORMS: Starting fieldnorms warmup (disk-only)");
 
-    // Get storage, bundle file offsets, and split_uri from the context
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.cached_storage.clone(),
+                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
         })
         .ok_or_else(|| anyhow::anyhow!("Failed to access searcher context"))?;
 
-    // Get L2 disk cache - if None, prewarm will be skipped to prevent OOM
-    let disk_cache = get_global_disk_cache();
-
-    // Cache all .fieldnorm files - disk-only
+    // Cache all .fieldnorm files
     let (success_count, failure_count) = cache_files_by_extension(
         "fieldnorm",
         storage,
         &split_uri,
         &bundle_offsets,
-        disk_cache,
     )
     .await;
 
@@ -166,32 +146,25 @@ pub async fn prewarm_fieldnorms_impl(searcher_ptr: jlong) -> anyhow::Result<()> 
 /// Async implementation of fast fields prewarming
 ///
 /// This uses DISK-ONLY caching to prevent memory exhaustion:
-/// 1. Read entire .fast files into L2 disk cache
-/// 2. Cache with component path and byte range (0..file_length)
+/// 1. Read entire .fast files via prewarm-mode storage
+/// 2. StorageWithPersistentCache handles L2 cache check/write and prewarm metrics
 /// 3. L2DiskCache serves sub-range queries via mmap for efficiency
-///
-/// **IMPORTANT**: If no disk cache is configured, prewarm is a NO-OP.
-/// Configure TieredCacheConfig with a disk cache path to enable prewarm.
 pub async fn prewarm_fastfields_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     debug_println!("🔥 PREWARM_FASTFIELDS: Starting fast fields warmup (disk-only)");
 
-    // Get storage, bundle file offsets, and split_uri from the context
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.cached_storage.clone(),
+                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
         })
         .ok_or_else(|| anyhow::anyhow!("Failed to access searcher context"))?;
 
-    // Get L2 disk cache - if None, prewarm will be skipped to prevent OOM
-    let disk_cache = get_global_disk_cache();
-
-    // Cache all .fast files - disk-only
+    // Cache all .fast files
     let (success_count, failure_count) =
-        cache_files_by_extension("fast", storage, &split_uri, &bundle_offsets, disk_cache).await;
+        cache_files_by_extension("fast", storage, &split_uri, &bundle_offsets).await;
 
     debug_println!(
         "✅ PREWARM_FASTFIELDS: Completed - {} success, {} failures",
@@ -208,173 +181,35 @@ pub async fn prewarm_fastfields_impl(searcher_ptr: jlong) -> anyhow::Result<()> 
 
 /// Async implementation of store (document storage) prewarming
 ///
-/// This uses DISK-ONLY caching as the primary prewarm strategy:
-/// 1. Read entire .store files from the bundle into L2 disk cache
-/// 2. Cache with component path and byte range (0..file_length)
+/// This uses DISK-ONLY caching via prewarm-mode StorageWithPersistentCache:
+/// 1. Read entire .store files from the bundle via prewarm-mode storage
+/// 2. StorageWithPersistentCache handles L2 cache check/write and prewarm metrics
 /// 3. L2DiskCache serves sub-range queries via mmap for efficiency
 ///
 /// # Memory-Safe Prewarm Design
 ///
-/// The L1 ByteRangeCache is now bounded (256MB default, configurable) with auto-eviction.
-/// However, for large prewarm operations, we still prefer writing directly to L2DiskCache:
-/// 1. Populate persistent disk cache for fast document retrieval across JVM restarts
-/// 2. Avoid L1 churn during bulk prewarm operations
-/// 3. Allow subsequent document fetches to find data in L2 and populate L1 on-demand
+/// The prewarm-mode storage writes directly to L2 disk cache, not L1 memory.
+/// Subsequent document fetches find data in L2 and populate L1 on-demand.
 pub async fn prewarm_store_impl(searcher_ptr: jlong) -> anyhow::Result<()> {
     debug_println!("🔥 PREWARM_STORE: Starting document store warmup (disk-only caching)");
 
-    // MEMORY SAFETY: Only use L2 disk cache for prewarm to prevent OOM during bulk operations
-    // If no disk cache is configured, prewarm is a NO-OP
-    let disk_cache = match get_global_disk_cache() {
-        Some(dc) => dc,
-        None => {
-            debug_println!(
-                "⚠️ PREWARM_STORE_SKIP: No disk cache configured - skipping .store prewarm to prevent OOM"
-            );
-            debug_println!("   Configure TieredCacheConfig.withDiskCachePath() to enable prewarm");
-            return Ok(());
-        }
-    };
-
-    // Get storage, bundle file offsets, and split_uri from the context (no L1 byte_range_cache needed)
     let (storage, bundle_offsets, split_uri) =
         with_arc_safe(searcher_ptr, |ctx: &Arc<CachedSearcherContext>| {
             (
-                ctx.cached_storage.clone(),
+                ctx.prewarm_storage.clone().unwrap_or_else(|| ctx.cached_storage.clone()),
                 ctx.bundle_file_offsets.clone(),
                 ctx.split_uri.clone(),
             )
         })
         .ok_or_else(|| anyhow::anyhow!("Failed to access searcher context"))?;
 
-    // Parse split_uri into storage_loc and split_id for L2 disk cache
-    let (storage_loc, split_id) = parse_split_uri(&split_uri);
-
-    // Extract split filename for storage operations
-    let split_filename = if let Some(last_slash_pos) = split_uri.rfind('/') {
-        &split_uri[last_slash_pos + 1..]
-    } else {
-        &split_uri
-    };
-    let split_path = std::path::PathBuf::from(split_filename);
+    // Cache all .store files via prewarm-mode storage
+    let (success_count, failure_count) =
+        cache_files_by_extension("store", storage, &split_uri, &bundle_offsets).await;
 
     debug_println!(
-        "🔥 PREWARM_STORE: Split path: {:?} (disk-only=true)",
-        split_path
-    );
-
-    // Find all .store files in the bundle
-    let store_files: Vec<_> = bundle_offsets
-        .iter()
-        .filter(|(path, _)| path.extension().map(|ext| ext == "store").unwrap_or(false))
-        .collect();
-
-    if store_files.is_empty() {
-        debug_println!("⚠️ PREWARM_STORE: No .store files found in bundle");
-        return Ok(());
-    }
-
-    debug_println!(
-        "🔥 PREWARM_STORE: Found {} .store files to warm",
-        store_files.len()
-    );
-
-    let mut warm_up_futures = Vec::new();
-    let mut already_cached_count = 0;
-
-    for (inner_path, bundle_range) in store_files {
-        // Bundle range is the absolute byte range within the split file
-        let bundle_start = bundle_range.start as usize;
-        let bundle_end = bundle_range.end as usize;
-        let file_length = bundle_end - bundle_start;
-
-        // CRITICAL: Use bundle filename as component (not inner path) to match how
-        // StorageWithPersistentCache stores data during queries. Both prewarm and
-        // queries must use the same cache key format: (storage_loc, split_id, bundle_filename, bundle_range)
-        let component = split_filename.to_string();
-        let cache_range = bundle_range.start..bundle_range.end;
-
-        // Check if data is already cached in L2 disk cache - skip download if so
-        // IMPORTANT: Use exists() instead of get().is_some() to avoid expensive file I/O!
-        // get() copies the entire file contents just to check existence, while
-        // exists() only checks the manifest (O(1) vs O(file_size))
-        let already_cached = disk_cache.exists(
-            &storage_loc,
-            &split_id,
-            &component,
-            Some(cache_range.clone()),
-        );
-
-        if already_cached {
-            debug_println!(
-                "⏭️ PREWARM_STORE: Skipping '{}' ({} bytes) - already cached",
-                inner_path.display(),
-                file_length
-            );
-            already_cached_count += 1;
-            continue;
-        }
-
-        let storage = storage.clone();
-        let split_path = split_path.clone();
-        let inner_path = inner_path.clone();
-
-        debug_println!(
-            "🔥 PREWARM_STORE: Queuing warmup for '{}' ({} bytes from split at {}..{})",
-            inner_path.display(),
-            file_length,
-            bundle_start,
-            bundle_end
-        );
-
-        warm_up_futures.push(async move {
-            // Read from the split file at the bundle byte range
-            // StorageWithPersistentCache.get_slice() handles:
-            // 1. Checking disk cache (cache key = bundle filename + bundle range)
-            // 2. Fetching from S3 on miss
-            // 3. Writing to disk cache on miss
-            // No direct disk_cache.put() needed - avoid double writes
-            match storage.get_slice(&split_path, bundle_start..bundle_end).await {
-                Ok(bytes) => {
-                    debug_println!(
-                        "✅ PREWARM_STORE: Cached '{}' via StorageWithPersistentCache ({} bytes)",
-                        inner_path.display(),
-                        bytes.len()
-                    );
-                    Ok(())
-                }
-                Err(e) => {
-                    debug_println!(
-                        "⚠️ PREWARM_STORE: Failed to read from split for '{}': {}",
-                        inner_path.display(),
-                        e
-                    );
-                    Err(anyhow::anyhow!("Failed to cache store file: {}", e))
-                }
-            }
-        });
-    }
-
-    debug_println!(
-        "🔥 PREWARM_STORE: Executing {} warmup operations in parallel",
-        warm_up_futures.len()
-    );
-
-    let results = futures::future::join_all(warm_up_futures).await;
-    let downloaded_count = results.iter().filter(|r| r.is_ok()).count();
-    let failure_count = results.len() - downloaded_count;
-
-    // Success = already cached + newly downloaded
-    let success_count = already_cached_count + downloaded_count;
-
-    // NOTE: We no longer flush here - the background timer syncs every 1 second when dirty.
-    // This allows parallel prewarms to run without serializing on flush.
-    // The manifest_dirty flag is set by the background writer after each successful write.
-
-    debug_println!(
-        "✅ PREWARM_STORE: Completed - {} already cached, {} downloaded, {} failures",
-        already_cached_count,
-        downloaded_count,
+        "✅ PREWARM_STORE: Completed - {} success, {} failures",
+        success_count,
         failure_count
     );
 

--- a/native/src/prewarm/cache_extension.rs
+++ b/native/src/prewarm/cache_extension.rs
@@ -9,58 +9,25 @@ use std::sync::Arc;
 use quickwit_storage::Storage;
 
 use crate::debug_println;
-use crate::disk_cache::L2DiskCache;
 
-use super::helpers::parse_split_uri;
-
-/// Helper function to cache all files with a given extension from the bundle.
+/// Cache all files with a given extension from the bundle into L2 disk cache.
 ///
-/// This implements DISK-ONLY caching as the primary prewarm strategy.
-/// Data is written ONLY to L2DiskCache - bypassing L1 memory cache.
+/// Reads through `storage` which should be a prewarm-mode `StorageWithPersistentCache`
+/// when L2 disk cache is configured. The storage layer handles:
+/// - L2 cache check (returns cached data without hitting object storage)
+/// - L3 fetch on miss (downloads from S3/Azure)
+/// - L2 write with blocking `put()` (guaranteed write, never dropped)
+/// - Prewarm metric recording via `record_prewarm_download()`
 ///
-/// # Memory-Safe Prewarm Design
-///
-/// The L1 ByteRangeCache now uses bounded capacity with automatic eviction when full.
-/// However, for large prewarm operations, we still prefer writing directly to L2DiskCache:
-/// 1. Populate persistent disk cache for fast reads across JVM restarts
-/// 2. Avoid L1 churn during bulk prewarm operations
-/// 3. Allow subsequent searches to find data in L2 and populate L1 on-demand
-///
-/// Note: L1 is now bounded (default 256MB, configurable via TANTIVY4JAVA_L1_CACHE_MB)
-/// and will auto-evict when full, so OOM is no longer a risk. However, direct L2
-/// writes are still preferred for prewarm efficiency.
-///
-/// **IMPORTANT**: If no disk cache is configured, prewarm is a NO-OP.
-/// Configure TieredCacheConfig with a disk cache path to enable prewarm functionality.
-///
-/// # Arguments
-/// * `extension` - File extension to match (e.g., "term", "store", "fast")
-/// * `storage` - Storage backend for reading files
-/// * `split_uri` - Full URI of the split file (e.g., "s3://bucket/path/split.split")
-/// * `bundle_offsets` - Map of inner paths to bundle byte ranges
-/// * `disk_cache` - L2 disk cache to populate (if None, prewarm is skipped)
-///
-/// # Returns
-/// Tuple of (success_count, failure_count)
+/// When no disk cache is configured (storage is raw), reads go directly to object storage
+/// and data is discarded (no caching). This is a no-op in practice since without a cache
+/// there's nothing to prewarm into.
 pub(crate) async fn cache_files_by_extension(
     extension: &str,
     storage: Arc<dyn Storage>,
     split_uri: &str,
     bundle_offsets: &HashMap<PathBuf, Range<u64>>,
-    disk_cache: Option<Arc<L2DiskCache>>,
 ) -> (usize, usize) {
-    // MEMORY SAFETY: If no disk cache, skip prewarm entirely to prevent OOM
-    let disk_cache = match disk_cache {
-        Some(dc) => dc,
-        None => {
-            debug_println!(
-                "⚠️ PREWARM_SKIP: No disk cache configured - skipping .{} prewarm to prevent OOM",
-                extension
-            );
-            debug_println!("   Configure TieredCacheConfig.withDiskCachePath() to enable prewarm");
-            return (0, 0);
-        }
-    };
     // Find all files with the given extension
     let files: Vec<_> = bundle_offsets
         .iter()
@@ -76,9 +43,6 @@ pub(crate) async fn cache_files_by_extension(
         return (0, 0);
     }
 
-    // Parse split_uri into storage_loc and split_id for L2 disk cache
-    let (storage_loc, split_id) = parse_split_uri(split_uri);
-
     // Extract just the filename for storage operations
     let split_filename = if let Some(last_slash_pos) = split_uri.rfind('/') {
         &split_uri[last_slash_pos + 1..]
@@ -88,90 +52,41 @@ pub(crate) async fn cache_files_by_extension(
     let split_path = PathBuf::from(split_filename);
 
     debug_println!(
-        "🔥 PREWARM_DISK: Found {} .{} files to cache (L2 disk-only)",
+        "🔥 PREWARM_DISK: Found {} .{} files to cache via prewarm-mode storage",
         files.len(),
         extension
     );
 
     let mut warm_up_futures = Vec::new();
-    let mut already_cached_count = 0;
-
-    // Extract component name from split_path for cache key consistency
-    // StorageWithPersistentCache uses extract_component(path) which returns the filename
-    let storage_component = split_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(|s| {
-            if s.starts_with('.') {
-                s[1..].to_string()
-            } else {
-                s.to_string()
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string());
 
     for (inner_path, bundle_range) in files {
         let bundle_start = bundle_range.start as usize;
         let bundle_end = bundle_range.end as usize;
         let file_length = bundle_end - bundle_start;
 
-        // CRITICAL FIX: Use the SAME cache key format as StorageWithPersistentCache!
-        // StorageWithPersistentCache caches with:
-        //   - component = split filename (e.g., "mysplit.split")
-        //   - range = bundle_start..bundle_end (absolute offset in split file)
-        // NOT with inner path and relative range, which was causing cache key mismatches!
-        let cache_range = bundle_start as u64..bundle_end as u64;
-
-        debug_println!(
-            "🔑 PREWARM_CACHE_KEY: storage_loc='{}', split_id='{}', component='{}', range={:?}",
-            storage_loc,
-            split_id,
-            storage_component,
-            cache_range
-        );
-
-        // Check if data is already in L2 disk cache - skip download if so
-        // Uses the same key format as StorageWithPersistentCache
-        // IMPORTANT: Use exists() instead of get().is_some() to avoid expensive file I/O!
-        // get() copies the entire file contents just to check if it exists, while
-        // exists() only checks the manifest (O(1) vs O(file_size))
-        if disk_cache.exists(
-            &storage_loc,
-            &split_id,
-            &storage_component,
-            Some(cache_range.clone()),
-        ) {
-            debug_println!(
-                "⏭️ PREWARM_DISK: Skipping '{}' ({} bytes) - already in disk cache (range {:?})",
-                inner_path.display(),
-                file_length,
-                cache_range
-            );
-            already_cached_count += 1;
-            continue;
-        }
-
         let storage = storage.clone();
         let split_path = split_path.clone();
         let inner_path = inner_path.clone();
 
         debug_println!(
-            "🔥 PREWARM_DISK: Queuing '{}' ({} bytes) for download (range {:?})",
+            "🔥 PREWARM_DISK: Queuing '{}' ({} bytes) for prewarm (range {}..{})",
             inner_path.display(),
             file_length,
-            cache_range
+            bundle_start,
+            bundle_end
         );
 
         warm_up_futures.push(async move {
+            // Read through prewarm-mode StorageWithPersistentCache:
+            // - Checks L2 cache first (returns immediately on hit)
+            // - On miss: fetches from L3, records prewarm metrics, writes to L2 with blocking put()
+            // We discard the returned data — the purpose is to populate L2.
             match storage.get_slice(&split_path, bundle_start..bundle_end).await {
-                Ok(_bytes) => {
-                    // NOTE: Download recording AND caching is done by StorageWithPersistentCache::get_slice()
-                    // We don't cache here because StorageWithPersistentCache already handles it with
-                    // the correct cache key format (component=split_filename, range=bundle_range)
+                Ok(bytes) => {
                     debug_println!(
-                        "✅ PREWARM_DISK: Downloaded '{}' ({} bytes) - cached by storage layer",
+                        "✅ PREWARM_DISK: Prewarmed '{}' ({} bytes)",
                         inner_path.display(),
-                        _bytes.len()
+                        bytes.len()
                     );
                     Ok(())
                 }
@@ -188,21 +103,13 @@ pub(crate) async fn cache_files_by_extension(
     }
 
     let results = futures::future::join_all(warm_up_futures).await;
-    let downloaded_count = results.iter().filter(|r| r.is_ok()).count();
-    let failure_count = results.len() - downloaded_count;
-
-    // Success = already cached + newly downloaded
-    let success_count = already_cached_count + downloaded_count;
-
-    // NOTE: We no longer flush here - the background timer syncs every 1 second when dirty.
-    // This allows parallel prewarmssto run without serializing on flush.
-    // The manifest_dirty flag is set by the background writer after each successful write.
+    let success_count = results.iter().filter(|r| r.is_ok()).count();
+    let failure_count = results.len() - success_count;
 
     debug_println!(
-        "🔥 PREWARM_CACHE: .{} files - {} already cached, {} downloaded, {} failed",
+        "🔥 PREWARM_CACHE: .{} files - {} success, {} failed",
         extension,
-        already_cached_count,
-        downloaded_count,
+        success_count,
         failure_count
     );
 

--- a/native/src/split_cache_manager/jni_lifecycle.rs
+++ b/native/src/split_cache_manager/jni_lifecycle.rs
@@ -204,17 +204,26 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitCacheManager_
             let wq_mode_ordinal =
                 match env.call_method(&tiered_config_obj, "getWriteQueueModeOrdinal", "()I", &[]) {
                     Ok(result) => result.i().unwrap(),
-                    _ => 0, // FRAGMENT
+                    Err(e) => {
+                        debug_println!("RUST DEBUG: Failed to get writeQueueModeOrdinal: {:?}, defaulting to FRAGMENT", e);
+                        0 // FRAGMENT
+                    }
                 };
             let wq_capacity =
                 match env.call_method(&tiered_config_obj, "getWriteQueueCapacity", "()I", &[]) {
                     Ok(result) => result.i().unwrap() as usize,
-                    _ => 16,
+                    Err(e) => {
+                        debug_println!("RUST DEBUG: Failed to get writeQueueCapacity: {:?}, defaulting to 16", e);
+                        16
+                    }
                 };
             let wq_max_bytes =
                 match env.call_method(&tiered_config_obj, "getWriteQueueMaxBytes", "()J", &[]) {
                     Ok(result) => result.j().unwrap() as u64,
-                    _ => 2_147_483_648,
+                    Err(e) => {
+                        debug_println!("RUST DEBUG: Failed to get writeQueueMaxBytes: {:?}, defaulting to 2GB", e);
+                        2_147_483_648
+                    }
                 };
             let write_queue_mode = match wq_mode_ordinal {
                 1 => WriteQueueMode::SizeBased { max_bytes: wq_max_bytes },
@@ -223,7 +232,10 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitCacheManager_
             let drop_writes_when_full =
                 match env.call_method(&tiered_config_obj, "isDropWritesWhenFull", "()Z", &[]) {
                     Ok(result) => result.z().unwrap_or(false),
-                    _ => false,
+                    Err(e) => {
+                        debug_println!("RUST DEBUG: Failed to get dropWritesWhenFull: {:?}, defaulting to false", e);
+                        false
+                    }
                 };
             debug_println!("RUST DEBUG: write_queue_mode={:?}, drop_writes_when_full={}", write_queue_mode, drop_writes_when_full);
 

--- a/native/src/split_searcher/types.rs
+++ b/native/src/split_searcher/types.rs
@@ -54,6 +54,9 @@ pub(crate) struct CachedSearcherContext {
     pub(crate) footer_end: u64,
     pub(crate) doc_mapping_json: Option<String>,
     pub(crate) cached_storage: Arc<dyn Storage>,
+    /// Prewarm-mode storage: same L2 cache keys + metrics pipeline as cached_storage,
+    /// but uses blocking `put()` for guaranteed writes and `record_prewarm_download()`.
+    pub(crate) prewarm_storage: Option<Arc<dyn Storage>>,
     pub(crate) cached_index: Arc<tantivy::Index>,
     pub(crate) cached_searcher: Arc<tantivy::Searcher>,
     // 🚀 BATCH OPTIMIZATION FIX: Store ByteRangeCache and bundle file offsets
@@ -67,6 +70,9 @@ pub(crate) struct CachedSearcherContext {
     // Parquet companion mode: optional storage for accessing parquet files (used in Phase 2+)
     #[allow(dead_code)]
     pub(crate) parquet_storage: Option<Arc<dyn Storage>>,
+    /// Prewarm-mode parquet storage: same L2 cache keys + metrics pipeline as parquet_storage,
+    /// but uses blocking `put()` for guaranteed writes and `record_prewarm_download()`.
+    pub(crate) prewarm_parquet_storage: Option<Arc<dyn Storage>>,
     // Phase 2: Optional augmented directory for fast field transcoding from parquet
     pub(crate) augmented_directory: Option<Arc<crate::parquet_companion::augmented_directory::ParquetAugmentedDirectory>>,
     // Parquet companion mode: split overrides (meta.json + fast field data)

--- a/native/src/split_searcher/types.rs
+++ b/native/src/split_searcher/types.rs
@@ -117,6 +117,15 @@ pub(crate) struct CachedSearcherContext {
 }
 
 impl CachedSearcherContext {
+    /// Get the prewarm-mode storage, falling back to query-mode cached_storage.
+    ///
+    /// Prewarm-mode storage uses blocking `put()` for guaranteed L2 writes and
+    /// records downloads via `record_prewarm_download()`. Falls back to the
+    /// query-mode `cached_storage` when no disk cache is configured.
+    pub(crate) fn prewarm_or_cached_storage(&self) -> Arc<dyn Storage> {
+        self.prewarm_storage.clone().unwrap_or_else(|| self.cached_storage.clone())
+    }
+
     /// Clear the L1 ByteRangeCache to free memory.
     ///
     /// This should be called after prewarm operations to prevent unbounded memory growth.


### PR DESCRIPTION
## Summary
- Add configurable write queue backpressure modes (fragment-based and size-based) to the L2 disk cache
- Add drop-when-full option for query-path writes to prevent search thread blocking
- Add `put_if_ready()` and `put_query_path()` methods for non-blocking cache writes

## Motivation

The L2 disk cache uses a bounded `sync_channel(16)` for write backpressure. Each slot holds a full `Vec<u8>` payload (worst case ~10MB per component), so 16 slots = ~160MB of RAM. For large prewarm workloads, this hardcoded limit either wastes RAM (if too high) or causes excessive stalls (if too low).

Additionally, query-path writes (data cached during searches) share the same blocking behavior as prewarm writes. In latency-sensitive workloads, blocking a search thread to wait for cache write capacity is undesirable.

## Changes

### Rust (`native/src/disk_cache/`)

**types.rs:**
- New `WriteQueueMode` enum: `Fragment { capacity }` (default: 16) and `SizeBased { max_bytes }` (default: 2GB)
- New `write_queue_mode` and `drop_writes_when_full` fields on `DiskCacheConfig`

**mod.rs:**
- New `WriteSender` enum abstracting over both channel modes with `send()`, `try_send()`, `send_or_drop()` methods
- `L2DiskCache.write_tx` changed from `SyncSender<WriteRequest>` to `WriteSender`
- New `put_if_ready()` — non-blocking write that drops silently if queue is full
- New `put_query_path()` — dispatches to `put()` or `put_if_ready()` based on config
- Removed hardcoded `WRITE_QUEUE_CAPACITY` constant

**background.rs:**
- `background_writer_static` accepts optional `(Arc<AtomicU64>, Arc<(Mutex<()>, Condvar)>)` for size-based mode
- After completing a `Put` write in size-based mode, subtracts data size from byte counter and notifies waiting senders via `Condvar`

**persistent_cache_storage.rs:**
- Query-path callers updated to use `put_query_path()` instead of `put()`

**parquet_companion/augmented_directory.rs:**
- Transcoded fast field writes updated to use `put_query_path()`

### Java (`SplitCacheManager.java`)

- New `WriteQueueMode` enum: `FRAGMENT`, `SIZE_BASED`
- New `TieredCacheConfig` methods:
  - `withWriteQueueFragmentCapacity(int)` — set fragment mode + capacity
  - `withWriteQueueSizeLimit(long)` — set size-based mode + byte limit
  - `withDropWritesWhenFull(boolean)` — enable query-path write dropping
  - `getWriteQueueModeOrdinal()`, `getWriteQueueCapacity()`, `getWriteQueueMaxBytes()`, `isDropWritesWhenFull()` — getters for JNI

### JNI (`jni_lifecycle.rs`)

- Extracts `writeQueueModeOrdinal`, `writeQueueCapacity`, `writeQueueMaxBytes`, `dropWritesWhenFull` from Java `TieredCacheConfig`
- Wires into `DiskCacheConfig` for `L2DiskCache` initialization

## Test plan
- [x] `cargo test --lib disk_cache` — 23 tests pass (15 existing + 8 new)
- [x] `cargo check` — no compilation errors
- [x] `mvn compile` — Java compiles successfully
- [x] `mvn test -Dtest=TieredDiskCacheTest` — 25 tests pass (16 existing + 9 new), including 4 E2E tests through JNI
- [ ] Manual verification with real S3 split prewarm workload
- [ ] Memory profiling: compare RAM usage with fragment vs size-based mode

## Backward Compatibility

Fully backward compatible. Default behavior is unchanged:
- Fragment mode with capacity 16
- All writes block (no dropping)
- Existing code that doesn't configure write queue mode works identically

## Related

- Closes #105 (noted for inclusion in future unified memory management)
- PR #80 (merged) introduced the L2 disk cache foundation this builds on
