### PR TITLE
Convert Cargo path deps to GitHub git references

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -32,17 +32,18 @@ once_cell = "1.19.0"
 bytesize = "1.3"
 
 # Quickwit dependencies (for main library only - binaries use lightweight approach)
+# Pin to specific commit on indextables/quickwit fork (fix/zero_copy branch)
 # Azure feature enabled for Azure Blob Storage support
-quickwit-storage = { path = "../../quickwit/quickwit/quickwit-storage", features = ["azure"] }
-quickwit-metastore = { path = "../../quickwit/quickwit/quickwit-metastore" }
-quickwit-proto = { path = "../../quickwit/quickwit/quickwit-proto" }
-quickwit-directories = { path = "../../quickwit/quickwit/quickwit-directories" }
-quickwit-common = { path = "../../quickwit/quickwit/quickwit-common" }
-quickwit-config = { path = "../../quickwit/quickwit/quickwit-config" }
-quickwit-search = { path = "../../quickwit/quickwit/quickwit-search" }
-quickwit-indexing = { path = "../../quickwit/quickwit/quickwit-indexing" }
-quickwit-doc-mapper = { path = "../../quickwit/quickwit/quickwit-doc-mapper" }
-quickwit-query = { path = "../../quickwit/quickwit/quickwit-query" }
+quickwit-storage = { git = "https://github.com/indextables/quickwit", rev = "7af2361e", features = ["azure"] }
+quickwit-metastore = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-proto = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-directories = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-common = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-config = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-search = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-indexing = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-doc-mapper = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
+quickwit-query = { git = "https://github.com/indextables/quickwit", rev = "7af2361e" }
 
 # Additional dependencies
 anyhow = "1.0"
@@ -62,8 +63,8 @@ async-trait = "0.1"  # For Storage trait implementation
 aws-sdk-s3 = "=1.62"  # For streaming file uploads (PutPayload implementation)
 
 # Tantivy sub-crates for direct columnar serialization (bypass ColumnarWriter for string fast fields)
-sstable = { path = "../../tantivy/sstable", package = "tantivy-sstable" }
-common = { path = "../../tantivy/common", package = "tantivy-common" }
+sstable = { git = "https://github.com/indextables/tantivy", rev = "4b6d7d49", package = "tantivy-sstable" }
+common = { git = "https://github.com/indextables/tantivy", rev = "4b6d7d49", package = "tantivy-common" }
 
 # Parquet companion mode - enables minimal splits referencing external parquet files
 parquet = { version = "57", default-features = false, features = ["async", "arrow", "zstd", "lz4", "snap", "flate2", "flate2-rust_backened"] }
@@ -89,12 +90,10 @@ iceberg-catalog-hms = "0.8"
 [build-dependencies]
 jni = "0.21.1"
 
-# Patch to redirect ALL tantivy references to local fork (for pub mod iterable and direct columnar APIs)
+# Patch to redirect quickwit-oss tantivy references to indextables fork (for pub mod iterable and direct columnar APIs)
+# Note: [patch."indextables/tantivy"] is not needed since the main tantivy dep already points there
 [patch."https://github.com/quickwit-oss/tantivy/"]
-tantivy = { path = "../../tantivy" }
-
-[patch."https://github.com/indextables/tantivy/"]
-tantivy = { path = "../../tantivy" }
+tantivy = { git = "https://github.com/indextables/tantivy", rev = "4b6d7d49" }
 
 # Debug symbols configuration for maximum debug information
 [profile.dev]


### PR DESCRIPTION
## Summary

- Replace all local `path = "../../quickwit/..."` and `path = "../../tantivy/..."` dependencies with pinned git references to the indextables forks on GitHub
- Quickwit crates pinned to `indextables/quickwit` at rev `7af2361e` (fix/zero_copy branch)
- Tantivy + sub-crates (sstable, common) pinned to `indextables/tantivy` at rev `4b6d7d49`
- Removed redundant `[patch."indextables/tantivy"]` section (was self-referencing with git deps)
- Kept `[patch."quickwit-oss/tantivy"]` to redirect quickwit's internal tantivy references

This enables building from a clean clone without requiring local checkouts of the quickwit and tantivy forks.

## Test plan

- [x] `cargo check` passes with all git dependencies resolved
- [ ] Full `cargo build` on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)