### PR TITLE
Fix concurrent auto-checkpoint race condition losing file entries

### DIFF
--- a/native/src/txlog/distributed.rs
+++ b/native/src/txlog/distributed.rs
@@ -676,7 +676,11 @@ pub async fn maybe_auto_checkpoint(
     let metadata = version_metadata.or(cp_metadata).unwrap_or_else(MetadataAction::empty);
 
     // Full checkpoint: state dir + _last_checkpoint (every write)
-    match write_checkpoint(table_path, config, replay_result.files, metadata, protocol).await {
+    // Use written_version (not list_versions().last()) to avoid a race where
+    // a concurrent write advances the version but our replay only covers up to
+    // written_version. Using list_versions().last() would create a checkpoint
+    // that claims a higher version than its contents actually cover.
+    match write_checkpoint_at_version(table_path, config, replay_result.files, metadata, protocol, written_version).await {
         Ok(cp_info) => {
             debug_println!("✅ DISTRIBUTED: checkpoint at v{}, {:?} files",
                 cp_info.version, cp_info.num_files);
@@ -708,6 +712,31 @@ pub async fn write_checkpoint(
     ).await?;
 
     // Invalidate cache after checkpoint write
+    cache::invalidate_table_cache(table_path);
+    Ok(result)
+}
+
+/// Create an Avro state checkpoint at a specific version.
+/// Used by auto-checkpoint to avoid a race where list_versions().last() advances
+/// past the version that was actually replayed.
+pub async fn write_checkpoint_at_version(
+    table_path: &str,
+    config: &DeltaStorageConfig,
+    entries: Vec<FileEntry>,
+    metadata: MetadataAction,
+    protocol: ProtocolAction,
+    version: i64,
+) -> Result<LastCheckpointInfo> {
+    let storage = TxLogStorage::new(table_path, config)?;
+
+    let result = super::avro::state_writer::write_state_checkpoint(
+        &storage,
+        version,
+        &entries,
+        &protocol,
+        &metadata,
+    ).await?;
+
     cache::invalidate_table_cache(table_path);
     Ok(result)
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.33.2</version>
+    <version>0.33.3</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>


### PR DESCRIPTION
## Summary

Fixes a transient race condition where concurrent writes cause auto-checkpoint to create a checkpoint with a version number higher than its contents cover, leading to missing file entries on subsequent reads.

## Root Cause

`maybe_auto_checkpoint` replays version files up to `written_version` to build the checkpoint state. But `write_checkpoint` determined the checkpoint version from `list_versions().last()`, which can advance due to concurrent writes.

**Race sequence:**
1. Write v1 completes → starts auto-checkpoint, replays v0+v1
2. Write v2 completes (version file now exists on disk)
3. v1's auto-checkpoint calls `write_checkpoint` → `list_versions().last()` returns **v2**
4. Checkpoint written at **v2** but only contains v0+v1 entries (v2 was not replayed)
5. Reader sees checkpoint v2, no post-checkpoint versions → returns only 200 records instead of 300

## Fix

Added `write_checkpoint_at_version()` which accepts an explicit version number. `maybe_auto_checkpoint` now passes `written_version` instead of relying on `list_versions().last()`.

If a concurrent write creates version N+1 while we checkpoint at N, the N+1 entries correctly appear as post-checkpoint changes and are included in the next snapshot read.

Also bumps version to 0.33.3.

## Test plan

- [x] 189 Rust txlog tests pass
- [x] Reproduces with `CloudAzurePostCommitMergeOnWriteTest` (transient — fails when two auto-checkpoints overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)