### PR TITLE
Fix Range bucket aggregation missing nested Terms flattening

### DIFF
--- a/native/src/split_searcher/aggregation_arrow_ffi.rs
+++ b/native/src/split_searcher/aggregation_arrow_ffi.rs
@@ -241,6 +241,11 @@ fn bucket_to_record_batch(
     is_date_histogram: bool,
     hash_resolution_map: Option<&HashMap<u64, String>>,
 ) -> Result<RecordBatch> {
+    crate::debug_println!("BUCKET_TO_BATCH: variant={}", match bucket {
+        BucketResult::Terms { .. } => "Terms",
+        BucketResult::Histogram { .. } => "Histogram",
+        BucketResult::Range { .. } => "Range",
+    });
     match bucket {
         BucketResult::Terms { buckets, .. } => terms_to_record_batch(buckets, hash_resolution_map),
         BucketResult::Histogram { buckets } => {
@@ -402,12 +407,22 @@ fn date_histogram_to_record_batch(
 
 fn range_to_record_batch(
     buckets: &BucketEntries<RangeBucketEntry>,
-    _hash_resolution_map: Option<&HashMap<u64, String>>,
+    hash_resolution_map: Option<&HashMap<u64, String>>,
 ) -> Result<RecordBatch> {
     let entries: Vec<&RangeBucketEntry> = match buckets {
         BucketEntries::Vec(v) => v.iter().collect(),
         BucketEntries::HashMap(m) => m.values().collect(),
     };
+
+    // Check for nested bucket sub-aggregation (e.g., Range → nested Terms GROUP BY)
+    crate::debug_println!("RANGE_AGG: {} range entries, first sub_agg keys: {:?}",
+        entries.len(),
+        entries.first().map(|b| b.sub_aggregation.0.keys().collect::<Vec<_>>()));
+    if let Some(nested) = find_nested_bucket_sub_agg(entries.first().map(|b| &b.sub_aggregation)) {
+        crate::debug_println!("RANGE_AGG: Found nested bucket sub-agg '{}', flattening", nested.0);
+        return flatten_nested_bucket_range(&entries, &nested.0, &nested.1, hash_resolution_map);
+    }
+    crate::debug_println!("RANGE_AGG: No nested bucket sub-agg, using flat range schema");
 
     let sub_agg_names = collect_metric_sub_agg_names(
         entries.first().map(|b| &b.sub_aggregation),
@@ -445,6 +460,113 @@ fn range_to_record_batch(
     }
 
     RecordBatch::try_new(schema, columns).context("Failed to create Range RecordBatch")
+}
+
+/// Flatten Range → nested Terms into cross-product rows.
+/// key_0 is Utf8 (range bucket name), remaining key_1..key_N-1 are Utf8 from nested Terms.
+fn flatten_nested_bucket_range(
+    outer_entries: &[&RangeBucketEntry],
+    _nested_name: &str,
+    _nested_template: &BucketResult,
+    hash_resolution_map: Option<&HashMap<u64, String>>,
+) -> Result<RecordBatch> {
+    let first_inner: Vec<BucketEntry> = outer_entries
+        .first()
+        .and_then(|e| {
+            e.sub_aggregation.0.values().find_map(|r| match r {
+                AggregationResult::BucketResult(b) => {
+                    Some(extract_inner_buckets(b).into_iter().cloned().collect::<Vec<_>>())
+                }
+                _ => None,
+            })
+        })
+        .unwrap_or_default();
+
+    let inner_depth = if first_inner.is_empty() {
+        1
+    } else {
+        count_nesting_depth(&first_inner)
+    };
+    let total_key_cols = 1 + inner_depth; // outer range key + inner Terms keys
+    let metric_names = if first_inner.is_empty() {
+        Vec::new()
+    } else {
+        find_leaf_metric_names(&first_inner)
+    };
+
+    // Build schema: key_0 (range name, Utf8), key_1..key_N-1 (Utf8), doc_count, metrics...
+    let mut fields = vec![Field::new("key_0", DataType::Utf8, false)];
+    for i in 1..total_key_cols {
+        fields.push(Field::new(format!("key_{}", i), DataType::Utf8, false));
+    }
+    fields.push(Field::new("doc_count", DataType::Int64, false));
+    for name in &metric_names {
+        fields.push(Field::new(name, DataType::Float64, true));
+    }
+    let schema = Arc::new(Schema::new(fields));
+
+    // Collect rows
+    let mut key_0_values: Vec<String> = Vec::new();
+    let mut inner_key_columns: Vec<Vec<String>> = (0..inner_depth).map(|_| Vec::new()).collect();
+    let mut doc_count_values: Vec<i64> = Vec::new();
+    let mut metric_values: Vec<Vec<Option<f64>>> =
+        metric_names.iter().map(|_| Vec::new()).collect();
+
+    for outer in outer_entries {
+        let inner_buckets: Vec<BucketEntry> = outer
+            .sub_aggregation
+            .0
+            .values()
+            .find_map(|r| match r {
+                AggregationResult::BucketResult(b) => {
+                    Some(extract_inner_buckets(b).into_iter().cloned().collect::<Vec<_>>())
+                }
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        let mut inner_keys: Vec<Vec<String>> = (0..inner_depth).map(|_| Vec::new()).collect();
+        let mut inner_docs: Vec<i64> = Vec::new();
+        let mut inner_metrics: Vec<Vec<Option<f64>>> =
+            metric_names.iter().map(|_| Vec::new()).collect();
+
+        collect_nested_rows(
+            &inner_buckets,
+            &[],
+            inner_depth,
+            &metric_names,
+            &mut inner_keys,
+            &mut inner_docs,
+            &mut inner_metrics,
+            hash_resolution_map,
+        );
+
+        let num_inner_rows = inner_docs.len();
+        for _ in 0..num_inner_rows {
+            key_0_values.push(key_to_string(&outer.key));
+        }
+        for (col_idx, col) in inner_keys.into_iter().enumerate() {
+            inner_key_columns[col_idx].extend(col);
+        }
+        doc_count_values.extend(inner_docs);
+        for (i, vals) in inner_metrics.into_iter().enumerate() {
+            metric_values[i].extend(vals);
+        }
+    }
+
+    let mut columns: Vec<Arc<dyn arrow_array::Array>> = vec![
+        Arc::new(StringArray::from(key_0_values)),
+    ];
+    for col in inner_key_columns {
+        columns.push(Arc::new(StringArray::from(col)));
+    }
+    columns.push(Arc::new(Int64Array::from(doc_count_values)));
+    for vals in &metric_values {
+        columns.push(Arc::new(Float64Array::from(vals.clone())));
+    }
+
+    RecordBatch::try_new(schema, columns)
+        .context("Failed to create flattened nested Range RecordBatch")
 }
 
 // ---- FR-2: Nested Bucket Sub-Aggregation Flattening ----


### PR DESCRIPTION
## Summary

Fixes `CompanionBucketAggHashBugTest` Range + GROUP BY failures (tantivy4java#135).

`range_to_record_batch` was the only bucket aggregation function that didn't check for nested bucket sub-aggregations. While `terms_to_record_batch` and `histogram_to_record_batch` both call `find_nested_bucket_sub_agg` and flatten nested Terms chains, `range_to_record_batch` skipped this entirely.

**Changes:**
- Added nested bucket detection to `range_to_record_batch`
- Added `flatten_nested_bucket_range()` following the same pattern as `flatten_nested_bucket_histogram()`
- Hash resolution map is now properly threaded through for string field resolution
- Added debug logging to trace Range aggregation path

**Status:** The fix addresses the missing flattening logic. However, the Range tests may also involve the Spark-side `GroupByAggregateColumnarReader` constructing the aggregation JSON differently than expected. Debug logging is included to help diagnose if the Range path is actually reached. If the Spark planner decomposes Range + GROUP BY into a different aggregation structure, the fix may need to be on both sides.

## Test plan

- [x] 805 Rust tests pass
- [ ] `CompanionBucketAggHashBugTest` Range tests (need executor-level `TANTIVY4JAVA_DEBUG=1` to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)