### PR TITLE
Switch Claude code review to OAuth token authentication

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           model: "claude-sonnet-4-20250514"
           direct_prompt: |
             Review this PR for:


### PR DESCRIPTION
Use claude_code_oauth_token instead of anthropic_api_key to match the authentication pattern used in other projects.