### PR TITLE
Fix: add id-token:write permission for Claude code review OIDC

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@beta


### PR DESCRIPTION
## Summary

Adds the missing `id-token: write` permission to the Claude code review workflow. Without this, the action fails with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

This PR also serves as a test to verify the reviewer works end-to-end.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>