### PR TITLE
Add Linux version script for JNI symbol visibility

### DIFF
--- a/native/tantivy4java.version
+++ b/native/tantivy4java.version
@@ -1,0 +1,14 @@
+# Linux version script for tantivy4java shared library
+# This script controls symbol visibility, only exporting JNI methods
+# Usage: rustc -C link-args="-Wl,--version-script=tantivy4java.version"
+
+# Version block defines what symbols to export
+TANTIVY4JAVA_1.0 {
+    global:
+        # Export all JNI methods (Java_ prefixed functions)
+        Java_*;
+
+    local:
+        # Hide all other symbols
+        *;
+};


### PR DESCRIPTION
## Summary
- Commits the `native/tantivy4java.version` linker script that was missing from the repo
- The `build.rs` already references this file but it wasn't tracked, causing the warning: `Linux version script not found, all symbols will be exported`
- Limits exported symbols to `Java_*` JNI entry points, hiding all internal Rust/C symbols

## Why
- Prevents symbol collisions with other native libraries loaded in the same JVM process
- Reduces `.so` export table size
- Matches macOS behavior where symbol visibility is already restricted

## Test plan
- [ ] Verify Linux build no longer emits the `version script not found` warning
- [ ] Verify JNI methods are still exported: `nm -D libtantivy4java.so | grep Java_`
- [ ] Verify internal symbols are hidden: `nm -D libtantivy4java.so | grep -v Java_ | wc -l` should be minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)