### PR TITLE
Fix Arrow FFI behavioral parity with TANT batch path

### DIFF
--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use anyhow::{Context, Result};
 use arrow_schema::{DataType, Schema as ArrowSchema};
-use tantivy::schema::{Schema, SchemaBuilder};
+use tantivy::schema::{DateTimePrecision, Schema, SchemaBuilder};
 
 use super::manifest::FastFieldMode;
 use super::string_indexing::{self, StringIndexingMode};
@@ -148,11 +148,12 @@ fn add_field_for_arrow_type(
             DataType::Utf8 | DataType::LargeUtf8 => {
                 // STRING column forced to JSON: stored + indexed + fast
                 // Fast fields are required for range queries on numeric sub-fields
+                // Use "raw" tokenizer to match TANT batch path behavior (exact string matching)
                 let opts = JsonObjectOptions::default()
                     .set_stored()
                     .set_indexing_options(
                         TextFieldIndexing::default()
-                            .set_tokenizer("default")
+                            .set_tokenizer("raw")
                             .set_index_option(IndexRecordOption::Basic)
                             .set_fieldnorms(config.fieldnorms_enabled),
                     )
@@ -329,6 +330,7 @@ fn add_field_for_arrow_type(
         DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64 => {
             let mut opts = DateOptions::default();
             opts = opts.set_indexed();
+            opts = opts.set_precision(DateTimePrecision::Microseconds);
             if config.store_fields {
                 opts = opts.set_stored();
             }
@@ -341,11 +343,12 @@ fn add_field_for_arrow_type(
         DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) | DataType::Map(_, _) | DataType::Struct(_) => {
             // Complex types → JSON object field: stored + indexed + fast
             // Fast fields are required for range queries on numeric sub-fields
+            // Use "raw" tokenizer to match TANT batch path behavior (exact string matching)
             let opts = JsonObjectOptions::default()
                 .set_stored()
                 .set_indexing_options(
                     TextFieldIndexing::default()
-                        .set_tokenizer("default")
+                        .set_tokenizer("raw")
                         .set_index_option(IndexRecordOption::Basic)
                         .set_fieldnorms(config.fieldnorms_enabled),
                 )


### PR DESCRIPTION
## Summary
- **Fix timestamp equality queries** — add `DateTimePrecision::Microseconds` to date fields in `schema_derivation.rs`, matching the JNI schema builder. Without this, date fast fields truncate to seconds and microsecond-precision range queries return 0 results.
- **Fix JSON struct sub-field tokenization** — change JSON object field tokenizer from `"default"` to `"raw"` for both the Struct/List/Map complex-type path and the explicit JSON-string-column path. The `"default"` tokenizer splits on whitespace and lowercases, breaking exact term queries like `doc.title:"Spark Guide"`. The `"raw"` tokenizer preserves the original string, matching TANT batch path behavior.
- **Issue 2 (double statistics format)** intentionally not fixed — Java side will tolerate either `"75000"` or `"75000.0"` format.

## Test plan
- [x] `cargo check` — clean compilation
- [x] `cargo test --lib parquet_companion` — 309/309 pass
- [x] `cargo test --lib schema_derivation` — 37/37 pass
- [ ] Verify TANT batch path and Arrow FFI path produce identical query results for timestamp equality and struct sub-field exact match

🤖 Generated with [Claude Code](https://claude.com/claude-code)