### PR TITLE
Exclude cloud/Docker integration tests from default test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,8 @@ MVN := mvn
 # ---------------------------------------------------------------------------
 # Targets
 # ---------------------------------------------------------------------------
-# Integration test patterns (cloud/Docker tests excluded from default run)
-INTEGRATION_EXCLUDES = **/Real*Test.java,**/AzureIntegrationTest.java,**/AzureOAuthTokenTest.java
-INTEGRATION_INCLUDES = **/Real*Test.java,**/AzureIntegrationTest.java,**/AzureOAuthTokenTest.java
+# Integration test class patterns for -Dtest (simple class name globs, not ANT paths)
+INTEGRATION_TESTS = Real*Test,AzureIntegrationTest,AzureOAuthTokenTest
 
 .PHONY: help setup compile test test-cloud test-all package clean
 
@@ -33,7 +32,7 @@ test: ## Run unit tests (excludes cloud/Docker integration tests)
 	$(MVN) test
 
 test-cloud: ## Run cloud/Docker integration tests only (requires credentials/Docker)
-	$(MVN) test -Dtest="$(INTEGRATION_INCLUDES)" -DfailIfNoTests=false
+	$(MVN) test -Dtest="$(INTEGRATION_TESTS)" -DfailIfNoTests=false
 
 test-all: ## Run all tests (unit + cloud/Docker integration)
 	$(MVN) test -Pintegration-tests

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,15 @@ MVN := mvn
 # ---------------------------------------------------------------------------
 # Targets
 # ---------------------------------------------------------------------------
-.PHONY: help setup compile test package clean
+# Integration test patterns (cloud/Docker tests excluded from default run)
+INTEGRATION_EXCLUDES = **/Real*Test.java,**/AzureIntegrationTest.java,**/AzureOAuthTokenTest.java
+INTEGRATION_INCLUDES = **/Real*Test.java,**/AzureIntegrationTest.java,**/AzureOAuthTokenTest.java
+
+.PHONY: help setup compile test test-cloud test-all package clean
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 setup: ## Install/verify development dependencies (Java 11, Maven, Rust, protoc)
 	./scripts/setup.sh
@@ -25,8 +29,14 @@ setup: ## Install/verify development dependencies (Java 11, Maven, Rust, protoc)
 compile: ## Compile sources (Java + Rust native via cargo)
 	$(MVN) clean compile
 
-test: ## Run JUnit 5 tests
+test: ## Run unit tests (excludes cloud/Docker integration tests)
 	$(MVN) test
+
+test-cloud: ## Run cloud/Docker integration tests only (requires credentials/Docker)
+	$(MVN) test -Dtest="$(INTEGRATION_INCLUDES)" -DfailIfNoTests=false
+
+test-all: ## Run all tests (unit + cloud/Docker integration)
+	$(MVN) test -Pintegration-tests
 
 package: ## Build JAR, skip tests (mvn clean package -DskipTests)
 	$(MVN) clean package -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,13 @@
                     <forkCount>1</forkCount>
                     <!-- Set test execution order to be predictable -->
                     <runOrder>filesystem</runOrder>
+                    <!-- Exclude cloud/Docker integration tests by default.
+                         Run with: mvn test -Pintegration-tests -->
+                    <excludes>
+                        <exclude>**/Real*Test.java</exclude>
+                        <exclude>**/AzureIntegrationTest.java</exclude>
+                        <exclude>**/AzureOAuthTokenTest.java</exclude>
+                    </excludes>
                     <!-- Enable native access for JNI operations (Java 17+ only; see jdk17plus profile) -->
                     <argLine>${surefire.argLine}</argLine>
                 </configuration>
@@ -556,6 +563,23 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <tokenAuth>true</tokenAuth>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Integration tests profile - includes cloud/Docker tests excluded by default.
+             Activate with: mvn test -Pintegration-tests -->
+        <profile>
+            <id>integration-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override" />
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary

- Exclude `Real*Test` (S3/Azure credentials) and Azurite-based tests (Docker) from default `mvn test`
- Add `integration-tests` Maven profile to include them
- Add Makefile targets:
  - `make test` — unit tests only (default)
  - `make test-cloud` — cloud/Docker integration tests only
  - `make test-all` — everything

## Test plan

- [ ] `make test` passes without Docker/credentials
- [ ] `make test-all` includes integration tests