### PR TITLE
Add single-field text_and_string indexing with native fast field support

### DIFF
--- a/docs/COMPACT_STRING_INDEXING_GUIDE.md
+++ b/docs/COMPACT_STRING_INDEXING_GUIDE.md
@@ -25,6 +25,7 @@ Similarly, log messages like `"Error processing request 550e8400-e29b-41d4-a716-
 | **Text UUID Strip** | `text_uuid_strip` | Strip UUIDs → "default" tokenizer text. UUIDs discarded. | Log messages where UUIDs aren't queryable |
 | **Text Custom Exactonly** | `text_custom_exactonly:<regex>` | Like UUID exactonly but with custom regex. | Custom patterns (SSNs, order IDs) |
 | **Text Custom Strip** | `text_custom_strip:<regex>` | Like UUID strip but with custom regex. | Strip custom patterns from text |
+| **Text and String** | `text_and_string` | Dual-field: raw Str (exact match/range) + `__text` companion (tokenized full-text search). | Fields needing both exact match and full-text search |
 
 UUID pattern used: `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}` (dashed only)
 
@@ -65,6 +66,7 @@ ParquetCompanionConfig config = new ParquetCompanionConfig(tableRoot)
 When a field has a compact indexing mode, the schema derivation creates different field types:
 
 - **`exact_only`**: Creates a single U64 field (indexed + fast) instead of a Str field
+- **`text_and_string`**: Creates a raw Str field `<name>` (indexed with raw tokenizer, `IndexRecordOption::Basic`) + a text Str field `<name>__text` (indexed with default tokenizer, `IndexRecordOption::WithFreqsAndPositions`). Neither field is stored or fast — in companion mode, storage comes from parquet and aggregations use hashed fast fields.
 - **`text_*_exactonly`**: Creates a Str field (with "default" tokenizer) + a U64 companion field `<name>__uuids`
 - **`text_*_strip`**: Creates a Str field (with "default" tokenizer) only
 
@@ -73,6 +75,7 @@ When a field has a compact indexing mode, the schema derivation creates differen
 During document indexing:
 
 - **`exact_only`**: Computes xxHash64 of the string value and stores it as U64
+- **`text_and_string`**: Indexes the original string value into both the raw field (whole-string, for exact match) and the `__text` companion field (tokenized, for full-text search). Text companion fields are pre-resolved once at split creation time for performance.
 - **`text_*_exactonly`**: Extracts regex matches, stores stripped text in the Str field, and stores xxHash64 of each match in the companion U64 field
 - **`text_*_strip`**: Strips regex matches and stores the cleaned text in the Str field
 
@@ -81,6 +84,9 @@ During document indexing:
 At query time, queries are automatically rewritten for compact string indexing:
 
 - **Term queries** on `exact_only`: The search term is hashed and the query targets the U64 field
+- **Term queries** on `text_and_string`: Not rewritten — term queries target the raw field for exact match
+- **Full-text queries** on `text_and_string`: Redirected to the `__text` companion field (the raw field uses the raw tokenizer and cannot perform tokenized search)
+- **Phrase queries** on `text_and_string`: Redirected to the `__text` companion field (the raw field stores `IndexRecordOption::Basic` with no positions)
 - **Term queries** on `text_*_exactonly`: If the search term contains a regex match (unanchored), the matched portion is extracted and hashed, and the query is redirected to the companion `__uuids` hash field. Non-matching terms query the text field directly.
 - **Term queries** on `text_*_strip`: No rewriting — queries hit the text field directly
 - **`parseQuery()` / full_text queries** on `exact_only`: Automatically converted to a hashed term query (the original text is preserved in the `full_text` AST node)
@@ -99,14 +105,14 @@ The existing hash-based aggregation pipeline handles compact indexing modes auto
 
 ## Querying Behavior
 
-| Query Type | `exact_only` | `text_*_exactonly` | `text_*_strip` |
-|-----------|-------------|-------------------|---------------|
-| **Term (exact)** | Hash match on U64 | Regex match → companion hash; else text search | Text search (stripped) |
-| **parseQuery / full_text** | Converted to hashed term | Regex match → companion hash; else text search | Text search (stripped) |
-| **Phrase** | Converted to hashed term | Regex match → companion hash; else stripped text | On stripped text |
-| **Wildcard** | **Blocked** (error) | On stripped text only | On stripped text |
-| **Regex** | **Blocked** (error) | On stripped text only | On stripped text |
-| **Exists** | U64 field presence | Text field presence | Text field presence |
+| Query Type | `exact_only` | `text_and_string` | `text_*_exactonly` | `text_*_strip` |
+|-----------|-------------|------------------|-------------------|---------------|
+| **Term (exact)** | Hash match on U64 | Raw field (exact match) | Regex match → companion hash; else text search | Text search (stripped) |
+| **parseQuery / full_text** | Converted to hashed term | Redirected to `__text` companion | Regex match → companion hash; else text search | Text search (stripped) |
+| **Phrase** | Converted to hashed term | Redirected to `__text` companion | Regex match → companion hash; else stripped text | On stripped text |
+| **Wildcard** | **Blocked** (error) | On `__text` companion | On stripped text only | On stripped text |
+| **Regex** | **Blocked** (error) | On `__text` companion | On stripped text only | On stripped text |
+| **Exists** | U64 field presence | Raw field presence | Text field presence | Text field presence |
 | **Range** | Not meaningful | On text field | On text field |
 | **Terms agg** | Via hash touchup | Text or companion depending on field | On text field |
 

--- a/native/src/parquet_companion/arrow_ffi_import.rs
+++ b/native/src/parquet_companion/arrow_ffi_import.rs
@@ -566,7 +566,6 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
     let string_hash_fields: HashMap<String, String> = HashMap::new();
     let string_indexing_modes: HashMap<String, StringIndexingMode> = HashMap::new();
     let compiled_regexes: HashMap<String, regex::Regex> = HashMap::new();
-    let text_companion_fields: HashMap<String, Field> = HashMap::new();
 
     let num_rows = batch.num_rows();
 
@@ -596,7 +595,6 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
                 &string_indexing_modes,
                 &compiled_regexes,
                 &prebuilt,
-                &text_companion_fields,
             )?;
             pw.writer.add_document(doc)?;
             pw.doc_count += 1;
@@ -657,7 +655,6 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
                     &string_indexing_modes,
                     &compiled_regexes,
                     &prebuilt,
-                    &text_companion_fields,
                 )?;
                 pw.writer.add_document(doc)?;
                 pw.doc_count += 1;
@@ -715,7 +712,6 @@ fn build_doc_from_arrow_row(
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
     prebuilt: &PrebuiltComplexColumns,
-    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<TantivyDocument> {
     let mut doc = TantivyDocument::new();
 
@@ -765,7 +761,6 @@ fn build_doc_from_arrow_row(
             accumulators,
             string_indexing_modes,
             compiled_regexes,
-            text_companion_fields,
         )?;
     }
 

--- a/native/src/parquet_companion/arrow_ffi_import.rs
+++ b/native/src/parquet_companion/arrow_ffi_import.rs
@@ -566,6 +566,7 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
     let string_hash_fields: HashMap<String, String> = HashMap::new();
     let string_indexing_modes: HashMap<String, StringIndexingMode> = HashMap::new();
     let compiled_regexes: HashMap<String, regex::Regex> = HashMap::new();
+    let text_companion_fields: HashMap<String, Field> = HashMap::new();
 
     let num_rows = batch.num_rows();
 
@@ -595,6 +596,7 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
                 &string_indexing_modes,
                 &compiled_regexes,
                 &prebuilt,
+                &text_companion_fields,
             )?;
             pw.writer.add_document(doc)?;
             pw.doc_count += 1;
@@ -655,6 +657,7 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
                     &string_indexing_modes,
                     &compiled_regexes,
                     &prebuilt,
+                    &text_companion_fields,
                 )?;
                 pw.writer.add_document(doc)?;
                 pw.doc_count += 1;
@@ -712,6 +715,7 @@ fn build_doc_from_arrow_row(
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
     prebuilt: &PrebuiltComplexColumns,
+    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<TantivyDocument> {
     let mut doc = TantivyDocument::new();
 
@@ -761,6 +765,7 @@ fn build_doc_from_arrow_row(
             accumulators,
             string_indexing_modes,
             compiled_regexes,
+            text_companion_fields,
         )?;
     }
 

--- a/native/src/parquet_companion/hash_field_rewriter.rs
+++ b/native/src/parquet_companion/hash_field_rewriter.rs
@@ -499,6 +499,9 @@ fn rewrite_string_indexing_node(
                     StringIndexingMode::TextUuidStrip | StringIndexingMode::TextCustomStrip { .. } => {
                         // No rewriting needed
                     }
+                    StringIndexingMode::TextAndString => {
+                        // No rewriting needed — queries target raw or text companion field directly
+                    }
                 }
             }
             Ok(false)

--- a/native/src/parquet_companion/hash_field_rewriter.rs
+++ b/native/src/parquet_companion/hash_field_rewriter.rs
@@ -23,7 +23,7 @@ use serde_json::{json, Value};
 
 use crate::parquet_companion::indexing::hash_string_value;
 use crate::parquet_companion::string_indexing::{
-    StringIndexingMode, companion_field_name, compile_regexes,
+    StringIndexingMode, companion_field_name, compile_regexes, text_companion_field_name,
 };
 
 /// Info needed to resolve hash bucket keys back to strings after aggregation (Phase 3).
@@ -550,6 +550,14 @@ fn rewrite_string_indexing_node(
                         }
                         // Non-matching text: leave as full_text on stripped text field
                     }
+                    StringIndexingMode::TextAndString => {
+                        // Redirect full_text queries to the tokenized __text companion field.
+                        // The primary field uses "raw" tokenizer (whole-string), so full_text
+                        // queries would not match individual tokens.
+                        let text_name = text_companion_field_name(&field);
+                        obj.insert("field".to_string(), Value::String(text_name));
+                        return Ok(true);
+                    }
                     _ => {} // strip modes: leave as-is
                 }
             }
@@ -616,6 +624,14 @@ fn rewrite_string_indexing_node(
                             }
                         }
                         // Non-matching: leave as phrase query on stripped text field
+                    }
+                    StringIndexingMode::TextAndString => {
+                        // Redirect phrase queries to the tokenized __text companion field.
+                        // The primary field uses IndexRecordOption::Basic (no positions),
+                        // so phrase queries cannot match.
+                        let text_name = text_companion_field_name(&field);
+                        obj.insert("field".to_string(), Value::String(text_name));
+                        return Ok(true);
                     }
                     _ => {} // strip modes: leave as-is
                 }
@@ -903,6 +919,7 @@ mod tests {
         m.insert("data".to_string(), StringIndexingMode::TextCustomExactonly {
             regex: r"\d{3}-\d{2}-\d{4}".to_string()
         });
+        m.insert("body".to_string(), StringIndexingMode::TextAndString);
         m
     }
 
@@ -1176,5 +1193,36 @@ mod tests {
         assert!(result.is_err(), "invalid regex should return Err");
         assert!(result.unwrap_err().to_string().contains("Invalid regex"),
             "error should mention invalid regex");
+    }
+
+    #[test]
+    fn test_string_indexing_text_and_string_full_text_redirected() {
+        let query = r#"{"type":"full_text","field":"body","text":"hello world","params":{}}"#;
+        let modes = make_string_indexing_modes();
+        let result = rewrite_query_for_string_indexing(query, &modes).unwrap();
+        assert!(result.is_some(), "full_text on TextAndString should be redirected");
+        let parsed: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(parsed["type"], "full_text");
+        assert_eq!(parsed["field"], "body__text");
+    }
+
+    #[test]
+    fn test_string_indexing_text_and_string_phrase_redirected() {
+        let query = r#"{"type":"phrase","field":"body","phrases":["hello","world"],"slop":0}"#;
+        let modes = make_string_indexing_modes();
+        let result = rewrite_query_for_string_indexing(query, &modes).unwrap();
+        assert!(result.is_some(), "phrase on TextAndString should be redirected");
+        let parsed: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(parsed["type"], "phrase");
+        assert_eq!(parsed["field"], "body__text");
+    }
+
+    #[test]
+    fn test_string_indexing_text_and_string_term_not_rewritten() {
+        let query = r#"{"type":"term","field":"body","value":"hello world"}"#;
+        let modes = make_string_indexing_modes();
+        let result = rewrite_query_for_string_indexing(query, &modes).unwrap();
+        // Term queries on TextAndString should NOT be rewritten — they target the raw field for exact match
+        assert!(result.is_none(), "term on TextAndString should not be rewritten");
     }
 }

--- a/native/src/parquet_companion/hash_field_rewriter.rs
+++ b/native/src/parquet_companion/hash_field_rewriter.rs
@@ -23,7 +23,7 @@ use serde_json::{json, Value};
 
 use crate::parquet_companion::indexing::hash_string_value;
 use crate::parquet_companion::string_indexing::{
-    StringIndexingMode, companion_field_name, compile_regexes, text_companion_field_name,
+    StringIndexingMode, companion_field_name, compile_regexes,
 };
 
 /// Info needed to resolve hash bucket keys back to strings after aggregation (Phase 3).
@@ -551,12 +551,7 @@ fn rewrite_string_indexing_node(
                         // Non-matching text: leave as full_text on stripped text field
                     }
                     StringIndexingMode::TextAndString => {
-                        // Redirect full_text queries to the tokenized __text companion field.
-                        // The primary field uses "raw" tokenizer (whole-string), so full_text
-                        // queries would not match individual tokens.
-                        let text_name = text_companion_field_name(&field);
-                        obj.insert("field".to_string(), Value::String(text_name));
-                        return Ok(true);
+                        // Single-field: the field uses "default" tokenizer, so full_text works directly.
                     }
                     _ => {} // strip modes: leave as-is
                 }
@@ -626,12 +621,7 @@ fn rewrite_string_indexing_node(
                         // Non-matching: leave as phrase query on stripped text field
                     }
                     StringIndexingMode::TextAndString => {
-                        // Redirect phrase queries to the tokenized __text companion field.
-                        // The primary field uses IndexRecordOption::Basic (no positions),
-                        // so phrase queries cannot match.
-                        let text_name = text_companion_field_name(&field);
-                        obj.insert("field".to_string(), Value::String(text_name));
-                        return Ok(true);
+                        // Single-field: has WithFreqsAndPositions, so phrase queries work directly.
                     }
                     _ => {} // strip modes: leave as-is
                 }
@@ -1196,25 +1186,19 @@ mod tests {
     }
 
     #[test]
-    fn test_string_indexing_text_and_string_full_text_redirected() {
+    fn test_string_indexing_text_and_string_full_text_not_rewritten() {
         let query = r#"{"type":"full_text","field":"body","text":"hello world","params":{}}"#;
         let modes = make_string_indexing_modes();
         let result = rewrite_query_for_string_indexing(query, &modes).unwrap();
-        assert!(result.is_some(), "full_text on TextAndString should be redirected");
-        let parsed: Value = serde_json::from_str(&result.unwrap()).unwrap();
-        assert_eq!(parsed["type"], "full_text");
-        assert_eq!(parsed["field"], "body__text");
+        assert!(result.is_none(), "full_text on TextAndString should not be rewritten");
     }
 
     #[test]
-    fn test_string_indexing_text_and_string_phrase_redirected() {
+    fn test_string_indexing_text_and_string_phrase_not_rewritten() {
         let query = r#"{"type":"phrase","field":"body","phrases":["hello","world"],"slop":0}"#;
         let modes = make_string_indexing_modes();
         let result = rewrite_query_for_string_indexing(query, &modes).unwrap();
-        assert!(result.is_some(), "phrase on TextAndString should be redirected");
-        let parsed: Value = serde_json::from_str(&result.unwrap()).unwrap();
-        assert_eq!(parsed["type"], "phrase");
-        assert_eq!(parsed["field"], "body__text");
+        assert!(result.is_none(), "phrase on TextAndString should not be rewritten");
     }
 
     #[test]
@@ -1222,7 +1206,6 @@ mod tests {
         let query = r#"{"type":"term","field":"body","value":"hello world"}"#;
         let modes = make_string_indexing_modes();
         let result = rewrite_query_for_string_indexing(query, &modes).unwrap();
-        // Term queries on TextAndString should NOT be rewritten — they target the raw field for exact match
         assert!(result.is_none(), "term on TextAndString should not be rewritten");
     }
 }

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -353,9 +353,6 @@ pub async fn create_split_from_parquet(
         string_hash_fields.len()
     );
 
-    // Single-field TextAndString has no companion fields to resolve.
-    let text_companion_fields: HashMap<String, Field> = HashMap::new();
-
     // ── Step 5: Build column mapping ─────────���──────────────────────────
     let mut column_mapping = build_column_mapping(&arrow_schema, &name_mapping, &parquet_metadata, &config);
 
@@ -564,7 +561,6 @@ pub async fn create_split_from_parquet(
                     &mut accumulators,
                     &string_indexing_modes,
                     &compiled_regexes,
-                    &text_companion_fields,
                 )?;
 
                 // Attach merge-safe parquet coordinates to each document
@@ -736,7 +732,6 @@ pub(crate) fn arrow_row_to_tantivy_doc(
     accumulators: &mut HashMap<String, StatisticsAccumulator>,
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
-    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<TantivyDocument> {
     let mut doc = TantivyDocument::new();
 
@@ -774,7 +769,6 @@ pub(crate) fn arrow_row_to_tantivy_doc(
             &mut doc, field, array, arrow_field.data_type(), row_idx,
             tantivy_field_name, config, string_hash_fields, tantivy_schema,
             accumulators, string_indexing_modes, compiled_regexes,
-            text_companion_fields,
         )?;
     }
 
@@ -798,7 +792,6 @@ pub(crate) fn add_arrow_value_to_doc(
     accumulators: &mut HashMap<String, StatisticsAccumulator>,
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
-    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<()> {
     match data_type {
         DataType::Boolean => {
@@ -899,7 +892,6 @@ pub(crate) fn add_arrow_value_to_doc(
             add_string_value_to_doc(
                 doc, field, val, field_name, config, string_hash_fields,
                 tantivy_schema, accumulators, string_indexing_modes, compiled_regexes,
-                text_companion_fields,
             )?;
         }
         DataType::LargeUtf8 => {
@@ -908,7 +900,6 @@ pub(crate) fn add_arrow_value_to_doc(
             add_string_value_to_doc(
                 doc, field, val, field_name, config, string_hash_fields,
                 tantivy_schema, accumulators, string_indexing_modes, compiled_regexes,
-                text_companion_fields,
             )?;
         }
 
@@ -1052,7 +1043,6 @@ pub(crate) fn add_string_value_to_doc(
     accumulators: &mut HashMap<String, StatisticsAccumulator>,
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
-    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<()> {
     if config.ip_address_fields.contains(field_name) {
         add_ip_addr_value(doc, field, val, field_name)?;

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -353,25 +353,8 @@ pub async fn create_split_from_parquet(
         string_hash_fields.len()
     );
 
-    // Pre-resolve text companion fields for TextAndString modes (avoids per-doc HashMap lookup + allocation)
-    let text_companion_fields: HashMap<String, Field> = {
-        let mut cache = HashMap::new();
-        for (field_name, mode) in &string_indexing_modes {
-            if matches!(mode, StringIndexingMode::TextAndString) {
-                let text_name = string_indexing::text_companion_field_name(field_name);
-                match tantivy_schema.get_field(&text_name) {
-                    Ok(f) => { cache.insert(field_name.clone(), f); }
-                    Err(_) => {
-                        debug_println!(
-                            "WARNING: TextAndString companion field '{}' not found in schema for field '{}'",
-                            text_name, field_name
-                        );
-                    }
-                }
-            }
-        }
-        cache
-    };
+    // Single-field TextAndString has no companion fields to resolve.
+    let text_companion_fields: HashMap<String, Field> = HashMap::new();
 
     // ── Step 5: Build column mapping ─────────���──────────────────────────
     let mut column_mapping = build_column_mapping(&arrow_schema, &name_mapping, &parquet_metadata, &config);
@@ -1117,12 +1100,9 @@ pub(crate) fn add_string_value_to_doc(
                 }
             }
             StringIndexingMode::TextAndString => {
-                // Primary field: raw string value
+                // Single field: tokenized by "default" for inverted index,
+                // stored raw in the fast field — both handled by tantivy automatically.
                 doc.add_text(field, val);
-                // Secondary field: tokenized text companion (resolved once at setup, not per-doc)
-                if let Some(&text_field) = text_companion_fields.get(field_name) {
-                    doc.add_text(text_field, val);
-                }
                 if let Some(acc) = accumulators.get_mut(field_name) {
                     acc.observe_string(val);
                 }
@@ -3471,19 +3451,14 @@ mod tests {
         writer.close().unwrap();
     }
 
-    /// Integration test: create a split with text_and_string indexing mode and verify
-    /// both exact (raw) and tokenized (default) searches work.
+    /// Integration test: single-field text_and_string — tokenized search + fast field retrieval.
     #[tokio::test]
     async fn test_create_split_with_text_and_string_indexing() {
         let temp_dir = tempfile::tempdir().unwrap();
         let parquet_path = temp_dir.path().join("tas.parquet");
         let output_path = temp_dir.path().join("tas.split");
 
-        let messages = &[
-            "the quick brown fox",
-            "hello world",
-            "the lazy dog sleeps",
-        ];
+        let messages = &["the quick brown fox", "hello world", "the lazy dog sleeps"];
         write_test_parquet_for_text_and_string(&parquet_path, messages);
 
         let mut tokenizer_overrides = HashMap::new();
@@ -3509,61 +3484,56 @@ mod tests {
         ).await.expect("text_and_string split creation should succeed");
 
         assert_eq!(result.metadata.num_docs, 3);
-        assert!(output_path.exists());
 
-        // Open the split and verify schema
         let (index, _bundle_dir) = crate::quickwit_split::split_utils::open_split_with_quickwit_native(
             output_path.to_str().unwrap()
         ).expect("Should open the created split");
 
         let schema = index.schema();
 
-        // Verify both fields exist
+        // Single field with default tokenizer + raw fast field
         let msg_field = schema.get_field("message").unwrap();
-        let msg_entry = schema.get_field_entry(msg_field);
-        assert!(
-            matches!(msg_entry.field_type(), tantivy::schema::FieldType::Str(_)),
-            "Primary field 'message' should be Str type, got {:?}", msg_entry.field_type()
-        );
+        match schema.get_field_entry(msg_field).field_type() {
+            tantivy::schema::FieldType::Str(text_opts) => {
+                assert_eq!(text_opts.get_indexing_options().unwrap().tokenizer(), "default");
+                assert!(text_opts.is_fast());
+            }
+            other => panic!("Expected Str, got {:?}", other),
+        }
+        assert!(schema.get_field("message__text").is_err());
 
-        let text_field = schema.get_field("message__text").unwrap();
-        let text_entry = schema.get_field_entry(text_field);
-        assert!(
-            matches!(text_entry.field_type(), tantivy::schema::FieldType::Str(_)),
-            "Companion field 'message__text' should be Str type, got {:?}", text_entry.field_type()
-        );
-
-        let reader = index.reader().expect("Should create reader");
-        reader.reload().expect("Should reload");
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
         let searcher = reader.searcher();
         assert_eq!(searcher.num_docs(), 3);
 
-        // Verify exact search on "message" field (raw tokenizer) finds results
-        let exact_term = tantivy::Term::from_field_text(msg_field, "the quick brown fox");
-        let exact_query = tantivy::query::TermQuery::new(exact_term, tantivy::schema::IndexRecordOption::Basic);
-        let exact_results = searcher.search(&exact_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
-        assert_eq!(exact_results.len(), 1,
-            "Exact search for 'the quick brown fox' on raw-tokenized 'message' should find 1 doc");
+        // Tokenized search on the single field
+        let quick_term = tantivy::Term::from_field_text(msg_field, "quick");
+        let quick_query = tantivy::query::TermQuery::new(quick_term, tantivy::schema::IndexRecordOption::WithFreqsAndPositions);
+        assert_eq!(searcher.search(&quick_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap().len(), 1);
 
-        // Verify tokenized search on "message__text" field (default tokenizer) finds results
-        let token_term = tantivy::Term::from_field_text(text_field, "quick");
-        let token_query = tantivy::query::TermQuery::new(token_term, tantivy::schema::IndexRecordOption::Basic);
-        let token_results = searcher.search(&token_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
-        assert_eq!(token_results.len(), 1,
-            "Tokenized search for 'quick' on default-tokenized 'message__text' should find 1 doc");
+        let the_term = tantivy::Term::from_field_text(msg_field, "the");
+        let the_query = tantivy::query::TermQuery::new(the_term, tantivy::schema::IndexRecordOption::WithFreqsAndPositions);
+        assert_eq!(searcher.search(&the_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap().len(), 2);
 
-        // Verify another tokenized search works
-        let the_term = tantivy::Term::from_field_text(text_field, "the");
-        let the_query = tantivy::query::TermQuery::new(the_term, tantivy::schema::IndexRecordOption::Basic);
-        let the_results = searcher.search(&the_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
-        assert_eq!(the_results.len(), 2,
-            "Tokenized search for 'the' on 'message__text' should find 2 docs (rows 0 and 2)");
+        // Fast field returns original untokenized strings
+        let segment_reader = searcher.segment_readers().first().unwrap();
+        let fast_field = segment_reader.fast_fields().str("message").unwrap().unwrap();
+        let mut fast_values: Vec<String> = Vec::new();
+        for doc_id in 0..segment_reader.num_docs() {
+            let mut output = String::new();
+            let ord = fast_field.term_ords(doc_id).next().unwrap();
+            fast_field.ord_to_str(ord, &mut output).unwrap();
+            fast_values.push(output);
+        }
+        assert!(fast_values.contains(&"the quick brown fox".to_string()));
+        assert!(fast_values.contains(&"hello world".to_string()));
+        assert!(fast_values.contains(&"the lazy dog sleeps".to_string()));
     }
 
     // ── TextAndString edge-case integration test ────────────────────────
 
-    /// Helper: create a parquet file with id (Int64), message (Utf8), and tag (Utf8)
-    /// columns for multi-column text_and_string edge-case tests.
+    /// Helper: create a parquet file with id, message, and tag columns.
     fn write_test_parquet_for_text_and_string_multi(
         path: &std::path::Path,
         messages: &[&str],
@@ -3574,16 +3544,13 @@ mod tests {
         use parquet::arrow::ArrowWriter;
         use std::sync::Arc;
 
-        assert_eq!(messages.len(), tags.len(), "messages and tags must have same length");
-
+        assert_eq!(messages.len(), tags.len());
         let schema = Arc::new(ArrowSchema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("message", DataType::Utf8, false),
             Field::new("tag", DataType::Utf8, false),
         ]));
-
         let ids: Vec<i64> = (0..messages.len()).map(|i| i as i64).collect();
-
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![
@@ -3592,30 +3559,21 @@ mod tests {
                 Arc::new(StringArray::from(tags.to_vec())),
             ],
         ).unwrap();
-
         let file = std::fs::File::create(path).unwrap();
         let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
     }
 
-    /// Integration test: text_and_string with multiple columns and empty strings.
+    /// Integration test: multi-column text_and_string with empty strings.
     #[tokio::test]
     async fn test_text_and_string_edge_cases() {
         let temp_dir = tempfile::tempdir().unwrap();
         let parquet_path = temp_dir.path().join("tas_edge.parquet");
         let output_path = temp_dir.path().join("tas_edge.split");
 
-        let messages = &[
-            "the quick brown fox",
-            "",
-            "hello world",
-        ];
-        let tags = &[
-            "animal",
-            "empty-message",
-            "",
-        ];
+        let messages = &["the quick brown fox", "", "hello world"];
+        let tags = &["animal", "empty-message", ""];
         write_test_parquet_for_text_and_string_multi(&parquet_path, messages, tags);
 
         let mut tokenizer_overrides = HashMap::new();
@@ -3639,70 +3597,173 @@ mod tests {
             output_path.to_str().unwrap(),
             &config,
             &storage,
-        ).await.expect("text_and_string multi-column split creation should succeed");
+        ).await.expect("edge case split creation should succeed");
 
         assert_eq!(result.metadata.num_docs, 3);
-        assert!(output_path.exists());
 
-        // Open the split and verify schema
         let (index, _bundle_dir) = crate::quickwit_split::split_utils::open_split_with_quickwit_native(
             output_path.to_str().unwrap()
         ).expect("Should open the created split");
 
         let schema = index.schema();
+        let msg_field = schema.get_field("message").unwrap();
+        let tag_field = schema.get_field("tag").unwrap();
+        assert!(schema.get_field("message__text").is_err());
+        assert!(schema.get_field("tag__text").is_err());
 
-        // Verify all four text_and_string fields exist
-        let msg_field = schema.get_field("message")
-            .expect("message field should exist");
-        let msg_text_field = schema.get_field("message__text")
-            .expect("message__text companion field should exist");
-        let tag_field = schema.get_field("tag")
-            .expect("tag field should exist");
-        let tag_text_field = schema.get_field("tag__text")
-            .expect("tag__text companion field should exist");
+        for (field, name) in [(msg_field, "message"), (tag_field, "tag")] {
+            match schema.get_field_entry(field).field_type() {
+                tantivy::schema::FieldType::Str(text_opts) => {
+                    assert_eq!(text_opts.get_indexing_options().unwrap().tokenizer(), "default",
+                        "{name} should use default tokenizer");
+                    assert!(text_opts.is_fast(), "{name} should have fast field");
+                }
+                other => panic!("{name}: expected Str, got {:?}", other),
+            }
+        }
 
-        // Verify field types
-        assert!(
-            matches!(schema.get_field_entry(msg_field).field_type(), tantivy::schema::FieldType::Str(_)),
-            "message should be Str type"
-        );
-        assert!(
-            matches!(schema.get_field_entry(msg_text_field).field_type(), tantivy::schema::FieldType::Str(_)),
-            "message__text should be Str type"
-        );
-        assert!(
-            matches!(schema.get_field_entry(tag_field).field_type(), tantivy::schema::FieldType::Str(_)),
-            "tag should be Str type"
-        );
-        assert!(
-            matches!(schema.get_field_entry(tag_text_field).field_type(), tantivy::schema::FieldType::Str(_)),
-            "tag__text should be Str type"
-        );
-
-        let reader = index.reader().expect("Should create reader");
-        reader.reload().expect("Should reload");
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
         let searcher = reader.searcher();
         assert_eq!(searcher.num_docs(), 3);
 
-        // Tokenized search for "quick" on message__text should find 1 doc
-        let quick_term = tantivy::Term::from_field_text(msg_text_field, "quick");
-        let quick_query = tantivy::query::TermQuery::new(quick_term, tantivy::schema::IndexRecordOption::Basic);
-        let quick_results = searcher.search(&quick_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
-        assert_eq!(quick_results.len(), 1,
-            "Tokenized search for 'quick' on message__text should find 1 doc");
+        let quick_term = tantivy::Term::from_field_text(msg_field, "quick");
+        let quick_query = tantivy::query::TermQuery::new(quick_term, tantivy::schema::IndexRecordOption::WithFreqsAndPositions);
+        assert_eq!(searcher.search(&quick_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap().len(), 1);
 
-        // Tokenized search for "animal" on tag__text should find 1 doc
-        let animal_term = tantivy::Term::from_field_text(tag_text_field, "animal");
-        let animal_query = tantivy::query::TermQuery::new(animal_term, tantivy::schema::IndexRecordOption::Basic);
-        let animal_results = searcher.search(&animal_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
-        assert_eq!(animal_results.len(), 1,
-            "Tokenized search for 'animal' on tag__text should find 1 doc");
+        let animal_term = tantivy::Term::from_field_text(tag_field, "animal");
+        let animal_query = tantivy::query::TermQuery::new(animal_term, tantivy::schema::IndexRecordOption::WithFreqsAndPositions);
+        assert_eq!(searcher.search(&animal_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap().len(), 1);
 
-        // Exact search for "" (empty string) on message field should find 1 doc (row 1)
+        // Empty string produces no tokens with default tokenizer
         let empty_term = tantivy::Term::from_field_text(msg_field, "");
-        let empty_query = tantivy::query::TermQuery::new(empty_term, tantivy::schema::IndexRecordOption::Basic);
-        let empty_results = searcher.search(&empty_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
-        assert_eq!(empty_results.len(), 1,
-            "Exact search for empty string on 'message' should find 1 doc (the empty-message row)");
+        let empty_query = tantivy::query::TermQuery::new(empty_term, tantivy::schema::IndexRecordOption::WithFreqsAndPositions);
+        assert_eq!(searcher.search(&empty_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap().len(), 0);
+    }
+
+    /// PhraseQuery(slop=0) on "New York" also matches "New York City" — this is the expected
+    /// false positive that Spark post-filters away. Verifies the core trade-off of the
+    /// single-field approach.
+    #[tokio::test]
+    async fn test_text_and_string_phrase_query_false_positives() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let parquet_path = temp_dir.path().join("tas_fp.parquet");
+        let output_path = temp_dir.path().join("tas_fp.split");
+
+        let messages = &[
+            "New York",
+            "New York City",
+            "York New",          // wrong order — should NOT match
+            "New Jersey",        // different second token — should NOT match
+            "I love New York!",  // "new york" at positions 2,3 — WILL match (false positive)
+        ];
+        write_test_parquet_for_text_and_string(&parquet_path, messages);
+
+        let mut tokenizer_overrides = HashMap::new();
+        tokenizer_overrides.insert("message".to_string(), "text_and_string".to_string());
+
+        let config = CreateFromParquetConfig {
+            table_root: temp_dir.path().to_string_lossy().to_string(),
+            schema_config: SchemaDerivationConfig {
+                tokenizer_overrides,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let storage: Arc<dyn quickwit_storage::Storage> =
+            Arc::new(quickwit_storage::RamStorage::default());
+
+        create_split_from_parquet(
+            &[parquet_path.to_string_lossy().to_string()],
+            output_path.to_str().unwrap(),
+            &config,
+            &storage,
+        ).await.unwrap();
+
+        let (index, _bundle_dir) = crate::quickwit_split::split_utils::open_split_with_quickwit_native(
+            output_path.to_str().unwrap()
+        ).unwrap();
+
+        let msg_field = index.schema().get_field("message").unwrap();
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        let searcher = reader.searcher();
+
+        // PhraseQuery for "new york" (slop=0): matches docs where "new" is immediately followed by "york"
+        let phrase_query = tantivy::query::PhraseQuery::new(vec![
+            tantivy::Term::from_field_text(msg_field, "new"),
+            tantivy::Term::from_field_text(msg_field, "york"),
+        ]);
+        let results = searcher.search(&phrase_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
+
+        // Should match: "New York" (exact), "New York City" (prefix), "I love New York!" (contains)
+        // Should NOT match: "York New" (wrong order), "New Jersey" (different token)
+        assert_eq!(results.len(), 3, "PhraseQuery should match 3 docs (1 exact + 2 false positives)");
+    }
+
+    /// Fast field correctly stores values with punctuation that the default tokenizer splits.
+    #[tokio::test]
+    async fn test_text_and_string_punctuation_in_fast_field() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let parquet_path = temp_dir.path().join("tas_punct.parquet");
+        let output_path = temp_dir.path().join("tas_punct.split");
+
+        let messages = &[
+            "user@example.com",
+            "https://google.com/search?q=test",
+            "hello-world_v2.0",
+        ];
+        write_test_parquet_for_text_and_string(&parquet_path, messages);
+
+        let mut tokenizer_overrides = HashMap::new();
+        tokenizer_overrides.insert("message".to_string(), "text_and_string".to_string());
+
+        let config = CreateFromParquetConfig {
+            table_root: temp_dir.path().to_string_lossy().to_string(),
+            schema_config: SchemaDerivationConfig {
+                tokenizer_overrides,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let storage: Arc<dyn quickwit_storage::Storage> =
+            Arc::new(quickwit_storage::RamStorage::default());
+
+        create_split_from_parquet(
+            &[parquet_path.to_string_lossy().to_string()],
+            output_path.to_str().unwrap(),
+            &config,
+            &storage,
+        ).await.unwrap();
+
+        let (index, _bundle_dir) = crate::quickwit_split::split_utils::open_split_with_quickwit_native(
+            output_path.to_str().unwrap()
+        ).unwrap();
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        let searcher = reader.searcher();
+
+        // Tokenized search finds "google" inside the URL
+        let msg_field = index.schema().get_field("message").unwrap();
+        let google_term = tantivy::Term::from_field_text(msg_field, "google");
+        let google_query = tantivy::query::TermQuery::new(google_term, tantivy::schema::IndexRecordOption::WithFreqsAndPositions);
+        assert_eq!(searcher.search(&google_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap().len(), 1);
+
+        // Fast field returns the original string with all punctuation intact
+        let segment_reader = searcher.segment_readers().first().unwrap();
+        let fast_field = segment_reader.fast_fields().str("message").unwrap().unwrap();
+        let mut fast_values: Vec<String> = Vec::new();
+        for doc_id in 0..segment_reader.num_docs() {
+            let mut output = String::new();
+            let ord = fast_field.term_ords(doc_id).next().unwrap();
+            fast_field.ord_to_str(ord, &mut output).unwrap();
+            fast_values.push(output);
+        }
+        assert!(fast_values.contains(&"user@example.com".to_string()));
+        assert!(fast_values.contains(&"https://google.com/search?q=test".to_string()));
+        assert!(fast_values.contains(&"hello-world_v2.0".to_string()));
     }
 }

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -1594,21 +1594,30 @@ fn build_column_mapping(
             arrow_type_to_tantivy_type(arrow_field.data_type()).to_string()
         };
 
-        // For Str columns, record the fast field tokenizer.
-        // Defaults to "raw" for text fields (no tokenization in fast field).
+        // For Str columns, record the fast field tokenizer used during parquet transcoding.
+        // TextAndString fields have native fast data (from set_fast(Some("raw")) in schema_derivation),
+        // so they don't need parquet transcoding — set fast_field_tokenizer to None.
+        // All other Str columns need transcoding and default to "raw" tokenizer.
         let fast_field_tokenizer = if tantivy_type_str == "Str" {
-            let tok = config.tokenizer_overrides
+            let mode = config.tokenizer_overrides
                 .get(&tantivy_field_name)
-                .cloned()
-                .unwrap_or_else(|| "raw".to_string());
-            // Normalize string indexing mode keywords to their actual primary tokenizer.
-            // text_and_string and exact_only both use "raw" as their primary tokenizer;
-            // the mode keyword itself is not a valid tantivy tokenizer name.
-            let tok = match tok.as_str() {
-                "text_and_string" | "exact_only" => "raw".to_string(),
-                _ => tok,
-            };
-            Some(tok)
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            if mode == "text_and_string" {
+                // TextAndString has native fast data — no transcoding needed
+                None
+            } else {
+                let tok = config.tokenizer_overrides
+                    .get(&tantivy_field_name)
+                    .cloned()
+                    .unwrap_or_else(|| "raw".to_string());
+                // Normalize string indexing mode keywords to their actual primary tokenizer.
+                let tok = match tok.as_str() {
+                    "exact_only" => "raw".to_string(),
+                    _ => tok,
+                };
+                Some(tok)
+            }
         } else {
             None
         };

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -353,7 +353,27 @@ pub async fn create_split_from_parquet(
         string_hash_fields.len()
     );
 
-    // ── Step 5: Build column mapping ────────────────────────────────────
+    // Pre-resolve text companion fields for TextAndString modes (avoids per-doc HashMap lookup + allocation)
+    let text_companion_fields: HashMap<String, Field> = {
+        let mut cache = HashMap::new();
+        for (field_name, mode) in &string_indexing_modes {
+            if matches!(mode, StringIndexingMode::TextAndString) {
+                let text_name = string_indexing::text_companion_field_name(field_name);
+                match tantivy_schema.get_field(&text_name) {
+                    Ok(f) => { cache.insert(field_name.clone(), f); }
+                    Err(_) => {
+                        debug_println!(
+                            "WARNING: TextAndString companion field '{}' not found in schema for field '{}'",
+                            text_name, field_name
+                        );
+                    }
+                }
+            }
+        }
+        cache
+    };
+
+    // ── Step 5: Build column mapping ─────────���──────────────────────────
     let mut column_mapping = build_column_mapping(&arrow_schema, &name_mapping, &parquet_metadata, &config);
 
     // Patch tantivy_type for exact_only fields: they are U64, not Str
@@ -561,6 +581,7 @@ pub async fn create_split_from_parquet(
                     &mut accumulators,
                     &string_indexing_modes,
                     &compiled_regexes,
+                    &text_companion_fields,
                 )?;
 
                 // Attach merge-safe parquet coordinates to each document
@@ -732,6 +753,7 @@ pub(crate) fn arrow_row_to_tantivy_doc(
     accumulators: &mut HashMap<String, StatisticsAccumulator>,
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
+    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<TantivyDocument> {
     let mut doc = TantivyDocument::new();
 
@@ -769,6 +791,7 @@ pub(crate) fn arrow_row_to_tantivy_doc(
             &mut doc, field, array, arrow_field.data_type(), row_idx,
             tantivy_field_name, config, string_hash_fields, tantivy_schema,
             accumulators, string_indexing_modes, compiled_regexes,
+            text_companion_fields,
         )?;
     }
 
@@ -792,6 +815,7 @@ pub(crate) fn add_arrow_value_to_doc(
     accumulators: &mut HashMap<String, StatisticsAccumulator>,
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
+    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<()> {
     match data_type {
         DataType::Boolean => {
@@ -892,6 +916,7 @@ pub(crate) fn add_arrow_value_to_doc(
             add_string_value_to_doc(
                 doc, field, val, field_name, config, string_hash_fields,
                 tantivy_schema, accumulators, string_indexing_modes, compiled_regexes,
+                text_companion_fields,
             )?;
         }
         DataType::LargeUtf8 => {
@@ -900,6 +925,7 @@ pub(crate) fn add_arrow_value_to_doc(
             add_string_value_to_doc(
                 doc, field, val, field_name, config, string_hash_fields,
                 tantivy_schema, accumulators, string_indexing_modes, compiled_regexes,
+                text_companion_fields,
             )?;
         }
 
@@ -1043,6 +1069,7 @@ pub(crate) fn add_string_value_to_doc(
     accumulators: &mut HashMap<String, StatisticsAccumulator>,
     string_indexing_modes: &HashMap<String, StringIndexingMode>,
     compiled_regexes: &HashMap<String, regex::Regex>,
+    text_companion_fields: &HashMap<String, Field>,
 ) -> Result<()> {
     if config.ip_address_fields.contains(field_name) {
         add_ip_addr_value(doc, field, val, field_name)?;
@@ -1092,9 +1119,8 @@ pub(crate) fn add_string_value_to_doc(
             StringIndexingMode::TextAndString => {
                 // Primary field: raw string value
                 doc.add_text(field, val);
-                // Secondary field: tokenized text companion
-                let text_name = string_indexing::text_companion_field_name(field_name);
-                if let Ok(text_field) = tantivy_schema.get_field(&text_name) {
+                // Secondary field: tokenized text companion (resolved once at setup, not per-doc)
+                if let Some(&text_field) = text_companion_fields.get(field_name) {
                     doc.add_text(text_field, val);
                 }
                 if let Some(acc) = accumulators.get_mut(field_name) {
@@ -1595,6 +1621,13 @@ fn build_column_mapping(
                 .get(&tantivy_field_name)
                 .cloned()
                 .unwrap_or_else(|| "raw".to_string());
+            // Normalize string indexing mode keywords to their actual primary tokenizer.
+            // text_and_string and exact_only both use "raw" as their primary tokenizer;
+            // the mode keyword itself is not a valid tantivy tokenizer name.
+            let tok = match tok.as_str() {
+                "text_and_string" | "exact_only" => "raw".to_string(),
+                _ => tok,
+            };
             Some(tok)
         } else {
             None
@@ -3525,5 +3558,151 @@ mod tests {
         let the_results = searcher.search(&the_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
         assert_eq!(the_results.len(), 2,
             "Tokenized search for 'the' on 'message__text' should find 2 docs (rows 0 and 2)");
+    }
+
+    // ── TextAndString edge-case integration test ────────────────────────
+
+    /// Helper: create a parquet file with id (Int64), message (Utf8), and tag (Utf8)
+    /// columns for multi-column text_and_string edge-case tests.
+    fn write_test_parquet_for_text_and_string_multi(
+        path: &std::path::Path,
+        messages: &[&str],
+        tags: &[&str],
+    ) {
+        use arrow_array::*;
+        use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+        use parquet::arrow::ArrowWriter;
+        use std::sync::Arc;
+
+        assert_eq!(messages.len(), tags.len(), "messages and tags must have same length");
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("message", DataType::Utf8, false),
+            Field::new("tag", DataType::Utf8, false),
+        ]));
+
+        let ids: Vec<i64> = (0..messages.len()).map(|i| i as i64).collect();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(StringArray::from(messages.to_vec())),
+                Arc::new(StringArray::from(tags.to_vec())),
+            ],
+        ).unwrap();
+
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    /// Integration test: text_and_string with multiple columns and empty strings.
+    #[tokio::test]
+    async fn test_text_and_string_edge_cases() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let parquet_path = temp_dir.path().join("tas_edge.parquet");
+        let output_path = temp_dir.path().join("tas_edge.split");
+
+        let messages = &[
+            "the quick brown fox",
+            "",
+            "hello world",
+        ];
+        let tags = &[
+            "animal",
+            "empty-message",
+            "",
+        ];
+        write_test_parquet_for_text_and_string_multi(&parquet_path, messages, tags);
+
+        let mut tokenizer_overrides = HashMap::new();
+        tokenizer_overrides.insert("message".to_string(), "text_and_string".to_string());
+        tokenizer_overrides.insert("tag".to_string(), "text_and_string".to_string());
+
+        let config = CreateFromParquetConfig {
+            table_root: temp_dir.path().to_string_lossy().to_string(),
+            schema_config: SchemaDerivationConfig {
+                tokenizer_overrides,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let storage: Arc<dyn quickwit_storage::Storage> =
+            Arc::new(quickwit_storage::RamStorage::default());
+
+        let result = create_split_from_parquet(
+            &[parquet_path.to_string_lossy().to_string()],
+            output_path.to_str().unwrap(),
+            &config,
+            &storage,
+        ).await.expect("text_and_string multi-column split creation should succeed");
+
+        assert_eq!(result.metadata.num_docs, 3);
+        assert!(output_path.exists());
+
+        // Open the split and verify schema
+        let (index, _bundle_dir) = crate::quickwit_split::split_utils::open_split_with_quickwit_native(
+            output_path.to_str().unwrap()
+        ).expect("Should open the created split");
+
+        let schema = index.schema();
+
+        // Verify all four text_and_string fields exist
+        let msg_field = schema.get_field("message")
+            .expect("message field should exist");
+        let msg_text_field = schema.get_field("message__text")
+            .expect("message__text companion field should exist");
+        let tag_field = schema.get_field("tag")
+            .expect("tag field should exist");
+        let tag_text_field = schema.get_field("tag__text")
+            .expect("tag__text companion field should exist");
+
+        // Verify field types
+        assert!(
+            matches!(schema.get_field_entry(msg_field).field_type(), tantivy::schema::FieldType::Str(_)),
+            "message should be Str type"
+        );
+        assert!(
+            matches!(schema.get_field_entry(msg_text_field).field_type(), tantivy::schema::FieldType::Str(_)),
+            "message__text should be Str type"
+        );
+        assert!(
+            matches!(schema.get_field_entry(tag_field).field_type(), tantivy::schema::FieldType::Str(_)),
+            "tag should be Str type"
+        );
+        assert!(
+            matches!(schema.get_field_entry(tag_text_field).field_type(), tantivy::schema::FieldType::Str(_)),
+            "tag__text should be Str type"
+        );
+
+        let reader = index.reader().expect("Should create reader");
+        reader.reload().expect("Should reload");
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 3);
+
+        // Tokenized search for "quick" on message__text should find 1 doc
+        let quick_term = tantivy::Term::from_field_text(msg_text_field, "quick");
+        let quick_query = tantivy::query::TermQuery::new(quick_term, tantivy::schema::IndexRecordOption::Basic);
+        let quick_results = searcher.search(&quick_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
+        assert_eq!(quick_results.len(), 1,
+            "Tokenized search for 'quick' on message__text should find 1 doc");
+
+        // Tokenized search for "animal" on tag__text should find 1 doc
+        let animal_term = tantivy::Term::from_field_text(tag_text_field, "animal");
+        let animal_query = tantivy::query::TermQuery::new(animal_term, tantivy::schema::IndexRecordOption::Basic);
+        let animal_results = searcher.search(&animal_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
+        assert_eq!(animal_results.len(), 1,
+            "Tokenized search for 'animal' on tag__text should find 1 doc");
+
+        // Exact search for "" (empty string) on message field should find 1 doc (row 1)
+        let empty_term = tantivy::Term::from_field_text(msg_field, "");
+        let empty_query = tantivy::query::TermQuery::new(empty_term, tantivy::schema::IndexRecordOption::Basic);
+        let empty_results = searcher.search(&empty_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
+        assert_eq!(empty_results.len(), 1,
+            "Exact search for empty string on 'message' should find 1 doc (the empty-message row)");
     }
 }

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -1089,6 +1089,18 @@ pub(crate) fn add_string_value_to_doc(
                     doc.add_text(field, val);
                 }
             }
+            StringIndexingMode::TextAndString => {
+                // Primary field: raw string value
+                doc.add_text(field, val);
+                // Secondary field: tokenized text companion
+                let text_name = string_indexing::text_companion_field_name(field_name);
+                if let Ok(text_field) = tantivy_schema.get_field(&text_name) {
+                    doc.add_text(text_field, val);
+                }
+                if let Some(acc) = accumulators.get_mut(field_name) {
+                    acc.observe_string(val);
+                }
+            }
         }
     } else {
         // Standard text field path
@@ -3393,5 +3405,125 @@ mod tests {
             "_phash_name should exist (not excluded)");
         assert!(schema.get_field(&format!("{}category", PHASH_FIELD_PREFIX)).is_err(),
             "_phash_category should NOT exist (excluded)");
+    }
+
+    // ── TextAndString integration test ──────────────────────────────────
+
+    /// Helper: create a parquet file with id (Int64) and message (Utf8) columns
+    /// for text_and_string indexing mode tests.
+    fn write_test_parquet_for_text_and_string(path: &std::path::Path, messages: &[&str]) {
+        use arrow_array::*;
+        use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+        use parquet::arrow::ArrowWriter;
+        use std::sync::Arc;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("message", DataType::Utf8, false),
+        ]));
+
+        let ids: Vec<i64> = (0..messages.len()).map(|i| i as i64).collect();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(StringArray::from(messages.to_vec())),
+            ],
+        ).unwrap();
+
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    /// Integration test: create a split with text_and_string indexing mode and verify
+    /// both exact (raw) and tokenized (default) searches work.
+    #[tokio::test]
+    async fn test_create_split_with_text_and_string_indexing() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let parquet_path = temp_dir.path().join("tas.parquet");
+        let output_path = temp_dir.path().join("tas.split");
+
+        let messages = &[
+            "the quick brown fox",
+            "hello world",
+            "the lazy dog sleeps",
+        ];
+        write_test_parquet_for_text_and_string(&parquet_path, messages);
+
+        let mut tokenizer_overrides = HashMap::new();
+        tokenizer_overrides.insert("message".to_string(), "text_and_string".to_string());
+
+        let config = CreateFromParquetConfig {
+            table_root: temp_dir.path().to_string_lossy().to_string(),
+            schema_config: SchemaDerivationConfig {
+                tokenizer_overrides,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let storage: Arc<dyn quickwit_storage::Storage> =
+            Arc::new(quickwit_storage::RamStorage::default());
+
+        let result = create_split_from_parquet(
+            &[parquet_path.to_string_lossy().to_string()],
+            output_path.to_str().unwrap(),
+            &config,
+            &storage,
+        ).await.expect("text_and_string split creation should succeed");
+
+        assert_eq!(result.metadata.num_docs, 3);
+        assert!(output_path.exists());
+
+        // Open the split and verify schema
+        let (index, _bundle_dir) = crate::quickwit_split::split_utils::open_split_with_quickwit_native(
+            output_path.to_str().unwrap()
+        ).expect("Should open the created split");
+
+        let schema = index.schema();
+
+        // Verify both fields exist
+        let msg_field = schema.get_field("message").unwrap();
+        let msg_entry = schema.get_field_entry(msg_field);
+        assert!(
+            matches!(msg_entry.field_type(), tantivy::schema::FieldType::Str(_)),
+            "Primary field 'message' should be Str type, got {:?}", msg_entry.field_type()
+        );
+
+        let text_field = schema.get_field("message__text").unwrap();
+        let text_entry = schema.get_field_entry(text_field);
+        assert!(
+            matches!(text_entry.field_type(), tantivy::schema::FieldType::Str(_)),
+            "Companion field 'message__text' should be Str type, got {:?}", text_entry.field_type()
+        );
+
+        let reader = index.reader().expect("Should create reader");
+        reader.reload().expect("Should reload");
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 3);
+
+        // Verify exact search on "message" field (raw tokenizer) finds results
+        let exact_term = tantivy::Term::from_field_text(msg_field, "the quick brown fox");
+        let exact_query = tantivy::query::TermQuery::new(exact_term, tantivy::schema::IndexRecordOption::Basic);
+        let exact_results = searcher.search(&exact_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
+        assert_eq!(exact_results.len(), 1,
+            "Exact search for 'the quick brown fox' on raw-tokenized 'message' should find 1 doc");
+
+        // Verify tokenized search on "message__text" field (default tokenizer) finds results
+        let token_term = tantivy::Term::from_field_text(text_field, "quick");
+        let token_query = tantivy::query::TermQuery::new(token_term, tantivy::schema::IndexRecordOption::Basic);
+        let token_results = searcher.search(&token_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
+        assert_eq!(token_results.len(), 1,
+            "Tokenized search for 'quick' on default-tokenized 'message__text' should find 1 doc");
+
+        // Verify another tokenized search works
+        let the_term = tantivy::Term::from_field_text(text_field, "the");
+        let the_query = tantivy::query::TermQuery::new(the_term, tantivy::schema::IndexRecordOption::Basic);
+        let the_results = searcher.search(&the_query, &tantivy::collector::TopDocs::with_limit(10)).unwrap();
+        assert_eq!(the_results.len(), 2,
+            "Tokenized search for 'the' on 'message__text' should find 2 docs (rows 0 and 2)");
     }
 }

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -266,38 +266,18 @@ fn add_field_for_arrow_type(
                             );
                         builder.add_text_field(name, text_opts);
                     }
-                    // TextAndString creates two index-only fields (no stored/fast).
-                    // In companion mode, document storage comes from the parquet source,
-                    // and aggregations use hashed fast fields (_phash_) configured separately.
-                    // Neither the raw field nor the __text companion needs storage or fast field access.
+                    // Single-field: default-tokenized inverted index for full-text search
+                    // and PhraseQuery equality, raw fast field for aggregations/sorting.
                     StringIndexingMode::TextAndString => {
-                        // Primary field: raw string for exact matching
-                        let raw_opts = TextOptions::default()
-                            .set_indexing_options(
-                                TextFieldIndexing::default()
-                                    .set_tokenizer("raw")
-                                    .set_index_option(IndexRecordOption::Basic)
-                                    .set_fieldnorms(config.fieldnorms_enabled),
-                            );
-                        builder.add_text_field(name, raw_opts);
-
-                        // Secondary field: tokenized text for full-text search
-                        let text_name = string_indexing::text_companion_field_name(name);
-                        if all_field_names.contains(&text_name) {
-                            anyhow::bail!(
-                                "Text companion field name '{}' for field '{}' collides with an existing column. \
-                                 Rename the column or use a different indexing mode.",
-                                text_name, name
-                            );
-                        }
-                        let text_opts = TextOptions::default()
+                        let opts = TextOptions::default()
                             .set_indexing_options(
                                 TextFieldIndexing::default()
                                     .set_tokenizer("default")
                                     .set_index_option(IndexRecordOption::WithFreqsAndPositions)
                                     .set_fieldnorms(config.fieldnorms_enabled),
-                            );
-                        builder.add_text_field(&text_name, text_opts);
+                            )
+                            .set_fast(Some("raw"));
+                        builder.add_text_field(name, opts);
                     }
                 }
             } else {
@@ -1276,7 +1256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_text_and_string_creates_two_fields() {
+    fn test_text_and_string_creates_single_field() {
         let arrow = ArrowSchema::new(vec![
             Field::new("message", DataType::Utf8, true),
         ]);
@@ -1285,39 +1265,18 @@ mod tests {
 
         let schema = derive_tantivy_schema(&arrow, &config).unwrap();
 
-        // Primary field: "message" with raw tokenizer for exact matching
         let msg_field = schema.get_field("message").unwrap();
-        let msg_entry = schema.get_field_entry(msg_field);
-        assert!(
-            matches!(msg_entry.field_type(), tantivy::schema::FieldType::Str(_)),
-            "text_and_string primary field 'message' should be Str type, got {:?}", msg_entry.field_type()
-        );
-
-        // Secondary field: "message__text" with default tokenizer for full-text search
-        let text_field = schema.get_field("message__text").unwrap();
-        let text_entry = schema.get_field_entry(text_field);
-        assert!(
-            matches!(text_entry.field_type(), tantivy::schema::FieldType::Str(_)),
-            "text_and_string companion field 'message__text' should be Str type, got {:?}", text_entry.field_type()
-        );
-    }
-
-    #[test]
-    fn test_text_and_string_collision_detection() {
-        // Create an Arrow schema where "message__text" already exists as a column
-        let arrow = ArrowSchema::new(vec![
-            Field::new("message", DataType::Utf8, true),
-            Field::new("message__text", DataType::Utf8, true),
-        ]);
-        let mut config = SchemaDerivationConfig::default();
-        config.tokenizer_overrides.insert("message".to_string(), "text_and_string".to_string());
-
-        let result = derive_tantivy_schema(&arrow, &config);
-        assert!(result.is_err(), "Should fail when companion field name collides with existing column");
-        assert!(
-            result.unwrap_err().to_string().contains("collides"),
-            "Error message should mention collision"
-        );
+        match schema.get_field_entry(msg_field).field_type() {
+            tantivy::schema::FieldType::Str(text_opts) => {
+                let indexing = text_opts.get_indexing_options()
+                    .expect("Should have indexing options");
+                assert_eq!(indexing.tokenizer(), "default");
+                assert_eq!(indexing.index_option(),
+                    tantivy::schema::IndexRecordOption::WithFreqsAndPositions);
+                assert!(text_opts.is_fast(), "Should have fast field enabled");
+            }
+            other => panic!("Expected Str type, got {:?}", other),
+        }
     }
 }
 

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -266,6 +266,35 @@ fn add_field_for_arrow_type(
                             );
                         builder.add_text_field(name, text_opts);
                     }
+                    StringIndexingMode::TextAndString => {
+                        // Primary field: raw string for exact matching
+                        let raw_opts = TextOptions::default()
+                            .set_indexing_options(
+                                TextFieldIndexing::default()
+                                    .set_tokenizer("raw")
+                                    .set_index_option(IndexRecordOption::Basic)
+                                    .set_fieldnorms(config.fieldnorms_enabled),
+                            );
+                        builder.add_text_field(name, raw_opts);
+
+                        // Secondary field: tokenized text for full-text search
+                        let text_name = string_indexing::text_companion_field_name(name);
+                        if all_field_names.contains(&text_name) {
+                            anyhow::bail!(
+                                "Text companion field name '{}' for field '{}' collides with an existing column. \
+                                 Rename the column or use a different indexing mode.",
+                                text_name, name
+                            );
+                        }
+                        let text_opts = TextOptions::default()
+                            .set_indexing_options(
+                                TextFieldIndexing::default()
+                                    .set_tokenizer("default")
+                                    .set_index_option(IndexRecordOption::WithFreqsAndPositions)
+                                    .set_fieldnorms(config.fieldnorms_enabled),
+                            );
+                        builder.add_text_field(&text_name, text_opts);
+                    }
                 }
             } else {
                 // Standard tokenizer path
@@ -1240,6 +1269,51 @@ mod tests {
 
         assert!(schema.get_field("log_line").is_ok());
         assert!(schema.get_field("log_line__uuids").is_err());
+    }
+
+    #[test]
+    fn test_text_and_string_creates_two_fields() {
+        let arrow = ArrowSchema::new(vec![
+            Field::new("message", DataType::Utf8, true),
+        ]);
+        let mut config = SchemaDerivationConfig::default();
+        config.tokenizer_overrides.insert("message".to_string(), "text_and_string".to_string());
+
+        let schema = derive_tantivy_schema(&arrow, &config).unwrap();
+
+        // Primary field: "message" with raw tokenizer for exact matching
+        let msg_field = schema.get_field("message").unwrap();
+        let msg_entry = schema.get_field_entry(msg_field);
+        assert!(
+            matches!(msg_entry.field_type(), tantivy::schema::FieldType::Str(_)),
+            "text_and_string primary field 'message' should be Str type, got {:?}", msg_entry.field_type()
+        );
+
+        // Secondary field: "message__text" with default tokenizer for full-text search
+        let text_field = schema.get_field("message__text").unwrap();
+        let text_entry = schema.get_field_entry(text_field);
+        assert!(
+            matches!(text_entry.field_type(), tantivy::schema::FieldType::Str(_)),
+            "text_and_string companion field 'message__text' should be Str type, got {:?}", text_entry.field_type()
+        );
+    }
+
+    #[test]
+    fn test_text_and_string_collision_detection() {
+        // Create an Arrow schema where "message__text" already exists as a column
+        let arrow = ArrowSchema::new(vec![
+            Field::new("message", DataType::Utf8, true),
+            Field::new("message__text", DataType::Utf8, true),
+        ]);
+        let mut config = SchemaDerivationConfig::default();
+        config.tokenizer_overrides.insert("message".to_string(), "text_and_string".to_string());
+
+        let result = derive_tantivy_schema(&arrow, &config);
+        assert!(result.is_err(), "Should fail when companion field name collides with existing column");
+        assert!(
+            result.unwrap_err().to_string().contains("collides"),
+            "Error message should mention collision"
+        );
     }
 }
 

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -266,6 +266,10 @@ fn add_field_for_arrow_type(
                             );
                         builder.add_text_field(name, text_opts);
                     }
+                    // TextAndString creates two index-only fields (no stored/fast).
+                    // In companion mode, document storage comes from the parquet source,
+                    // and aggregations use hashed fast fields (_phash_) configured separately.
+                    // Neither the raw field nor the __text companion needs storage or fast field access.
                     StringIndexingMode::TextAndString => {
                         // Primary field: raw string for exact matching
                         let raw_opts = TextOptions::default()

--- a/native/src/parquet_companion/string_indexing.rs
+++ b/native/src/parquet_companion/string_indexing.rs
@@ -16,6 +16,9 @@ pub const UUID_REGEX: &str = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9
 /// Suffix appended to the original field name to create the companion hash field.
 pub const COMPANION_SUFFIX: &str = "__uuids";
 
+/// Suffix appended to the original field name to create the text companion field.
+pub const TEXT_COMPANION_SUFFIX: &str = "__text";
+
 /// Compact string indexing mode for a field.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
@@ -35,6 +38,9 @@ pub enum StringIndexingMode {
     /// Strip custom regex matches from text, index remaining text with "default" tokenizer.
     /// Matches are discarded.
     TextCustomStrip { regex: String },
+    /// Dual-field indexing: primary field uses "raw" tokenizer for exact string matching,
+    /// secondary `<field>__text` field uses "default" tokenizer for full-text search.
+    TextAndString,
 }
 
 /// Metadata about a companion hash field created for a string indexing mode.
@@ -55,6 +61,7 @@ pub fn parse_tokenizer_override(value: &str) -> Option<StringIndexingMode> {
         "exact_only" => Some(StringIndexingMode::ExactOnly),
         "text_uuid_exactonly" => Some(StringIndexingMode::TextUuidExactonly),
         "text_uuid_strip" => Some(StringIndexingMode::TextUuidStrip),
+        "text_and_string" => Some(StringIndexingMode::TextAndString),
         _ => {
             if let Some(regex) = value.strip_prefix("text_custom_exactonly:") {
                 if !regex.is_empty() {
@@ -80,13 +87,18 @@ pub fn companion_field_name(original: &str) -> String {
     format!("{}{}", original, COMPANION_SUFFIX)
 }
 
+/// Build the text companion field name for a given original field name.
+pub fn text_companion_field_name(field_name: &str) -> String {
+    format!("{}{}", field_name, TEXT_COMPANION_SUFFIX)
+}
+
 /// Get the regex pattern for a string indexing mode.
 ///
 /// Returns the UUID regex for uuid variants, the custom regex for custom variants,
 /// and None for ExactOnly (which has no regex pattern).
 pub fn regex_pattern(mode: &StringIndexingMode) -> Option<&str> {
     match mode {
-        StringIndexingMode::ExactOnly => None,
+        StringIndexingMode::ExactOnly | StringIndexingMode::TextAndString => None,
         StringIndexingMode::TextUuidExactonly | StringIndexingMode::TextUuidStrip => Some(UUID_REGEX),
         StringIndexingMode::TextCustomExactonly { regex } | StringIndexingMode::TextCustomStrip { regex } => {
             Some(regex.as_str())
@@ -371,5 +383,31 @@ mod tests {
         let (stripped, matches) = extract_pattern(text, &re);
         assert_eq!(stripped, "no matches here");
         assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_parse_text_and_string() {
+        assert_eq!(
+            parse_tokenizer_override("text_and_string"),
+            Some(StringIndexingMode::TextAndString)
+        );
+    }
+
+    #[test]
+    fn test_text_companion_field_name() {
+        assert_eq!(text_companion_field_name("message"), "message__text");
+    }
+
+    #[test]
+    fn test_regex_pattern_text_and_string() {
+        assert_eq!(regex_pattern(&StringIndexingMode::TextAndString), None);
+    }
+
+    #[test]
+    fn test_serde_roundtrip_text_and_string() {
+        let mode = StringIndexingMode::TextAndString;
+        let json = serde_json::to_string(&mode).unwrap();
+        let parsed: StringIndexingMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, mode);
     }
 }

--- a/native/src/parquet_companion/string_indexing.rs
+++ b/native/src/parquet_companion/string_indexing.rs
@@ -410,4 +410,13 @@ mod tests {
         let parsed: StringIndexingMode = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, mode);
     }
+
+    #[test]
+    fn test_serde_wire_format_text_and_string() {
+        // Pin the exact JSON wire format to prevent accidental breaking changes
+        let json = r#"{"mode":"text_and_string"}"#;
+        let mode: StringIndexingMode = serde_json::from_str(json).unwrap();
+        assert_eq!(mode, StringIndexingMode::TextAndString);
+        assert_eq!(serde_json::to_string(&mode).unwrap(), json);
+    }
 }

--- a/native/src/parquet_companion/string_indexing.rs
+++ b/native/src/parquet_companion/string_indexing.rs
@@ -38,8 +38,8 @@ pub enum StringIndexingMode {
     /// Strip custom regex matches from text, index remaining text with "default" tokenizer.
     /// Matches are discarded.
     TextCustomStrip { regex: String },
-    /// Dual-field indexing: primary field uses "raw" tokenizer for exact string matching,
-    /// secondary `<field>__text` field uses "default" tokenizer for full-text search.
+    /// Single-field indexing: inverted index uses "default" tokenizer for full-text search
+    /// and PhraseQuery equality, fast field uses "raw" tokenizer for aggregations and sorting.
     TextAndString,
 }
 

--- a/native/src/parquet_companion/transcode.rs
+++ b/native/src/parquet_companion/transcode.rs
@@ -777,6 +777,27 @@ pub fn columns_to_transcode(
             if source != FieldSource::Parquet {
                 return false;
             }
+            // In Hybrid mode, TextAndString fields have native fast field data in the split
+            // (from set_fast(Some("raw")) in schema_derivation). Skip transcoding — the
+            // native data is already correct and transcoding would create duplicate ordinals
+            // in the merge.
+            //
+            // Backward compat: string_indexing_modes is #[serde(default)] so old manifests
+            // deserialize with an empty map. TextAndString and string_indexing_modes were
+            // introduced together, so no old manifest can have TextAndString native fast data
+            // without the corresponding entry here.
+            if mode == FastFieldMode::Hybrid {
+                use crate::parquet_companion::string_indexing::StringIndexingMode;
+                if let Some(StringIndexingMode::TextAndString) =
+                    manifest.string_indexing_modes.get(&mapping.tantivy_field_name)
+                {
+                    debug_println!(
+                        "📊 TRANSCODE: Skipping '{}' — TextAndString has native fast data in split",
+                        mapping.tantivy_field_name
+                    );
+                    return false;
+                }
+            }
             // If specific columns requested, filter to those
             if let Some(requested) = requested_columns {
                 return requested.iter().any(|r| r == &mapping.tantivy_field_name);
@@ -1094,18 +1115,37 @@ mod tests {
     fn test_columns_to_transcode_hybrid() {
         let manifest = make_test_manifest();
         let cols = columns_to_transcode(&manifest, FastFieldMode::Hybrid, None);
-        // Only Str columns should be transcoded in hybrid mode
+        // In Hybrid mode, TextAndString fields ("name") have native fast data → skipped.
+        // Regular string fields ("description") need parquet transcoding even though
+        // both have fast_field_tokenizer=Some("raw").
         assert_eq!(cols.len(), 1);
-        assert_eq!(cols[0].tantivy_name, "name");
+        assert_eq!(cols[0].tantivy_name, "description");
         assert_eq!(cols[0].tantivy_type, "Str");
+    }
+
+    #[test]
+    fn test_columns_to_transcode_hybrid_distinguishes_text_and_string_from_regular() {
+        // Regression test: fast_field_tokenizer.is_some() would skip BOTH Str fields,
+        // but only TextAndString has native fast data. Regular string must be transcoded.
+        let manifest = make_test_manifest();
+        let cols = columns_to_transcode(&manifest, FastFieldMode::Hybrid, None);
+        let col_names: Vec<&str> = cols.iter().map(|c| c.tantivy_name.as_str()).collect();
+        // "name" (TextAndString) → skipped (native fast data)
+        assert!(!col_names.contains(&"name"), "TextAndString field should NOT be transcoded in Hybrid mode");
+        // "description" (regular string) → transcoded (no native fast data)
+        assert!(col_names.contains(&"description"), "Regular string field SHOULD be transcoded in Hybrid mode");
     }
 
     #[test]
     fn test_columns_to_transcode_parquet_only() {
         let manifest = make_test_manifest();
         let cols = columns_to_transcode(&manifest, FastFieldMode::ParquetOnly, None);
-        // All columns should be transcoded
-        assert_eq!(cols.len(), 3);
+        // In ParquetOnly mode, ALL columns are transcoded including TextAndString,
+        // because native data is ignored in this mode.
+        assert_eq!(cols.len(), 4);
+        let col_names: Vec<&str> = cols.iter().map(|c| c.tantivy_name.as_str()).collect();
+        assert!(col_names.contains(&"name"), "TextAndString should be transcoded in ParquetOnly mode");
+        assert!(col_names.contains(&"description"), "Regular string should be transcoded in ParquetOnly mode");
     }
 
     #[test]
@@ -1115,6 +1155,16 @@ mod tests {
         let cols = columns_to_transcode(&manifest, FastFieldMode::ParquetOnly, Some(&requested));
         assert_eq!(cols.len(), 1);
         assert_eq!(cols[0].tantivy_name, "score");
+    }
+
+    #[test]
+    fn test_columns_to_transcode_hybrid_requested_text_and_string_still_skipped() {
+        // Even when explicitly requested, TextAndString fields should NOT be transcoded
+        // in Hybrid mode — they have native fast data and transcoding would double ordinals.
+        let manifest = make_test_manifest();
+        let requested = vec!["name".to_string()];
+        let cols = columns_to_transcode(&manifest, FastFieldMode::Hybrid, Some(&requested));
+        assert!(cols.is_empty(), "TextAndString should be skipped even when explicitly requested in Hybrid mode");
     }
 
     #[test]
@@ -1776,13 +1826,15 @@ mod tests {
                     fast_field_tokenizer: None,
                 },
                 ColumnMapping {
+                    // TextAndString field — fast_field_tokenizer is None because it has native
+                    // fast data from set_fast(Some("raw")) in schema_derivation. No transcoding needed.
                     tantivy_field_name: "name".to_string(),
                     parquet_column_name: "name".to_string(),
                     physical_ordinal: 1,
                     parquet_type: "BYTE_ARRAY".to_string(),
                     tantivy_type: "Str".to_string(),
                     field_id: None,
-                    fast_field_tokenizer: Some("raw".to_string()),
+                    fast_field_tokenizer: None,
                 },
                 ColumnMapping {
                     tantivy_field_name: "score".to_string(),
@@ -1793,12 +1845,30 @@ mod tests {
                     field_id: None,
                     fast_field_tokenizer: None,
                 },
+                // Regular Str field — has fast_field_tokenizer (all Str columns do in production)
+                // but is NOT TextAndString, so it has no native fast data and needs transcoding.
+                ColumnMapping {
+                    tantivy_field_name: "description".to_string(),
+                    parquet_column_name: "description".to_string(),
+                    physical_ordinal: 3,
+                    parquet_type: "BYTE_ARRAY".to_string(),
+                    tantivy_type: "Str".to_string(),
+                    field_id: None,
+                    fast_field_tokenizer: Some("raw".to_string()),
+                },
             ],
             total_rows: 100,
             storage_config: None,
             metadata: std::collections::HashMap::new(),
             string_hash_fields: std::collections::HashMap::new(),
-            string_indexing_modes: std::collections::HashMap::new(),
+            string_indexing_modes: {
+                let mut modes = std::collections::HashMap::new();
+                modes.insert(
+                    "name".to_string(),
+                    crate::parquet_companion::string_indexing::StringIndexingMode::TextAndString,
+                );
+                modes
+            },
             companion_hash_fields: std::collections::HashMap::new(),
         }
     }

--- a/native/src/split_searcher/async_impl.rs
+++ b/native/src/split_searcher/async_impl.rs
@@ -294,6 +294,19 @@ pub(crate) async fn ensure_fast_fields_for_query(
                         if hash_values.contains(col.as_str()) {
                             return true;
                         }
+                        // In Hybrid mode, TextAndString fields have native fast data
+                        if mode == crate::parquet_companion::manifest::FastFieldMode::Hybrid {
+                            use crate::parquet_companion::string_indexing::StringIndexingMode;
+                            if let Some(StringIndexingMode::TextAndString) =
+                                manifest.string_indexing_modes.get(col.as_str())
+                            {
+                                debug_println!(
+                                    "📊 LAZY_TRANSCODE: '{}' is TextAndString — using native fast data (no parquet transcode)",
+                                    col
+                                );
+                                return true;
+                            }
+                        }
                         // Check if this field's type is native in the current mode
                         if let Some(tantivy_type) = field_types.get(col.as_str()) {
                             crate::parquet_companion::transcode::field_source(tantivy_type, mode)

--- a/native/src/split_searcher/jni_prewarm.rs
+++ b/native/src/split_searcher/jni_prewarm.rs
@@ -866,15 +866,27 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_SplitSearcher_nati
             let json_str = "{}";
             return match string_to_jstring(env, json_str) {
                 Ok(jstr) => Ok(jstr.into_raw()),
-                Err(_) => Ok(std::ptr::null_mut()),
+                Err(e) => {
+                    debug_println!("ERROR: Failed to create JNI string for empty string_indexing_modes: {}", e);
+                    Ok(std::ptr::null_mut())
+                },
             };
         }
 
         // Serialize directly — StringIndexingMode derives serde::Serialize
-        let json_str = serde_json::to_string(&manifest.string_indexing_modes).unwrap_or_default();
+        let json_str = match serde_json::to_string(&manifest.string_indexing_modes) {
+            Ok(s) => s,
+            Err(e) => {
+                debug_println!("ERROR: Failed to serialize string_indexing_modes: {}", e);
+                String::from("{}")
+            }
+        };
         match string_to_jstring(env, &json_str) {
             Ok(jstr) => Ok(jstr.into_raw()),
-            Err(_) => Ok(std::ptr::null_mut()),
+            Err(e) => {
+                debug_println!("ERROR: Failed to create JNI string for string_indexing_modes: {}", e);
+                Ok(std::ptr::null_mut())
+            },
         }
     }).unwrap_or(std::ptr::null_mut())
 }


### PR DESCRIPTION
## Summary

Single-field `text_and_string` indexing mode for companion splits. One tantivy field serves both full-text search and aggregations — replacing the dual-field `__text` companion approach for lower storage cost and simpler query routing.

Rebased cleanly on latest main (5 commits, no stacked dependencies).

## Architecture

Each `text_and_string` column creates **one** tantivy field with two independent behaviors:

| Capability | Storage | Tokenizer | How it works |
|-----------|---------|-----------|--------------|
| Full-text search | Inverted index | `default` (lowercase + split) | Standard tantivy term/phrase queries |
| EqualTo / IN filters | Inverted index | `default` | PhraseQuery(slop=0) candidate, Spark post-filters |
| GROUP BY / aggregation | Fast field (columnar) | `raw` (original string) | Tantivy terms aggregation on raw values |

### Write path

```
schema_derivation.rs: TextAndString →
    TextOptions::default()
        .set_indexing_options(default tokenizer, WithFreqsAndPositions)
        .set_fast(Some("raw"))

indexing.rs: doc.add_text(field, val)
    → tantivy writes to inverted index (tokenized) AND fast field (raw) in one call
```

### Read path — fast field transcoding

TextAndString fields are **excluded from parquet transcoding** in Hybrid mode because they already have native fast data from `set_fast(Some("raw"))`. Without this, `merge_two_columnars()` combines native + transcoded data, doubling ordinals and GROUP BY counts.

The exclusion uses `manifest.string_indexing_modes` (checking for `TextAndString`) — not `fast_field_tokenizer.is_some()`, because `build_column_mapping` sets `fast_field_tokenizer` on ALL Str columns. Only `string_indexing_modes` correctly distinguishes TextAndString from regular string fields.

### Manifest representation

```
ColumnMapping { fast_field_tokenizer: None }     // TextAndString: native fast data
ColumnMapping { fast_field_tokenizer: Some("raw") }  // Regular string: needs transcoding
string_indexing_modes: { "message": TextAndString }
```

## Design decisions

1. **`string_indexing_modes` as discriminator**: All Str columns have `fast_field_tokenizer` set. Using `.is_some()` would skip transcoding for ALL Str fields, breaking regular string GROUP BY.
2. **`fast_field_tokenizer: None` for TextAndString**: Fixed `build_column_mapping` so the manifest accurately represents "has native fast data."
3. **Hybrid-only skip**: In `ParquetOnly` mode, native data is ignored, so TextAndString must still be transcoded.
4. **Backward compat**: `string_indexing_modes` is `#[serde(default)]`. TextAndString and `string_indexing_modes` were co-introduced, so no old manifest can have TextAndString without the entry.

## Testing

**6 Rust unit tests** (`transcode.rs`):
- Hybrid: TextAndString skipped, regular string transcoded
- Regression: same `fast_field_tokenizer` on both, only TextAndString skipped
- ParquetOnly: all transcoded including TextAndString
- Requested columns: explicit request can't force TextAndString transcoding

**3 Rust integration tests** (`indexing.rs`):
- Single-field schema validation
- PhraseQuery false positive behavior
- Punctuation in fast field

## Open items (out of scope)

1. **Rust-side fast field post-filter**: Would eliminate ~10% PhraseQuery false positives before Spark sees them. Rejected because companion streaming path bypasses `searchWithSplitQuery`. Spark candidate post-filter guarantees correctness.
2. **Non-companion text_and_string**: Java `SchemaBuilder.addTextField(fast=true)` uses one tokenizer for both inverted index and fast field. Separate tokenizers only available through companion schema derivation.

## Dependencies
- Companion Spark PR: indextables/indextables_spark#292

🤖 Generated with [Claude Code](https://claude.com/claude-code)