### PR TITLE
Fix empty string statistics in Arrow FFI path

### DIFF
--- a/native/src/parquet_companion/arrow_ffi_import.rs
+++ b/native/src/parquet_companion/arrow_ffi_import.rs
@@ -352,6 +352,9 @@ fn create_partition_writer(
                     DataType::Timestamp(_, _) => "datetime",
                     _ => continue, // Skip non-eligible types
                 };
+                // truncate_length=0 means no truncation at the native layer.
+                // The JVM side applies StatisticsTruncation before writing to
+                // the transaction log (default: 32 chars, configurable).
                 accumulators.insert(
                     mapping.field_name.clone(),
                     StatisticsAccumulator::new(&mapping.field_name, field_type, 0),

--- a/native/src/parquet_companion/statistics.rs
+++ b/native/src/parquet_companion/statistics.rs
@@ -80,13 +80,13 @@ impl StatisticsAccumulator {
     }
 
     pub fn observe_string(&mut self, value: &str) {
-        let truncated_min = if value.len() > self.truncate_length {
+        let truncated_min = if self.truncate_length > 0 && value.len() > self.truncate_length {
             safe_truncate(value, self.truncate_length).to_string()
         } else {
             value.to_string()
         };
 
-        let truncated_max = if value.len() > self.truncate_length {
+        let truncated_max = if self.truncate_length > 0 && value.len() > self.truncate_length {
             truncate_ceiling(safe_truncate(value, self.truncate_length))
         } else {
             value.to_string()
@@ -363,6 +363,31 @@ mod tests {
         let result = acc.finalize();
         assert_eq!(result.min_string, Some("".to_string()));
         assert_eq!(result.max_string, Some("zzz".to_string()));
+    }
+
+    #[test]
+    fn test_string_no_truncation_when_zero() {
+        // truncate_length=0 means disabled — strings should not be truncated
+        let mut acc = StatisticsAccumulator::new("s", "Str", 0);
+        acc.observe_string("data.csv");
+        acc.observe_string("report.json");
+        acc.observe_string("config.json");
+        acc.observe_string("readme.txt");
+        acc.observe_string("schema.json");
+        let result = acc.finalize();
+        assert_eq!(result.min_string, Some("config.json".to_string()));
+        assert_eq!(result.max_string, Some("schema.json".to_string()));
+    }
+
+    #[test]
+    fn test_string_no_truncation_long_values_when_zero() {
+        // truncate_length=0 means disabled — even long strings pass through
+        let mut acc = StatisticsAccumulator::new("s", "Str", 0);
+        let long_val = "a".repeat(500);
+        acc.observe_string(&long_val);
+        let result = acc.finalize();
+        assert_eq!(result.min_string.as_ref().unwrap().len(), 500);
+        assert_eq!(result.max_string.as_ref().unwrap().len(), 500);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix `StatisticsAccumulator::observe_string()` treating `truncate_length=0` as "truncate to 0 bytes" instead of "no truncation"
- Add `truncate_length > 0` guard so 0 means disabled
- Add 2 regression tests for `truncate_length=0` behavior

## Root Cause

The Arrow FFI path passes `truncate_length=0` because the JVM side handles truncation via `StatisticsTruncation` (default: 32 chars). But `observe_string()` compared `value.len() > 0` which is always true for non-empty strings, causing `safe_truncate(value, 0)` to return `""` for every value.

This broke data skipping in IndexTables4Spark — empty statistics caused `StringEndsWith`/`StringContains` filters to incorrectly skip all splits (11 test failures in `StringPatternPushdownTest`).

## Test plan

- [x] All 23 statistics tests pass (`cargo test --lib statistics`)
- [ ] Verify `finishAllSplitsRaw()` returns non-empty min/max for text fields with `"stats":true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)