### PR TITLE
Fix flaky disk cache tests by replacing thread::sleep with flush_blocking

### DIFF
--- a/native/src/disk_cache/tests.rs
+++ b/native/src/disk_cache/tests.rs
@@ -3,8 +3,6 @@
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use tempfile::TempDir;
 
     use super::super::*;
@@ -79,7 +77,7 @@ mod tests {
         let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
 
         cache.put("s3://bucket/path", "split-001", "term", None, &data);
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         let retrieved = cache.get("s3://bucket/path", "split-001", "term", None);
         assert!(retrieved.is_some());
@@ -96,7 +94,7 @@ mod tests {
         let range = Some(0u64..5000u64);
 
         cache.put("s3://bucket", "split-002", "idx", range.clone(), &data);
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         let retrieved = cache.get("s3://bucket", "split-002", "idx", range);
         assert!(retrieved.is_some());
@@ -115,20 +113,20 @@ mod tests {
 
         let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
         cache.put("s3://bucket", "split-001", "term", None, &data);
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         assert!(cache.get_total_bytes() > 0);
         assert_eq!(cache.get_split_count(), 1);
         assert_eq!(cache.get_component_count(), 1);
 
         cache.put("s3://bucket", "split-001", "idx", None, &data);
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         assert_eq!(cache.get_split_count(), 1);
         assert_eq!(cache.get_component_count(), 2);
 
         cache.put("s3://bucket", "split-002", "term", None, &data);
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         assert_eq!(cache.get_split_count(), 2);
         assert_eq!(cache.get_component_count(), 3);
@@ -145,14 +143,14 @@ mod tests {
         cache.put("s3://bucket", "split-001", "term", None, &data);
         cache.put("s3://bucket", "split-001", "idx", None, &data);
         cache.put("s3://bucket", "split-002", "term", None, &data);
-        std::thread::sleep(Duration::from_millis(150));
+        cache.flush_blocking();
 
         assert_eq!(cache.get_split_count(), 2);
         assert_eq!(cache.get_component_count(), 3);
         let bytes_before = cache.get_total_bytes();
 
         cache.evict_split("s3://bucket", "split-001");
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         assert_eq!(cache.get_split_count(), 1);
         assert_eq!(cache.get_component_count(), 1);
@@ -177,7 +175,7 @@ mod tests {
         let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
 
         cache.put("s3://bucket", "split-001", "term", None, &data);
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         let retrieved = cache.get("s3://bucket", "split-001", "term", None);
         assert!(retrieved.is_some());
@@ -216,10 +214,10 @@ mod tests {
             let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
             cache.put("s3://bucket", "split-001", "term", None, &data);
             cache.put("s3://bucket", "split-002", "idx", None, &data);
-            std::thread::sleep(Duration::from_millis(100));
+            cache.flush_blocking();
 
             cache.sync_manifest().unwrap();
-            std::thread::sleep(Duration::from_millis(100));
+            cache.flush_blocking();
         }
 
         let manifest_path = cache_path.join(CACHE_SUBDIR).join("manifest.json");
@@ -249,7 +247,7 @@ mod tests {
 
             let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
             cache.put("s3://bucket", "split-001", "term", None, &data);
-            std::thread::sleep(Duration::from_millis(100));
+            cache.flush_blocking();
             cache.sync_manifest().unwrap();
         }
 
@@ -290,10 +288,8 @@ mod tests {
 
         for i in 0..6 {
             cache.put("s3://bucket", &format!("split-{:03}", i), "term", None, &data);
-            std::thread::sleep(Duration::from_millis(50));
+            cache.flush_blocking();
         }
-
-        std::thread::sleep(Duration::from_millis(200));
 
         let total_bytes = cache.get_total_bytes();
         assert!(total_bytes <= 50000);
@@ -333,7 +329,7 @@ mod tests {
             handle.join().unwrap();
         }
 
-        std::thread::sleep(Duration::from_millis(200));
+        cache.flush_blocking();
 
         let mut read_handles = vec![];
         for i in 0..4 {
@@ -372,7 +368,7 @@ mod tests {
 
         cache.put("s3://bucket", "split-001", "idx", Some(0..5000), &data1);
         cache.put("s3://bucket", "split-001", "idx", Some(5000..10000), &data2);
-        std::thread::sleep(Duration::from_millis(100));
+        cache.flush_blocking();
 
         let r1 = cache.get("s3://bucket", "split-001", "idx", Some(0..5000));
         let r2 = cache.get("s3://bucket", "split-001", "idx", Some(5000..10000));
@@ -407,7 +403,7 @@ mod tests {
         cache.put("s3://bucket-a", "split-001", "term", None, &data);
         cache.put("s3://bucket-b", "split-001", "term", None, &data);
         cache.put("azure://container", "split-001", "term", None, &data);
-        std::thread::sleep(Duration::from_millis(150));
+        cache.flush_blocking();
 
         assert!(cache.get("s3://bucket-a", "split-001", "term", None).is_some());
         assert!(cache.get("s3://bucket-b", "split-001", "term", None).is_some());


### PR DESCRIPTION
## Summary
- Replace all `thread::sleep()` calls with `cache.flush_blocking()` in 12 older disk cache tests
- Remove unused `use std::time::Duration` import
- Add `flush_blocking()` after `sync_manifest()` in `test_manifest_persistence` to ensure manifest is written before assertion

## Problem
Under parallel test execution (`cargo test`), the older disk cache tests use `thread::sleep(100ms)` to wait for async background writes. When all 23 disk_cache tests run in parallel — each spawning its own tokio runtime with 18 worker threads (~414 OS threads total) — the sleep window is insufficient, causing random failures.

Not branch-specific — same failures reproduce on main.

## Fix
`flush_blocking()` deterministically waits for all pending writes by sending a Flush request through the write channel and blocking until the background writer signals completion. Unlike sleep, it waits exactly as long as needed — no more, no less. The newer write-queue-mode tests in the same file already use this pattern.

## Files changed
- `native/src/disk_cache/tests.rs` — test-only change, no production code modified

## Test plan
- [ ] `cargo test disk_cache` passes with default parallel execution
- [ ] `cargo test disk_cache -- --test-threads=1` still passes (sequential baseline)

🤖 Generated with [Claude Code](https://claude.ai/code)