### PR TITLE
Fix: add checkout step before claude-code-action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,10 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
The action requires the repo to be checked out first, otherwise it fails with "fatal: not a git repository".