### PR TITLE
Fix all parquet_companion code-review findings (read/indexing path + merge + FFI)

### DIFF
--- a/native/src/parquet_companion/arrow_ffi_import.rs
+++ b/native/src/parquet_companion/arrow_ffi_import.rs
@@ -72,6 +72,11 @@ pub(crate) struct ArrowFfiSplitContext {
     /// Column names for which to compute min/max statistics (empty = none).
     /// Populated from the "stats" flag in fieldConfigJson.
     stats_columns: std::collections::HashSet<String>,
+    /// Split config (index_uid/source_id/node_id/tags) applied to every split this
+    /// session produces. Single source of truth so that auto-rolled splits (during
+    /// addArrowBatch), explicitly-rolled splits, and the final splits all share the
+    /// same identity — they must never diverge depending on when a split was rolled.
+    split_config: SplitConfig,
 }
 
 /// Per-partition state: each partition gets its own Index + IndexWriter + temp dir.
@@ -320,6 +325,7 @@ pub(crate) fn begin_split_from_arrow(
         output_dir,
         rolled_splits: Vec::new(),
         stats_columns,
+        split_config: default_split_config("arrow-ffi", "arrow-ffi-source", "arrow-ffi-node"),
     })
 }
 
@@ -550,7 +556,10 @@ impl PrebuiltComplexColumns {
 ///
 /// Returns cumulative total doc count across all partitions.
 pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &RecordBatch) -> Result<u64> {
-    // Validate schema matches
+    // Validate schema matches. Checking only the column count is not enough: a
+    // batch with the same arity but reordered (or renamed) columns of compatible
+    // types would otherwise be indexed under the wrong field names, silently
+    // corrupting the data. Verify each column's name and type positionally.
     let batch_schema = batch.schema();
     if batch_schema.fields().len() != ctx.arrow_schema.fields().len() {
         bail!(
@@ -558,6 +567,24 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
             ctx.arrow_schema.fields().len(),
             batch_schema.fields().len()
         );
+    }
+    for (i, (expected, actual)) in ctx.arrow_schema.fields().iter()
+        .zip(batch_schema.fields().iter())
+        .enumerate()
+    {
+        if expected.name() != actual.name() {
+            bail!(
+                "Schema mismatch at column {}: expected field '{}', got '{}' \
+                 (columns must match the schema declared at beginSplitFromArrow)",
+                i, expected.name(), actual.name()
+            );
+        }
+        if expected.data_type() != actual.data_type() {
+            bail!(
+                "Schema mismatch for column '{}': expected type {:?}, got {:?}",
+                expected.name(), expected.data_type(), actual.data_type()
+            );
+        }
     }
 
     // Use the config from context (populated from field_config_json if provided)
@@ -575,7 +602,8 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
     let prebuilt = PrebuiltComplexColumns::build(batch, &ctx.field_mapping)?;
 
     let max_docs = ctx.max_docs_per_split;
-    let split_config = default_split_config("arrow-ffi", "arrow-ffi-source", "arrow-ffi-node");
+    // Use the session's single split config so auto-rolled splits match the final ones.
+    let split_config = ctx.split_config.clone();
 
     if ctx.partition_col_indices.is_empty() {
         // Non-partitioned path: add all rows to default writer
@@ -943,8 +971,11 @@ async fn finalize_partition_writer_into_split(
 pub(crate) async fn finish_all_splits(
     mut ctx: ArrowFfiSplitContext,
     output_dir: &str,
-    split_config: &SplitConfig,
 ) -> Result<Vec<PartitionSplitResult>> {
+    // Use the session's single split config (same one applied to auto-rolled splits)
+    // so every split in the session shares one identity.
+    let split_config = ctx.split_config.clone();
+    let split_config = &split_config;
     // Start with any splits that were auto-rolled during addArrowBatch
     let mut results = std::mem::take(&mut ctx.rolled_splits);
 
@@ -988,8 +1019,10 @@ pub(crate) async fn roll_partition_split(
     ctx: &mut ArrowFfiSplitContext,
     partition_key: &str,
     output_dir: &str,
-    split_config: &SplitConfig,
 ) -> Result<PartitionSplitResult> {
+    // Use the session's single split config so rolled splits match the final ones.
+    let split_config = ctx.split_config.clone();
+    let split_config = &split_config;
     // Take the writer out of the context
     let (pw, partition_values) = if partition_key.is_empty() {
         // Non-partitioned: take default_writer
@@ -1176,9 +1209,8 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test-index", "test-source", "test-node");
 
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             assert_eq!(results.len(), 1);
             let result = &results[0];
@@ -1282,9 +1314,8 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test-index", "test-source", "test-node");
 
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             assert_eq!(results.len(), 1);
             assert_eq!(results[0].partition_key, "event_date=2023-01-15");
@@ -1311,9 +1342,8 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test-index", "test-source", "test-node");
 
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             assert_eq!(results.len(), 3);
 
@@ -1357,9 +1387,8 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch3).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test-index", "test-source", "test-node");
 
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             assert_eq!(results.len(), 2);
 
@@ -1426,9 +1455,8 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test-index", "test-source", "test-node");
 
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             // 3 distinct partition combinations
             assert_eq!(results.len(), 3);
@@ -1465,8 +1493,7 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch2).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test", "test-source", "test-node");
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             assert_eq!(results.len(), 1);
             let result = &results[0];
@@ -1503,8 +1530,7 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test", "test-source", "test-node");
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             assert_eq!(results.len(), 1);
             // No statistics when not enabled
@@ -1539,8 +1565,7 @@ mod tests {
             add_arrow_batch(&mut ctx, &batch).await.unwrap();
 
             let output_dir = tempfile::tempdir().unwrap();
-            let split_config = default_split_config("test", "test-source", "test-node");
-            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap(), &split_config).await.unwrap();
+            let results = finish_all_splits(ctx, output_dir.path().to_str().unwrap()).await.unwrap();
 
             assert_eq!(results.len(), 2);
 

--- a/native/src/parquet_companion/arrow_ffi_import.rs
+++ b/native/src/parquet_companion/arrow_ffi_import.rs
@@ -35,6 +35,18 @@ use crate::quickwit_split::{
 };
 use crate::quickwit_split::json_discovery::{extract_doc_mapping_from_index, write_doc_mapping_to_dir};
 
+/// Maximum number of concurrent per-partition writers a single session may hold.
+///
+/// Every distinct partition key allocates a tempdir + tantivy `Index` + `IndexWriter`
+/// + heap `MemoryReservation`. Left unbounded, a mis-declared high-cardinality
+/// partition column would spawn one writer per distinct value and exhaust memory
+/// and file descriptors deep inside a batch (L16/D5). `add_arrow_batch` checks the
+/// projected writer count up front and rejects the batch with a clear error before
+/// creating any new writer or ingesting any row. Sized generously (a few thousand);
+/// partitioned tables with more concurrent partitions than this in flight should
+/// repartition upstream or lower partition cardinality.
+const MAX_PARTITION_WRITERS: usize = 4096;
+
 /// Context for streaming Arrow FFI split creation.
 /// Wrapped in Arc<Mutex<>> at the JNI layer (IndexWriter is !Sync).
 ///
@@ -376,7 +388,14 @@ fn create_partition_writer(
                     DataType::Float32 | DataType::Float64 => "f64",
                     DataType::Boolean => "bool",
                     DataType::Utf8 | DataType::LargeUtf8 => "text",
-                    DataType::Date32 => "datetime",
+                    // M19: Date32 is a calendar date, not a wall-clock timestamp. It must
+                    // use "Date" (not "datetime") so finalize_statistics_to_string_maps
+                    // takes the `== "Date"` branch and emits ISO date strings
+                    // ("2023-02-15") — matching the Scala StatisticsCalculator. Tagging it
+                    // "datetime" made that branch unreachable and emitted raw epoch micros,
+                    // so data-skipping comparisons against ISO date strings never matched.
+                    DataType::Date32 => "Date",
+                    // Timestamps stay "datetime": stored/compared as raw epoch micros.
                     DataType::Timestamp(_, _) => "datetime",
                     _ => continue, // Skip non-eligible types
                 };
@@ -554,6 +573,10 @@ impl PrebuiltComplexColumns {
 /// Complex Arrow types (Struct, List, Map) are pre-processed once per batch column via
 /// `PrebuiltComplexColumns`, eliminating redundant per-row downcast and recursive conversion.
 ///
+/// The batch is applied atomically (M16): every document is built and validated before any
+/// is committed, so a batch that fails on some row leaves `total_doc_count` and all writers
+/// unchanged and is safe to retry. See the inline notes for the statistics-accumulator caveat.
+///
 /// Returns cumulative total doc count across all partitions.
 pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &RecordBatch) -> Result<u64> {
     // Validate schema matches. Checking only the column count is not enough: a
@@ -605,25 +628,53 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
     // Use the session's single split config so auto-rolled splits match the final ones.
     let split_config = ctx.split_config.clone();
 
+    // Batch atomicity (M16): a batch is ingested in full or rejected without adding any
+    // documents. We BUILD every row's TantivyDocument up front (Phase 1) — this is where
+    // per-row failures surface: array downcast mismatches, timestamp/decimal/date
+    // overflow, invalid IP/JSON values, and unroutable partition-key extraction. Only
+    // after the ENTIRE batch has been built successfully do we hand documents to the
+    // writers and advance the counts (Phase 2). A rejected batch therefore leaves
+    // `total_doc_count`, `total_batch_count`, and every writer's committed document set
+    // unchanged, so a Spark task retry against the same context cannot duplicate rows.
+    //
+    // Statistics caveat: statistics accumulators are observed during the Phase 1 build,
+    // so a rejected batch may leave a writer's min/max advanced (idempotent under retry)
+    // and its null/nan counts marginally inflated — but this never affects query
+    // correctness: over-wide min/max only make data-skipping more conservative (never
+    // drops a matching row). The documented recovery for a failed batch is to cancel the
+    // session (see M17), which discards those accumulators entirely.
+
     if ctx.partition_col_indices.is_empty() {
-        // Non-partitioned path: add all rows to default writer
-        for row_idx in 0..num_rows {
+        // ---- Non-partitioned path ----
+        // Phase 1: build & validate every document. No add_document, no count change.
+        let mut built: Vec<TantivyDocument> = Vec::with_capacity(num_rows);
+        {
             let pw = ctx.default_writer.as_mut()
                 .ok_or_else(|| anyhow::anyhow!("No default writer for non-partitioned context"))?;
+            for row_idx in 0..num_rows {
+                let doc = build_doc_from_arrow_row(
+                    batch,
+                    row_idx,
+                    &ctx.field_mapping,
+                    &ctx.tantivy_schema,
+                    &name_mapping,
+                    schema_derivation_config,
+                    &string_hash_fields,
+                    &mut pw.accumulators,
+                    &string_indexing_modes,
+                    &compiled_regexes,
+                    &prebuilt,
+                )?;
+                built.push(doc);
+            }
+        }
 
-            let doc = build_doc_from_arrow_row(
-                batch,
-                row_idx,
-                &ctx.field_mapping,
-                &ctx.tantivy_schema,
-                &name_mapping,
-                schema_derivation_config,
-                &string_hash_fields,
-                &mut pw.accumulators,
-                &string_indexing_modes,
-                &compiled_regexes,
-                &prebuilt,
-            )?;
+        // Phase 2: commit. Per-row conversions were already validated in Phase 1, so this
+        // pass only performs the (effectively infallible) add_document plus threshold
+        // bookkeeping and auto-rolling.
+        for doc in built {
+            let pw = ctx.default_writer.as_mut()
+                .ok_or_else(|| anyhow::anyhow!("No default writer for non-partitioned context"))?;
             pw.writer.add_document(doc)?;
             pw.doc_count += 1;
 
@@ -648,58 +699,111 @@ pub(crate) async fn add_arrow_batch(ctx: &mut ArrowFfiSplitContext, batch: &Reco
             }
         }
     } else {
-        // Partitioned path: route each row to correct partition writer
+        // ---- Partitioned path ----
+        // Phase 1a: resolve each row's partition key. Validates partition-column
+        // downcasts/values up front. E6: cache the last (values → key) pair so
+        // sorted/clustered data reuses it instead of re-formatting the key and rebuilding
+        // the partition-values map on every row (the fast path; unsorted data simply
+        // misses the cache and falls back to the full build below).
+        let mut row_keys: Vec<String> = Vec::with_capacity(num_rows);
+        let mut new_partitions: HashMap<String, HashMap<String, String>> = HashMap::new();
+        let mut last: Option<(Vec<String>, String)> = None;
         for row_idx in 0..num_rows {
-            // Extract partition column values
-            let mut partition_values_vec = Vec::with_capacity(ctx.partition_col_indices.len());
+            let mut vals = Vec::with_capacity(ctx.partition_col_indices.len());
             for &col_idx in &ctx.partition_col_indices {
-                partition_values_vec.push(extract_partition_value(batch, col_idx, row_idx)?);
+                vals.push(extract_partition_value(batch, col_idx, row_idx)?);
             }
-            let partition_key = build_partition_key(&ctx.partition_col_names, &partition_values_vec);
-
-            // Get or lazily create partition writer
-            if !ctx.partition_writers.contains_key(&partition_key) {
+            // Fast path: reuse the previous row's key if its partition values are
+            // identical (evaluated in a scope that releases the `&last` borrow before we
+            // may reassign `last` below).
+            let cached = match &last {
+                Some((last_vals, last_key)) if *last_vals == vals => Some(last_key.clone()),
+                _ => None,
+            };
+            let partition_key = match cached {
+                Some(k) => k,
+                None => {
+                    let k = build_partition_key(&ctx.partition_col_names, &vals);
+                    last = Some((vals.clone(), k.clone()));
+                    k
+                }
+            };
+            if !ctx.partition_writers.contains_key(&partition_key)
+                && !new_partitions.contains_key(&partition_key)
+            {
                 let mut partition_values_map = HashMap::new();
-                for (name, value) in ctx.partition_col_names.iter().zip(partition_values_vec.iter()) {
+                for (name, value) in ctx.partition_col_names.iter().zip(vals.iter()) {
                     partition_values_map.insert(name.clone(), value.clone());
                 }
-                let pw = create_partition_writer(&ctx.tantivy_schema, ctx.heap_size, partition_values_map,
-                    &ctx.stats_columns, &ctx.field_mapping)?;
-                ctx.partition_writers.insert(partition_key.clone(), pw);
-                debug_println!("ARROW_FFI_IMPORT: Created new partition writer for '{}'", partition_key);
+                new_partitions.insert(partition_key.clone(), partition_values_map);
             }
+            row_keys.push(partition_key);
+        }
 
+        // Phase 1b: enforce the partition-writer bound up front (L16/D5) — reject a
+        // high-cardinality partition column before creating any writer or ingesting rows.
+        let projected_writers = ctx.partition_writers.len() + new_partitions.len();
+        if projected_writers > MAX_PARTITION_WRITERS {
+            bail!(
+                "Too many partitions: this batch would require {} concurrent partition \
+                 writers, exceeding the limit of {}. A high-cardinality column is likely \
+                 mis-declared as a partition column; reduce partition cardinality or \
+                 repartition upstream.",
+                projected_writers, MAX_PARTITION_WRITERS
+            );
+        }
+
+        // Phase 1c: create writers for newly-seen partition keys (bounded above).
+        for (partition_key, partition_values_map) in new_partitions {
+            let pw = create_partition_writer(&ctx.tantivy_schema, ctx.heap_size,
+                partition_values_map, &ctx.stats_columns, &ctx.field_mapping)?;
+            debug_println!("ARROW_FFI_IMPORT: Created new partition writer for '{}'", partition_key);
+            ctx.partition_writers.insert(partition_key, pw);
+        }
+
+        // Phase 1d: build & validate every document, observing statistics into the
+        // resolved writer's accumulators. No documents are committed yet.
+        let mut built: Vec<TantivyDocument> = Vec::with_capacity(num_rows);
+        for (row_idx, partition_key) in row_keys.iter().enumerate() {
+            let pw = ctx.partition_writers.get_mut(partition_key)
+                .expect("partition writer created in Phase 1c must exist");
+            let doc = build_doc_from_arrow_row(
+                batch,
+                row_idx,
+                &ctx.field_mapping,
+                &ctx.tantivy_schema,
+                &name_mapping,
+                schema_derivation_config,
+                &string_hash_fields,
+                &mut pw.accumulators,
+                &string_indexing_modes,
+                &compiled_regexes,
+                &prebuilt,
+            )?;
+            built.push(doc);
+        }
+
+        // Phase 2: commit each built document to its writer, then auto-roll if needed.
+        for (doc, partition_key) in built.into_iter().zip(row_keys.iter()) {
             {
-                let pw = ctx.partition_writers.get_mut(&partition_key).unwrap();
-                let doc = build_doc_from_arrow_row(
-                    batch,
-                    row_idx,
-                    &ctx.field_mapping,
-                    &ctx.tantivy_schema,
-                    &name_mapping,
-                    schema_derivation_config,
-                    &string_hash_fields,
-                    &mut pw.accumulators,
-                    &string_indexing_modes,
-                    &compiled_regexes,
-                    &prebuilt,
-                )?;
+                let pw = ctx.partition_writers.get_mut(partition_key)
+                    .expect("partition writer must exist during commit");
                 pw.writer.add_document(doc)?;
                 pw.doc_count += 1;
             }
 
             // Auto-roll if threshold reached (borrow of pw is dropped above)
             if max_docs > 0 {
-                let should_roll = ctx.partition_writers.get(&partition_key)
+                let should_roll = ctx.partition_writers.get(partition_key)
                     .map(|pw| pw.doc_count >= max_docs)
                     .unwrap_or(false);
                 if should_roll {
                     if let Some(output_dir) = ctx.output_dir.as_ref() {
                         let output_dir = output_dir.clone();
-                        let rolled_pw = ctx.partition_writers.remove(&partition_key).unwrap();
+                        let rolled_pw = ctx.partition_writers.remove(partition_key).unwrap();
                         let partition_values = rolled_pw.partition_values.clone();
                         let result = finalize_partition_writer_into_split(
-                            rolled_pw, &partition_key, partition_values.clone(),
+                            rolled_pw, partition_key, partition_values.clone(),
                             &output_dir, &split_config,
                         ).await?;
                         debug_println!(
@@ -991,6 +1095,19 @@ pub(crate) async fn finish_all_splits(
             .collect()
     };
 
+    // M17: finalize EVERY partition before deciding success/failure. Previously the first
+    // finalize error aborted the loop via `?`, which (a) discarded the metadata for all
+    // partitions already finalized and written to disk — leaving orphaned part-*.split
+    // files the caller never learned about — and (b) skipped every not-yet-finalized
+    // partition entirely. We now attempt all partitions, accumulate the failures, and only
+    // then fail — reporting which partitions failed and listing the split paths that were
+    // written successfully so an operator (or the caller's cleanup) can locate and reclaim
+    // them. Successful split files are intentionally left on disk rather than deleted.
+    //
+    // (Fully returning the successful `PartitionSplitResult`s to Java on the error path
+    // would require changing this function's `Result<Vec<..>>` signature and its JNI
+    // caller in quickwit_split/jni_functions.rs, which is out of scope here.)
+    let mut errors: Vec<String> = Vec::new();
     for (partition_key, partition_values, pw) in writers {
         // Skip empty partition writers that were created by auto-roll
         // (a new writer was started after roll but no rows were added).
@@ -999,10 +1116,27 @@ pub(crate) async fn finish_all_splits(
         if pw.doc_count == 0 && !partition_key.is_empty() {
             continue;
         }
-        let result = finalize_partition_writer_into_split(
+        match finalize_partition_writer_into_split(
             pw, &partition_key, partition_values, output_dir, split_config,
-        ).await?;
-        results.push(result);
+        ).await {
+            Ok(result) => results.push(result),
+            Err(e) => {
+                let label = if partition_key.is_empty() { "<default>" } else { partition_key.as_str() };
+                errors.push(format!("partition '{}': {}", label, e));
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        let written: Vec<&str> = results.iter().map(|r| r.split_path.as_str()).collect();
+        bail!(
+            "finish_all_splits failed to finalize {} partition(s): [{}]. \
+             {} split(s) were finalized successfully and remain on disk: [{}].",
+            errors.len(),
+            errors.join("; "),
+            written.len(),
+            written.join(", ")
+        );
     }
 
     Ok(results)
@@ -1588,6 +1722,97 @@ mod tests {
             let p2 = results.iter().find(|r| r.partition_key == "event_date=2023-01-16").unwrap();
             assert_eq!(p2.min_values.get("id"), Some(&"3".to_string()));
             assert_eq!(p2.max_values.get("id"), Some(&"4".to_string()));
+        });
+    }
+
+    // --- Atomicity / bounds tests ---
+
+    /// M16: a batch that fails on some row must not partially ingest — the doc count and
+    /// writer state must be exactly what they were before the failed call.
+    #[test]
+    fn test_batch_failure_is_atomic_doc_count_unchanged() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            // "addr" is declared as an IP field, so a non-parsable value fails mid-batch.
+            let arrow_schema = ArrowSchema::new(vec![
+                ArrowField::new("id", DataType::Int64, false),
+                ArrowField::new("addr", DataType::Utf8, false),
+            ]);
+            let field_config = r#"[{"name":"addr","type":"ip"}]"#;
+            let mut ctx = begin_split_from_arrow(
+                arrow_schema, &[], 50_000_000, Some(field_config), 0, None,
+            ).unwrap();
+
+            let make_batch = |ids: Vec<i64>, addrs: Vec<&str>| {
+                RecordBatch::try_new(
+                    Arc::new(ArrowSchema::new(vec![
+                        ArrowField::new("id", DataType::Int64, false),
+                        ArrowField::new("addr", DataType::Utf8, false),
+                    ])),
+                    vec![
+                        Arc::new(Int64Array::from(ids)),
+                        Arc::new(StringArray::from(addrs)),
+                    ],
+                ).unwrap()
+            };
+
+            // Good batch of 3 rows.
+            let good = make_batch(vec![1, 2, 3], vec!["1.1.1.1", "2.2.2.2", "3.3.3.3"]);
+            let count = add_arrow_batch(&mut ctx, &good).await.unwrap();
+            assert_eq!(count, 3);
+            assert_eq!(ctx.total_doc_count, 3);
+            assert_eq!(ctx.default_writer.as_ref().unwrap().doc_count, 3);
+
+            // Bad batch: row 1 (0-indexed) has an invalid IP → build fails mid-batch.
+            let bad = make_batch(vec![4, 5, 6], vec!["4.4.4.4", "not-an-ip", "6.6.6.6"]);
+            let res = add_arrow_batch(&mut ctx, &bad).await;
+            assert!(res.is_err(), "batch with an invalid IP value must be rejected");
+
+            // Atomicity: nothing from the rejected batch was ingested.
+            assert_eq!(ctx.total_doc_count, 3, "total_doc_count must be unchanged");
+            assert_eq!(ctx.total_batch_count, 1, "total_batch_count must be unchanged");
+            assert_eq!(
+                ctx.default_writer.as_ref().unwrap().doc_count, 3,
+                "writer doc_count must be unchanged after a rejected batch"
+            );
+
+            cancel_split(ctx);
+        });
+    }
+
+    /// L16/D5: a batch that would exceed the concurrent partition-writer bound is rejected
+    /// up front rather than failing deep inside ingestion.
+    #[test]
+    fn test_partition_writer_bound_rejected_up_front() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let schema = partitioned_schema();
+            let partition_cols = vec!["event_date".to_string()];
+            let mut ctx = begin_split_from_arrow(
+                schema, &partition_cols, 50_000_000, None, 0, None,
+            ).unwrap();
+
+            // MAX_PARTITION_WRITERS + 1 distinct partition keys in a single batch.
+            let n = MAX_PARTITION_WRITERS + 1;
+            let ids: Vec<i64> = (0..n as i64).collect();
+            let names: Vec<String> = (0..n).map(|i| format!("n{}", i)).collect();
+            let dates: Vec<String> = (0..n).map(|i| format!("d{}", i)).collect();
+            let batch = partitioned_batch(
+                ids,
+                names.iter().map(|s| s.as_str()).collect(),
+                dates.iter().map(|s| s.as_str()).collect(),
+            );
+
+            let res = add_arrow_batch(&mut ctx, &batch).await;
+            assert!(res.is_err(), "exceeding the partition-writer bound must be an error");
+            let msg = res.unwrap_err().to_string();
+            assert!(msg.contains("Too many partitions"), "unexpected error: {}", msg);
+
+            // Rejected up front: no writers were created, no rows ingested.
+            assert!(ctx.partition_writers.is_empty(), "no partition writers should be created");
+            assert_eq!(ctx.total_doc_count, 0);
+
+            cancel_split(ctx);
         });
     }
 }

--- a/native/src/parquet_companion/arrow_to_tant.rs
+++ b/native/src/parquet_companion/arrow_to_tant.rs
@@ -267,9 +267,12 @@ fn write_arrow_value_to_tant(
         }
         DataType::List(_)
         | DataType::LargeList(_)
+        | DataType::FixedSizeList(_, _)
         | DataType::Map(_, _)
         | DataType::Struct(_) => {
-            // Complex types: serialize via arrow_json_value, then length-prefixed string
+            // Complex types (incl. FixedSizeList, e.g. embeddings — schema
+            // derivation maps these to JSON, so retrieval must serialize them
+            // as JSON, not an empty string — M12): length-prefixed JSON string.
             let slice = array.slice(row_idx, 1);
             let json_value = arrow_json_value(&slice, 0);
             let json_str =
@@ -279,8 +282,18 @@ fn write_arrow_value_to_tant(
             buf.extend_from_slice(bytes);
         }
         _ => {
-            // Fallback: write as empty text
-            buf.extend_from_slice(&0u32.to_ne_bytes());
+            // Unknown/unsupported type (Dictionary, Time, Duration, …): write a
+            // best-effort JSON representation rather than a silent empty string,
+            // which would masquerade as real data on retrieval (M12). Types
+            // arrow_json_value can't represent become JSON null — still clearly
+            // distinguishable from a wrong "".
+            let slice = array.slice(row_idx, 1);
+            let json_value = arrow_json_value(&slice, 0);
+            let json_str =
+                serde_json::to_string(&json_value).unwrap_or_else(|_| "null".to_string());
+            let bytes = json_str.as_bytes();
+            buf.extend_from_slice(&(bytes.len() as u32).to_ne_bytes());
+            buf.extend_from_slice(bytes);
         }
     }
 
@@ -342,9 +355,18 @@ fn assemble_tant_buffer(doc_buffers: Vec<Option<Vec<u8>>>) -> Result<Vec<u8>> {
     // Header magic
     buffer.extend_from_slice(&MAGIC_NUMBER.to_ne_bytes());
 
-    // Write documents and collect offsets
+    // Write documents and collect offsets. Offsets are u32, so the whole buffer
+    // (documents + offset table) must stay under 4 GiB; otherwise `as u32` would
+    // silently wrap and the Java parser would read garbage. Guard it (L9).
     let mut offsets = Vec::with_capacity(doc_buffers.len());
     for doc_opt in &doc_buffers {
+        if buffer.len() > u32::MAX as usize {
+            anyhow::bail!(
+                "TANT batch buffer exceeds 4 GiB ({} bytes); u32 document offsets \
+                 would overflow. Reduce the batch size / number of documents per call.",
+                buffer.len()
+            );
+        }
         offsets.push(buffer.len() as u32);
         match doc_opt {
             Some(doc_bytes) => buffer.extend_from_slice(doc_bytes),
@@ -356,6 +378,13 @@ fn assemble_tant_buffer(doc_buffers: Vec<Option<Vec<u8>>>) -> Result<Vec<u8>> {
     }
 
     // Offset table
+    if buffer.len() > u32::MAX as usize {
+        anyhow::bail!(
+            "TANT batch buffer exceeds 4 GiB ({} bytes) at the offset table; \
+             u32 offsets would overflow.",
+            buffer.len()
+        );
+    }
     let offset_table_start = buffer.len() as u32;
     for offset in &offsets {
         buffer.extend_from_slice(&offset.to_ne_bytes());
@@ -693,6 +722,13 @@ pub async fn read_parquet_batches_for_file(
         t_file.elapsed().as_millis()
     );
 
+    // Decode Dictionary-encoded columns so downstream value extraction downcasts
+    // to concrete arrays rather than yielding empty/null for categoricals (M3).
+    let collected_batches = collected_batches
+        .into_iter()
+        .map(super::indexing::decode_dictionary_columns)
+        .collect::<Result<Vec<_>>>()?;
+
     Ok(collected_batches)
 }
 
@@ -716,11 +752,17 @@ pub async fn read_parquet_batches_by_groups(
     let projected_fields_shared: Option<Arc<[String]>> =
         projected_fields.map(|f| f.into());
 
+    // Share the manifest via a single Arc rather than deep-cloning it into every
+    // per-file task. The manifest packs page-location arrays for ALL files and
+    // can be multi-MB; with 200 touched files that was 200 full clones per
+    // docBatch call (E3). One clone into the Arc, then cheap Arc clones per task.
+    let manifest_shared: Arc<ParquetManifest> = Arc::new(manifest.clone());
+
     let file_futures: Vec<_> = groups
         .into_iter()
         .map(|(file_idx, rows)| {
             let storage = storage.clone();
-            let manifest = manifest.clone();
+            let manifest = manifest_shared.clone();
             let projected_fields_owned = projected_fields_shared.clone();
             let metadata_cache = metadata_cache.cloned();
             let byte_cache = byte_cache.cloned();

--- a/native/src/parquet_companion/arrow_to_tant.rs
+++ b/native/src/parquet_companion/arrow_to_tant.rs
@@ -164,8 +164,11 @@ fn write_arrow_value_to_tant(
             let s = if *scale == 0 {
                 raw.to_string()
             } else {
-                let val: f64 =
-                    raw.to_string().parse::<f64>().unwrap_or(0.0) / 10f64.powi(*scale as i32);
+                // Scale via f64. A parse failure means the i256 exceeded f64 range;
+                // surface it as an error rather than silently producing 0.0.
+                let parsed = raw.to_string().parse::<f64>()
+                    .map_err(|e| anyhow::anyhow!("Failed to parse Decimal256 value '{}' as f64: {}", raw, e))?;
+                let val: f64 = parsed / 10f64.powi(*scale as i32);
                 val.to_string()
             };
             let bytes = s.as_bytes();
@@ -246,12 +249,20 @@ fn write_arrow_value_to_tant(
         }
         DataType::Date32 => {
             let arr = array.as_any().downcast_ref::<Date32Array>().ok_or_else(|| anyhow::anyhow!("Expected Date32Array array"))?;
-            let nanos = arr.value(row_idx) as i64 * 86_400 * 1_000_000_000;
+            // Days since epoch → nanos. Use checked arithmetic: an extreme Date32
+            // from an untrusted parquet file would otherwise overflow (panic in
+            // debug, silently wrong date in release).
+            let nanos = (arr.value(row_idx) as i64)
+                .checked_mul(86_400 * 1_000_000_000)
+                .ok_or_else(|| anyhow::anyhow!("Date32 overflow converting to nanos"))?;
             buf.extend_from_slice(&nanos.to_ne_bytes());
         }
         DataType::Date64 => {
             let arr = array.as_any().downcast_ref::<Date64Array>().ok_or_else(|| anyhow::anyhow!("Expected Date64Array array"))?;
-            let nanos = arr.value(row_idx) * 1_000_000;
+            // Millis since epoch → nanos, checked to avoid overflow on extreme input.
+            let nanos = arr.value(row_idx)
+                .checked_mul(1_000_000)
+                .ok_or_else(|| anyhow::anyhow!("Date64 overflow converting to nanos"))?;
             buf.extend_from_slice(&nanos.to_ne_bytes());
         }
         DataType::List(_)
@@ -786,11 +797,38 @@ pub async fn batch_parquet_to_tant_buffer_by_groups(
             }
         }
 
-        // Pair rows with original indices
-        let mut drain_iter = collected_rows.drain(..);
-        for (original_idx, _) in &rows {
-            let data = drain_iter.next().unwrap_or_default();
-            doc_buffers[*original_idx] = Some(data);
+        // Pair decoded rows with original indices.
+        //
+        // `rows` is sorted by row_in_file and may contain duplicate rows (the same
+        // parquet row requested by multiple doc addresses in one batch). The
+        // RowSelection selects each physical row exactly once, so `collected_rows`
+        // holds one buffer per DISTINCT requested row, in sorted order. Walk runs
+        // of equal rows, assigning each decoded buffer to every original index in
+        // the run (cloning for all but the last so the common all-distinct case
+        // stays clone-free).
+        let mut buf_iter = collected_rows.into_iter();
+        let mut i = 0usize;
+        while i < rows.len() {
+            let row = rows[i].1;
+            let mut j = i + 1;
+            while j < rows.len() && rows[j].1 == row {
+                j += 1;
+            }
+            let data = buf_iter.next().ok_or_else(|| anyhow::anyhow!(
+                "Parquet decode row-count mismatch: fewer rows decoded than \
+                 requested (doc→row alignment would be corrupted)"
+            ))?;
+            for k in i..j - 1 {
+                doc_buffers[rows[k].0] = Some(data.clone());
+            }
+            doc_buffers[rows[j - 1].0] = Some(data);
+            i = j;
+        }
+        if buf_iter.next().is_some() {
+            anyhow::bail!(
+                "Parquet decode row-count mismatch: more rows decoded than \
+                 distinct rows requested (doc→row alignment would be corrupted)"
+            );
         }
     }
     if crate::ffi_profiler::is_enabled() {

--- a/native/src/parquet_companion/doc_retrieval.rs
+++ b/native/src/parquet_companion/doc_retrieval.rs
@@ -843,6 +843,25 @@ pub(crate) fn arrow_json_value(array: &ArrayRef, row_idx: usize) -> serde_json::
             }
             serde_json::Value::Array(arr)
         }
+        DataType::LargeList(_) => {
+            let list = array.as_any().downcast_ref::<LargeListArray>().expect("Expected LargeListArray array");
+            let values = list.value(row_idx);
+            let mut arr = Vec::new();
+            for i in 0..values.len() {
+                arr.push(arrow_json_value(&values, i));
+            }
+            serde_json::Value::Array(arr)
+        }
+        DataType::FixedSizeList(_, _) => {
+            // e.g. embedding vectors — serialize element-wise as a JSON array (M12).
+            let list = array.as_any().downcast_ref::<FixedSizeListArray>().expect("Expected FixedSizeListArray array");
+            let values = list.value(row_idx);
+            let mut arr = Vec::new();
+            for i in 0..values.len() {
+                arr.push(arrow_json_value(&values, i));
+            }
+            serde_json::Value::Array(arr)
+        }
         DataType::Struct(_) => {
             let struct_arr = array.as_any().downcast_ref::<StructArray>().expect("Expected StructArray array");
             let mut map = serde_json::Map::new();
@@ -867,6 +886,14 @@ pub(crate) fn arrow_json_value(array: &ArrayRef, row_idx: usize) -> serde_json::
                 }
             }
             serde_json::Value::Object(map)
+        }
+        DataType::Dictionary(_, value_type) => {
+            // Decode categorical columns to their value type rather than yielding
+            // null (M3). Cast the whole array once; callers are per-row.
+            match arrow::compute::cast(array.as_ref(), value_type) {
+                Ok(decoded) => arrow_json_value(&decoded, row_idx),
+                Err(_) => serde_json::Value::Null,
+            }
         }
         _ => {
             // Leaf types

--- a/native/src/parquet_companion/doc_retrieval.rs
+++ b/native/src/parquet_companion/doc_retrieval.rs
@@ -624,7 +624,20 @@ pub(crate) fn build_row_selection_for_rows_in_selected_groups(
             selectors.push(RowSelector::select(1));
             current_pos = absolute_pos + 1;
 
+            // Consume this row and any duplicate occurrences of it. A RowSelection
+            // is a forward-only cursor and cannot re-select the same physical row;
+            // emitting a second select(1) for a duplicate would instead select the
+            // adjacent row and return wrong data. Duplicates (same parquet row
+            // requested by multiple doc addresses) are handled by the caller when
+            // pairing decoded rows back to original indices.
             row_iter.next();
+            while let Some(&&next) = row_iter.peek() {
+                if next == file_row {
+                    row_iter.next();
+                } else {
+                    break;
+                }
+            }
         }
     }
 

--- a/native/src/parquet_companion/docid_mapping.rs
+++ b/native/src/parquet_companion/docid_mapping.rs
@@ -60,34 +60,44 @@ pub fn locate_row_in_file(
         ));
     }
 
-    // Binary search: find the last file whose row_offset <= global_row
-    let file_idx = match manifest
+    // Find the file whose half-open range [row_offset, row_offset + num_rows)
+    // contains global_row. We search on the *end* offset (row_offset + num_rows)
+    // rather than the start offset so the resolution is deterministic even when a
+    // zero-row file shares its row_offset with the following file: a zero-row
+    // file's range is empty (end == start) so `partition_point` never selects it.
+    //
+    // Files are stored in row order and are contiguous, so the end offsets are
+    // non-decreasing and this predicate is true for a prefix then false — the
+    // requirement for `partition_point`.
+    let file_idx = manifest
         .parquet_files
-        .binary_search_by_key(&global_row, |f| f.row_offset)
-    {
-        Ok(idx) => idx,
-        Err(idx) => {
-            // idx is where global_row would be inserted; the file is at idx - 1
-            if idx == 0 {
-                return Err(format!(
-                    "Global row {} is before first file offset {}",
-                    global_row, manifest.parquet_files[0].row_offset
-                ));
-            }
-            idx - 1
-        }
-    };
+        .partition_point(|f| f.row_offset + f.num_rows <= global_row);
+
+    // Because files cover [0, total_rows) contiguously and global_row <
+    // total_rows, partition_point always yields a valid, non-empty file. Guard
+    // defensively against a malformed manifest that slips past validation.
+    if file_idx >= manifest.parquet_files.len() {
+        return Err(format!(
+            "Global row {} could not be located in any parquet file \
+             (manifest may be malformed)",
+            global_row
+        ));
+    }
 
     let file = &manifest.parquet_files[file_idx];
-    let row_in_file = global_row - file.row_offset;
+    let row_in_file = global_row.checked_sub(file.row_offset).ok_or_else(|| {
+        format!(
+            "Global row {} precedes file[{}] offset {} (manifest may be malformed)",
+            global_row, file_idx, file.row_offset
+        )
+    })?;
 
-    debug_assert!(
-        row_in_file < file.num_rows,
-        "row_in_file {} >= num_rows {} for file[{}]",
-        row_in_file,
-        file.num_rows,
-        file_idx
-    );
+    if row_in_file >= file.num_rows {
+        return Err(format!(
+            "row_in_file {} >= num_rows {} for file[{}] (manifest may be malformed)",
+            row_in_file, file.num_rows, file_idx
+        ));
+    }
 
     Ok(FileRowLocation {
         file_idx,
@@ -284,6 +294,86 @@ mod tests {
     fn test_locate_out_of_range() {
         let manifest = make_multi_file_manifest();
         assert!(locate_row_in_file(3000, &manifest).is_err());
+    }
+
+    fn make_entry(path: &str, row_offset: u64, num_rows: u64) -> ParquetFileEntry {
+        ParquetFileEntry {
+            relative_path: path.to_string(),
+            file_size_bytes: 1024,
+            row_offset,
+            num_rows,
+            has_offset_index: false,
+            row_groups: vec![],
+        }
+    }
+
+    fn manifest_with_files(files: Vec<ParquetFileEntry>) -> ParquetManifest {
+        let total: u64 = files.iter().map(|f| f.num_rows).sum();
+        let mut m = make_multi_file_manifest();
+        m.parquet_files = files;
+        m.total_rows = total;
+        m.segment_row_ranges = vec![SegmentRowRange { segment_ord: 0, row_offset: 0, num_rows: total }];
+        m
+    }
+
+    #[test]
+    fn test_locate_skips_leading_zero_row_file() {
+        // A zero-row file shares row_offset 0 with the following real file.
+        // Every lookup must resolve to the real (non-empty) file, never the
+        // zero-row one.
+        let manifest = manifest_with_files(vec![
+            make_entry("empty.parquet", 0, 0),
+            make_entry("real.parquet", 0, 1000),
+        ]);
+
+        let loc = locate_row_in_file(0, &manifest).unwrap();
+        assert_eq!(loc.file_idx, 1, "row 0 must map to the real file, not the zero-row file");
+        assert_eq!(loc.row_in_file, 0);
+
+        let loc = locate_row_in_file(999, &manifest).unwrap();
+        assert_eq!(loc.file_idx, 1);
+        assert_eq!(loc.row_in_file, 999);
+    }
+
+    #[test]
+    fn test_locate_skips_interior_zero_row_file() {
+        // real(0..1000), zero-row(1000..1000), real2(1000..2000).
+        // The zero-row file shares row_offset 1000 with real2 and must never
+        // be selected.
+        let manifest = manifest_with_files(vec![
+            make_entry("a.parquet", 0, 1000),
+            make_entry("empty.parquet", 1000, 0),
+            make_entry("b.parquet", 1000, 1000),
+        ]);
+
+        let loc = locate_row_in_file(999, &manifest).unwrap();
+        assert_eq!(loc.file_idx, 0);
+        assert_eq!(loc.row_in_file, 999);
+
+        // Boundary row 1000 belongs to real2 (index 2), not the zero-row file.
+        let loc = locate_row_in_file(1000, &manifest).unwrap();
+        assert_eq!(loc.file_idx, 2, "boundary row must map to the real file at that offset");
+        assert_eq!(loc.row_in_file, 0);
+
+        let loc = locate_row_in_file(1999, &manifest).unwrap();
+        assert_eq!(loc.file_idx, 2);
+        assert_eq!(loc.row_in_file, 999);
+    }
+
+    #[test]
+    fn test_locate_trailing_zero_row_file() {
+        // A trailing zero-row file must not affect resolution of real rows.
+        let manifest = manifest_with_files(vec![
+            make_entry("real.parquet", 0, 1000),
+            make_entry("empty.parquet", 1000, 0),
+        ]);
+
+        let loc = locate_row_in_file(999, &manifest).unwrap();
+        assert_eq!(loc.file_idx, 0);
+        assert_eq!(loc.row_in_file, 999);
+
+        // row 1000 is out of range (total_rows == 1000).
+        assert!(locate_row_in_file(1000, &manifest).is_err());
     }
 
     #[test]

--- a/native/src/parquet_companion/field_extraction.rs
+++ b/native/src/parquet_companion/field_extraction.rs
@@ -70,6 +70,10 @@ const AGG_TYPE_KEYS: &[&str] = &[
     "terms", "histogram", "date_histogram", "stats",
     "min", "max", "avg", "sum", "value_count",
     "percentiles", "cardinality",
+    // Bucket/metric aggregations that also name their target column via "field".
+    // Omitting these meant a range aggregation on a parquet-sourced fast field
+    // never triggered lazy transcoding → "field is not fast" at query time.
+    "range", "date_range", "extended_stats", "percentile_ranks",
 ];
 
 fn extract_fields_from_agg_value(value: &serde_json::Value, fields: &mut HashSet<String>) {
@@ -106,12 +110,6 @@ fn extract_fields_from_query_value(value: &serde_json::Value, fields: &mut HashS
                     if let Some(field_name) = map.get("field").and_then(|f| f.as_str()) {
                         fields.insert(field_name.to_string());
                     }
-                }
-            }
-            // Also check Elasticsearch-style: { "range": { "field": "..." } }
-            if let Some(range_obj) = map.get("range") {
-                if let Some(field_name) = range_obj.get("field").and_then(|f| f.as_str()) {
-                    fields.insert(field_name.to_string());
                 }
             }
             // Recurse into all nested objects (bool must/should/must_not, etc.)
@@ -180,6 +178,29 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_range_agg_field() {
+        // Range aggregation names its column via "field" like other aggs.
+        let json = r#"{"price_ranges": {"range": {"field": "price", "ranges": [{"to": 10.0}, {"from": 10.0, "to": 100.0}]}}}"#;
+        let fields = extract_aggregation_fields(json);
+        assert_eq!(fields, HashSet::from(["price".to_string()]));
+    }
+
+    #[test]
+    fn test_extract_date_range_and_extended_stats_and_percentile_ranks_fields() {
+        let json = r#"{
+            "dr": {"date_range": {"field": "created_at", "ranges": [{"to": "now-1d"}]}},
+            "es": {"extended_stats": {"field": "latency"}},
+            "pr": {"percentile_ranks": {"field": "duration", "values": [95.0, 99.0]}}
+        }"#;
+        let fields = extract_aggregation_fields(json);
+        assert_eq!(fields, HashSet::from([
+            "created_at".to_string(),
+            "latency".to_string(),
+            "duration".to_string(),
+        ]));
+    }
+
+    #[test]
     fn test_extract_multiple_top_level_aggs() {
         let json = r#"{
             "agg1": {"terms": {"field": "status"}},
@@ -197,13 +218,6 @@ mod tests {
         let json = r#"{"type": "range", "field": "id", "lower_bound": {"included": "5"}, "upper_bound": {"included": "10"}}"#;
         let fields = extract_range_query_fields(json);
         assert_eq!(fields, HashSet::from(["id".to_string()]));
-    }
-
-    #[test]
-    fn test_extract_range_query_es_style() {
-        let json = r#"{"range": {"field": "price", "gte": "10", "lte": "100"}}"#;
-        let fields = extract_range_query_fields(json);
-        assert_eq!(fields, HashSet::from(["price".to_string()]));
     }
 
     #[test]

--- a/native/src/parquet_companion/hash_field_rewriter.rs
+++ b/native/src/parquet_companion/hash_field_rewriter.rs
@@ -44,6 +44,12 @@ pub struct HashFieldTouchupInfo {
     pub include_strings: Option<std::collections::HashSet<String>>,
     /// Original exclude filter string values (before hashing).
     pub exclude_strings: Option<std::collections::HashSet<String>>,
+    /// The originally-requested `size` (number of buckets to return). When an
+    /// include/exclude filter is present we enlarge the `size` sent to Tantivy so
+    /// the post-filter (in `create_terms_result_object`) has enough candidate
+    /// buckets to choose from, then truncate the filtered result back to this size.
+    /// `None` when no filter was applied (Tantivy already truncated to the size).
+    pub result_size: Option<usize>,
 }
 
 /// Output of the aggregation rewriter.
@@ -155,6 +161,13 @@ fn rewrite_agg_def(
                             .and_then(|m| m.as_str())
                             .map(|s| s.to_string());
 
+                        // Capture the originally-requested size before we enlarge it.
+                        // Tantivy/Elasticsearch default is 10.
+                        let original_size = terms_map
+                            .get("size")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(10) as usize;
+
                         // Capture include filter strings for post-processing.
                         // Tantivy ignores numeric include arrays for U64 fields, so we
                         // record the original strings and apply the filter ourselves in
@@ -200,6 +213,37 @@ fn rewrite_agg_def(
                             terms_map.remove("exclude");
                         }
 
+                        // When we strip an include/exclude filter, Tantivy computes the
+                        // top-`size` buckets over ALL hash values and only then do we
+                        // post-filter by the original strings. A rare included term is
+                        // unlikely to appear in an unfiltered top-`size`, so we must
+                        // enlarge the `size`/`segment_size` sent to Tantivy and truncate
+                        // the filtered result back to `original_size` afterwards.
+                        //
+                        // - include: the filtered result is bounded by include.len() but the
+                        //   included terms can have any count-rank, so we must request all
+                        //   buckets (a large ceiling; capped by the aggregation bucket limit).
+                        // - exclude only: removing at most exclude.len() buckets from the top
+                        //   `original_size + exclude.len()` guarantees `original_size` remain.
+                        let result_size = if include_strings.is_some() {
+                            // Request effectively all distinct buckets. Set size and
+                            // segment_size explicitly (equal) to avoid the `size * 10`
+                            // overflow in TermsAggregationInternal::from_req.
+                            const INCLUDE_ALL_CEILING: u64 = 1_000_000;
+                            terms_map.insert("size".to_string(), json!(INCLUDE_ALL_CEILING));
+                            terms_map.insert("segment_size".to_string(), json!(INCLUDE_ALL_CEILING));
+                            Some(original_size)
+                        } else if exclude_strings.is_some() {
+                            let enlarged = (original_size as u64)
+                                .saturating_add(exclude_strings.as_ref().unwrap().len() as u64)
+                                .min(u32::MAX as u64);
+                            terms_map.insert("size".to_string(), json!(enlarged));
+                            terms_map.insert("segment_size".to_string(), json!(enlarged));
+                            Some(original_size)
+                        } else {
+                            None
+                        };
+
                         // Map missing string → 0 (null sentinel for hash field)
                         if missing_value.is_some() {
                             terms_map.insert("missing".to_string(), json!(0u64));
@@ -217,6 +261,7 @@ fn rewrite_agg_def(
                             missing_value,
                             include_strings,
                             exclude_strings,
+                            result_size,
                         });
                     }
                 } else {
@@ -775,6 +820,47 @@ mod tests {
         assert!(exclude_strings.contains("deleted"));
         // include should be None
         assert!(out.touchup_infos[0].include_strings.is_none());
+    }
+
+    #[test]
+    fn test_rewrite_terms_include_enlarges_size() {
+        // When an include filter is stripped, Tantivy computes top-`size` over ALL
+        // hash values before we post-filter. A rare included term would be lost from
+        // an unfiltered top-10, so the rewriter must enlarge the requested size (and
+        // segment_size) and record the original size for later truncation.
+        let agg_json = r#"{"by_status": {"terms": {"field": "status", "size": 10, "include": ["rare_a", "rare_b"]}}}"#;
+        let out = rewrite_aggs_for_hash_fields(agg_json, &make_hash_fields()).unwrap();
+        let v: Value = serde_json::from_str(&out.rewritten_json).unwrap();
+        let enlarged = v["by_status"]["terms"]["size"].as_u64().unwrap();
+        assert!(enlarged > 10, "size should be enlarged well beyond the requested 10, got {}", enlarged);
+        // segment_size must be set explicitly (equal to size) to avoid the size*10 overflow
+        assert_eq!(v["by_status"]["terms"]["segment_size"].as_u64().unwrap(), enlarged);
+        // Original size retained for post-filter truncation.
+        assert_eq!(out.touchup_infos[0].result_size, Some(10));
+    }
+
+    #[test]
+    fn test_rewrite_terms_exclude_enlarges_size_by_exclude_count() {
+        // Excluding N terms from the top `size + N` guarantees `size` remain after
+        // post-filtering, so the rewriter enlarges size by exactly exclude.len().
+        let agg_json = r#"{"by_status": {"terms": {"field": "status", "size": 5, "exclude": ["inactive", "deleted"]}}}"#;
+        let out = rewrite_aggs_for_hash_fields(agg_json, &make_hash_fields()).unwrap();
+        let v: Value = serde_json::from_str(&out.rewritten_json).unwrap();
+        // 5 requested + 2 excluded = 7
+        assert_eq!(v["by_status"]["terms"]["size"].as_u64().unwrap(), 7);
+        assert_eq!(out.touchup_infos[0].result_size, Some(5));
+    }
+
+    #[test]
+    fn test_rewrite_terms_no_filter_leaves_size_and_result_size_unset() {
+        // Without include/exclude, Tantivy already truncates to `size`; the rewriter
+        // must not enlarge it or set result_size (which would trigger truncation).
+        let agg_json = r#"{"by_status": {"terms": {"field": "status", "size": 10}}}"#;
+        let out = rewrite_aggs_for_hash_fields(agg_json, &make_hash_fields()).unwrap();
+        let v: Value = serde_json::from_str(&out.rewritten_json).unwrap();
+        assert_eq!(v["by_status"]["terms"]["size"].as_u64().unwrap(), 10);
+        assert!(v["by_status"]["terms"]["segment_size"].is_null());
+        assert_eq!(out.touchup_infos[0].result_size, None);
     }
 
     #[test]

--- a/native/src/parquet_companion/hash_touchup.rs
+++ b/native/src/parquet_companion/hash_touchup.rs
@@ -273,12 +273,22 @@ pub async fn build_hash_resolution_map(
             .extend(hashes.into_iter().filter(|h| hash_to_doc.contains_key(h)));
     }
 
-    let mut all_resolutions: HashMap<u64, String> = HashMap::new();
+    // Phase A: resolve each unique hash → (file_idx, row_in_file, field) synchronously
+    // using the O(1) __pq column cache (with manifest-based fallback). Deduplicate by
+    // hash so each hash triggers at most one parquet read.
+    struct ReadTask {
+        hash_val: u64,
+        field: String,
+        file_idx: usize,
+        row_in_file: u64,
+    }
+    let mut read_tasks: Vec<ReadTask> = Vec::new();
+    let mut resolved_seen: HashSet<u64> = HashSet::new();
 
     for (original_field_name, hashes) in &field_to_hashes {
         for hash_val in hashes {
-            if all_resolutions.contains_key(hash_val) {
-                continue; // already resolved
+            if !resolved_seen.insert(*hash_val) {
+                continue; // already scheduled for this hash
             }
 
             let (seg_ord, doc_id) = match hash_to_doc.get(hash_val) {
@@ -334,11 +344,28 @@ pub async fn build_hash_resolution_map(
                 None => continue,
             };
 
-            let fields_to_read = vec![original_field_name.clone()];
-            match crate::parquet_companion::doc_retrieval::retrieve_document_by_location(
-                manifest,
+            read_tasks.push(ReadTask {
+                hash_val: *hash_val,
+                field: original_field_name.clone(),
                 file_idx,
                 row_in_file,
+            });
+        }
+    }
+
+    // Phase B: run the parquet reads concurrently. The reads are independent, and
+    // the shared metadata / byte-range caches deduplicate overlapping fetches, so
+    // running them with bounded concurrency turns N serial S3/Azure round trips
+    // into ceil(N / CONCURRENCY) waves.
+    use futures::StreamExt;
+    const HASH_TOUCHUP_READ_CONCURRENCY: usize = 16;
+    let resolutions: Vec<Option<(u64, String)>> = futures::stream::iter(
+        read_tasks.into_iter().map(|task| async move {
+            let fields_to_read = vec![task.field.clone()];
+            match crate::parquet_companion::doc_retrieval::retrieve_document_by_location(
+                manifest,
+                task.file_idx,
+                task.row_in_file,
                 Some(&fields_to_read),
                 parquet_storage,
                 Some(parquet_metadata_cache),
@@ -347,18 +374,24 @@ pub async fn build_hash_resolution_map(
             )
             .await
             {
-                Ok(doc_map) => {
-                    if let Some(val) = doc_map.get(original_field_name) {
-                        if let Some(s) = val.as_str() {
-                            all_resolutions.insert(*hash_val, s.to_string());
-                        }
-                    }
-                }
+                Ok(doc_map) => doc_map
+                    .get(&task.field)
+                    .and_then(|v| v.as_str())
+                    .map(|s| (task.hash_val, s.to_string())),
                 Err(e) => {
                     debug_println!("⚠️ HASH_TOUCHUP: Failed to read parquet cell: {}", e);
+                    None
                 }
             }
-        }
+        }),
+    )
+    .buffer_unordered(HASH_TOUCHUP_READ_CONCURRENCY)
+    .collect()
+    .await;
+
+    let mut all_resolutions: HashMap<u64, String> = HashMap::new();
+    for (hash_val, value) in resolutions.into_iter().flatten() {
+        all_resolutions.insert(hash_val, value);
     }
 
     if crate::ffi_profiler::is_enabled() {

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -466,18 +466,23 @@ pub async fn create_split_from_parquet(
     let mut cumulative_row_offset: u64 = 0;
     let mut total_rows: u64 = 0;
 
-    // Column projection (E1): only the columns we actually index (present in
-    // column_mapping — every skipped or unsupported-type column is excluded).
-    // Reading, decompressing and Arrow-decoding all N columns of a wide table
-    // when we index only a handful is ~95% wasted I/O/CPU. Compute the arrow
-    // top-level field indices to keep once (schema is validated consistent
-    // across files) and apply ProjectionMask::roots per file below.
-    let indexed_parquet_cols: std::collections::HashSet<&str> = column_mapping.iter()
-        .map(|m| m.parquet_column_name.as_str())
-        .collect();
+    // Column projection (E1): only the columns we actually index. Reading,
+    // decompressing and Arrow-decoding all N columns of a wide table when we
+    // index only a handful is ~95% wasted I/O/CPU. A column is indexed iff it is
+    // not skipped AND its mapped tantivy name is a real field in the derived
+    // schema (unsupported types were dropped during derivation). NB:
+    // build_column_mapping deliberately maps EVERY arrow column (for doc
+    // retrieval of non-indexed columns), so it is NOT the right source here.
+    // Compute the arrow top-level field indices to keep once (schema is validated
+    // consistent across files) and apply ProjectionMask::roots per file below.
     let projection_indices: Vec<usize> = arrow_schema.fields().iter().enumerate()
         .filter_map(|(i, f)| {
-            if indexed_parquet_cols.contains(f.name().as_str()) { Some(i) } else { None }
+            let pname = f.name();
+            if config.skip_fields.contains(pname.as_str()) {
+                return None;
+            }
+            let tname = map_to_tantivy(pname);
+            if tantivy_schema.get_field(&tname).is_ok() { Some(i) } else { None }
         })
         .collect();
     // Only project when it is a proper, non-empty subset — a full or empty mask

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -44,13 +44,16 @@ pub const PARQUET_FILE_HASH_FIELD: &str = "__pq_file_hash";
 /// Hidden u64 fast field storing the 0-based row index within the parquet file.
 pub const PARQUET_ROW_IN_FILE_FIELD: &str = "__pq_row_in_file";
 
-/// Compute a stable u64 hash for a parquet file's relative path.
-/// Uses FxHash-style mixing for speed; collision probability ~1/2^64 per pair.
+/// Compute a stable u64 hash for a parquet file's relative path using xxHash64.
+///
+/// This value is persisted into split files (the `__pq_file_hash` fast field is
+/// written at index time and must equal the hash recomputed at read time from the
+/// manifest paths in `docid_mapping::build_file_hash_index`). It therefore MUST use
+/// a hash with a stable, versioned algorithm — `std::hash::DefaultHasher` is
+/// explicitly unspecified across toolchain releases and would silently break
+/// doc→parquet resolution for every previously created split.
 pub fn hash_parquet_path(relative_path: &str) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    relative_path.hash(&mut hasher);
-    hasher.finish()
+    xxhash_rust::xxh64::xxh64(relative_path.as_bytes(), 0)
 }
 
 /// Compute a stable 64-bit hash for a string value using xxHash64.
@@ -553,13 +556,18 @@ pub async fn create_split_from_parquet(
             let batch = batch_result.context("Failed to read record batch")?;
             let batch_schema = batch.schema();
 
+            // Resolve column → tantivy field once per batch (batch-invariant work),
+            // instead of re-running name mapping and schema lookups per row.
+            let resolved_columns = resolve_batch_columns(
+                &batch_schema, &tantivy_schema, &name_mapping, &config,
+            );
+
             for row_idx in 0..batch.num_rows() {
                 let mut tantivy_doc = arrow_row_to_tantivy_doc(
                     &batch,
-                    &batch_schema,
+                    &resolved_columns,
                     row_idx,
                     &tantivy_schema,
-                    &name_mapping,
                     &config,
                     &string_hash_fields,
                     &mut accumulators,
@@ -734,12 +742,56 @@ pub async fn create_split_from_parquet(
 }
 
 /// Convert a single Arrow row into a tantivy Document.
-pub(crate) fn arrow_row_to_tantivy_doc(
-    batch: &RecordBatch,
+/// A parquet column resolved to its tantivy field. All fields here are
+/// batch-invariant, so this is computed once per batch (via
+/// [`resolve_batch_columns`]) and reused across every row, instead of re-running
+/// name mapping and `Schema::get_field` (a string-hash lookup) per row.
+pub(crate) struct ResolvedColumn {
+    /// Column index into the RecordBatch.
+    col_idx: usize,
+    /// The resolved tantivy field (Field is a cheap Copy handle).
+    field: Field,
+    /// The tantivy field name (used for statistics accumulator keys and hashing).
+    tantivy_field_name: String,
+}
+
+/// Resolve, once per batch, which columns map to a tantivy field (skip-field
+/// filtering + name mapping + schema lookup). Columns with no tantivy field
+/// (unsupported type or explicitly skipped) are omitted.
+pub(crate) fn resolve_batch_columns(
     batch_schema: &ArrowSchema,
-    row_idx: usize,
     tantivy_schema: &Schema,
     name_mapping: &name_mapping::NameMapping,
+    config: &SchemaDerivationConfig,
+) -> Vec<ResolvedColumn> {
+    let mut cols = Vec::with_capacity(batch_schema.fields().len());
+    for (col_idx, arrow_field) in batch_schema.fields().iter().enumerate() {
+        let parquet_col_name = arrow_field.name();
+        if config.skip_fields.contains(parquet_col_name.as_str()) {
+            continue;
+        }
+        let tantivy_field_name = name_mapping
+            .get(parquet_col_name.as_str())
+            .map(|s| s.as_str())
+            .unwrap_or(parquet_col_name.as_str());
+        let field = match tantivy_schema.get_field(tantivy_field_name) {
+            Ok(f) => f,
+            Err(_) => continue, // Field not in tantivy schema (unsupported type), skip
+        };
+        cols.push(ResolvedColumn {
+            col_idx,
+            field,
+            tantivy_field_name: tantivy_field_name.to_string(),
+        });
+    }
+    cols
+}
+
+pub(crate) fn arrow_row_to_tantivy_doc(
+    batch: &RecordBatch,
+    resolved_columns: &[ResolvedColumn],
+    row_idx: usize,
+    tantivy_schema: &Schema,
     config: &SchemaDerivationConfig,
     string_hash_fields: &HashMap<String, String>,
     accumulators: &mut HashMap<String, StatisticsAccumulator>,
@@ -748,39 +800,20 @@ pub(crate) fn arrow_row_to_tantivy_doc(
 ) -> Result<TantivyDocument> {
     let mut doc = TantivyDocument::new();
 
-    for (col_idx, arrow_field) in batch_schema.fields().iter().enumerate() {
-        let parquet_col_name = arrow_field.name();
-
-        // Skip fields that were excluded from schema derivation
-        if config.skip_fields.contains(parquet_col_name.as_str()) {
-            continue;
-        }
-
-        // Resolve display name via name mapping
-        let tantivy_field_name = name_mapping
-            .get(parquet_col_name.as_str())
-            .map(|s| s.as_str())
-            .unwrap_or(parquet_col_name.as_str());
-
-        // Look up the field in the tantivy schema
-        let field = match tantivy_schema.get_field(tantivy_field_name) {
-            Ok(f) => f,
-            Err(_) => continue, // Field not in tantivy schema (unsupported type), skip
-        };
-
-        let array = batch.column(col_idx);
+    for rc in resolved_columns {
+        let array = batch.column(rc.col_idx);
 
         if array.is_null(row_idx) {
             // Record null for statistics
-            if let Some(acc) = accumulators.get_mut(tantivy_field_name) {
+            if let Some(acc) = accumulators.get_mut(&rc.tantivy_field_name) {
                 acc.observe_null();
             }
             continue; // Skip null values — tantivy handles absent fields natively
         }
 
         add_arrow_value_to_doc(
-            &mut doc, field, array, arrow_field.data_type(), row_idx,
-            tantivy_field_name, config, string_hash_fields, tantivy_schema,
+            &mut doc, rc.field, array, array.data_type(), row_idx,
+            &rc.tantivy_field_name, config, string_hash_fields, tantivy_schema,
             accumulators, string_indexing_modes, compiled_regexes,
         )?;
     }
@@ -926,14 +959,19 @@ pub(crate) fn add_arrow_value_to_doc(
         }
 
         DataType::Timestamp(unit, _tz) => {
+            // Convert to micros with checked arithmetic — extreme values from an
+            // untrusted parquet file would otherwise overflow (panic in debug,
+            // silently wrong date in release).
             let micros = match unit {
                 TimeUnit::Second => {
                     let arr = array.as_any().downcast_ref::<TimestampSecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampSecondArray array"))?;
-                    arr.value(row_idx) * 1_000_000
+                    arr.value(row_idx).checked_mul(1_000_000)
+                        .ok_or_else(|| anyhow::anyhow!("Timestamp seconds overflow converting to micros"))?
                 }
                 TimeUnit::Millisecond => {
                     let arr = array.as_any().downcast_ref::<TimestampMillisecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampMillisecondArray array"))?;
-                    arr.value(row_idx) * 1_000
+                    arr.value(row_idx).checked_mul(1_000)
+                        .ok_or_else(|| anyhow::anyhow!("Timestamp millis overflow converting to micros"))?
                 }
                 TimeUnit::Microsecond => {
                     let arr = array.as_any().downcast_ref::<TimestampMicrosecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampMicrosecondArray array"))?;
@@ -954,7 +992,8 @@ pub(crate) fn add_arrow_value_to_doc(
         DataType::Date32 => {
             let arr = array.as_any().downcast_ref::<Date32Array>().ok_or_else(|| anyhow::anyhow!("Expected Date32Array array"))?;
             let days = arr.value(row_idx) as i64;
-            let micros = days * 86_400 * 1_000_000;
+            let micros = days.checked_mul(86_400 * 1_000_000)
+                .ok_or_else(|| anyhow::anyhow!("Date32 overflow converting to micros"))?;
             let dt = tantivy::DateTime::from_timestamp_micros(micros);
             doc.add_date(field, dt);
             if let Some(acc) = accumulators.get_mut(field_name) {
@@ -964,7 +1003,8 @@ pub(crate) fn add_arrow_value_to_doc(
         DataType::Date64 => {
             let arr = array.as_any().downcast_ref::<Date64Array>().ok_or_else(|| anyhow::anyhow!("Expected Date64Array array"))?;
             let millis = arr.value(row_idx);
-            let micros = millis * 1_000;
+            let micros = millis.checked_mul(1_000)
+                .ok_or_else(|| anyhow::anyhow!("Date64 overflow converting to micros"))?;
             let dt = tantivy::DateTime::from_timestamp_micros(micros);
             doc.add_date(field, dt);
             if let Some(acc) = accumulators.get_mut(field_name) {
@@ -988,8 +1028,11 @@ pub(crate) fn add_arrow_value_to_doc(
             let val = if *scale == 0 {
                 raw.to_string()
             } else {
-                let f: f64 = raw.to_string().parse::<f64>().unwrap_or(0.0)
-                    / 10f64.powi(*scale as i32);
+                // Scale via f64. A parse failure means the i256 exceeded f64 range;
+                // surface it as an error rather than silently producing 0.0.
+                let parsed = raw.to_string().parse::<f64>()
+                    .map_err(|e| anyhow::anyhow!("Failed to parse Decimal256 value '{}' as f64: {}", raw, e))?;
+                let f: f64 = parsed / 10f64.powi(*scale as i32);
                 f.to_string()
             };
             doc.add_text(field, &val);
@@ -1169,107 +1212,10 @@ fn add_json_string_value(
     Ok(())
 }
 
-/// Convert a complex Arrow type (List, Map, Struct) at a given row to a JSON value.
-///
-/// **Deprecated**: Prefer `convert_arrow_to_owned_value` which produces `OwnedValue` directly
-/// without the Arrow → serde_json::Value → String → OwnedValue round-trip.
-/// This function is retained for the TANT binary serialization path where a JSON string
-/// representation is still needed.
-pub(crate) fn convert_complex_to_json(array: &ArrayRef, row_idx: usize) -> Result<serde_json::Value> {
-    use arrow_array::*;
-    use arrow_schema::DataType;
-
-    if array.is_null(row_idx) {
-        return Ok(serde_json::Value::Null);
-    }
-
-    match array.data_type() {
-        DataType::List(_) | DataType::LargeList(_) => {
-            // Try ListArray first, then LargeListArray
-            if let Some(list_arr) = array.as_any().downcast_ref::<ListArray>() {
-                let inner = list_arr.value(row_idx);
-                let mut items = Vec::new();
-                for i in 0..inner.len() {
-                    items.push(convert_complex_to_json(&inner, i)?);
-                }
-                Ok(serde_json::Value::Array(items))
-            } else if let Some(list_arr) = array.as_any().downcast_ref::<LargeListArray>() {
-                let inner = list_arr.value(row_idx);
-                let mut items = Vec::new();
-                for i in 0..inner.len() {
-                    items.push(convert_complex_to_json(&inner, i)?);
-                }
-                Ok(serde_json::Value::Array(items))
-            } else {
-                Ok(serde_json::Value::Null)
-            }
-        }
-
-        DataType::Struct(fields) => {
-            let struct_arr = array.as_any().downcast_ref::<StructArray>().ok_or_else(|| anyhow::anyhow!("Expected StructArray array"))?;
-            let mut map = serde_json::Map::new();
-            for (i, field) in fields.iter().enumerate() {
-                let col = struct_arr.column(i);
-                if !col.is_null(row_idx) {
-                    let val = convert_complex_to_json(col, row_idx)?;
-                    map.insert(field.name().clone(), val);
-                }
-            }
-            Ok(serde_json::Value::Object(map))
-        }
-
-        // Scalar types inside complex types
-        DataType::Boolean => {
-            let arr = array.as_any().downcast_ref::<BooleanArray>().ok_or_else(|| anyhow::anyhow!("Expected BooleanArray array"))?;
-            Ok(serde_json::Value::Bool(arr.value(row_idx)))
-        }
-        DataType::Int32 => {
-            let arr = array.as_any().downcast_ref::<Int32Array>().ok_or_else(|| anyhow::anyhow!("Expected Int32Array array"))?;
-            Ok(serde_json::json!(arr.value(row_idx)))
-        }
-        DataType::Int64 => {
-            let arr = array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| anyhow::anyhow!("Expected Int64Array array"))?;
-            Ok(serde_json::json!(arr.value(row_idx)))
-        }
-        DataType::Float64 => {
-            let arr = array.as_any().downcast_ref::<Float64Array>().ok_or_else(|| anyhow::anyhow!("Expected Float64Array array"))?;
-            Ok(serde_json::json!(arr.value(row_idx)))
-        }
-        DataType::Utf8 => {
-            let arr = array.as_any().downcast_ref::<StringArray>().ok_or_else(|| anyhow::anyhow!("Expected StringArray array"))?;
-            Ok(serde_json::Value::String(arr.value(row_idx).to_string()))
-        }
-        DataType::Decimal128(_, scale) => {
-            let arr = array.as_any().downcast_ref::<Decimal128Array>().ok_or_else(|| anyhow::anyhow!("Expected Decimal128Array array"))?;
-            let raw = arr.value(row_idx) as f64;
-            let val = raw / 10f64.powi(*scale as i32);
-            Ok(serde_json::json!(val))
-        }
-        DataType::Decimal256(_, scale) => {
-            let arr = array.as_any().downcast_ref::<Decimal256Array>().ok_or_else(|| anyhow::anyhow!("Expected Decimal256Array array"))?;
-            let raw = arr.value(row_idx);
-            let val: f64 = raw.to_string().parse::<f64>().unwrap_or(0.0)
-                / 10f64.powi(*scale as i32);
-            Ok(serde_json::json!(val))
-        }
-        DataType::FixedSizeBinary(_) => {
-            let arr = array.as_any().downcast_ref::<FixedSizeBinaryArray>().ok_or_else(|| anyhow::anyhow!("Expected FixedSizeBinaryArray array"))?;
-            Ok(serde_json::Value::String(base64::Engine::encode(
-                &base64::engine::general_purpose::STANDARD,
-                arr.value(row_idx),
-            )))
-        }
-
-        _ => Ok(serde_json::Value::Null),
-    }
-}
-
 /// Convert an Arrow array value directly to tantivy `OwnedValue`, bypassing JSON serialization.
 ///
-/// This is the Arrow-native replacement for the previous pipeline:
-///   `convert_complex_to_json` → `serde_json::to_string` → `serde_json::from_str::<OwnedValue>`
-///
-/// By constructing `OwnedValue` directly from Arrow arrays, we eliminate:
+/// This replaced a previous pipeline that went Arrow → serde_json::Value → String →
+/// OwnedValue. By constructing `OwnedValue` directly from Arrow arrays, we eliminate:
 /// - serde_json::Value tree allocation
 /// - JSON string serialization
 /// - JSON string re-parsing back to OwnedValue
@@ -1439,22 +1385,28 @@ pub(crate) fn convert_arrow_to_owned_value(
             let arr = array.as_any().downcast_ref::<Decimal256Array>()
                 .ok_or_else(|| anyhow::anyhow!("Expected Decimal256Array"))?;
             let raw = arr.value(row_idx);
-            let val: f64 = raw.to_string().parse::<f64>().unwrap_or(0.0)
-                / 10f64.powi(*scale as i32);
+            // A parse failure means the i256 exceeded f64 range; surface it as an
+            // error rather than silently producing 0.0.
+            let parsed = raw.to_string().parse::<f64>()
+                .map_err(|e| anyhow::anyhow!("Failed to parse Decimal256 value '{}' as f64: {}", raw, e))?;
+            let val: f64 = parsed / 10f64.powi(*scale as i32);
             Ok(OwnedValue::F64(val))
         }
 
         DataType::Timestamp(unit, _) => {
+            // Checked conversion to micros — avoid overflow on extreme untrusted input.
             let micros = match unit {
                 TimeUnit::Second => {
                     let arr = array.as_any().downcast_ref::<TimestampSecondArray>()
                         .ok_or_else(|| anyhow::anyhow!("Expected TimestampSecondArray"))?;
-                    arr.value(row_idx) * 1_000_000
+                    arr.value(row_idx).checked_mul(1_000_000)
+                        .ok_or_else(|| anyhow::anyhow!("Timestamp seconds overflow converting to micros"))?
                 }
                 TimeUnit::Millisecond => {
                     let arr = array.as_any().downcast_ref::<TimestampMillisecondArray>()
                         .ok_or_else(|| anyhow::anyhow!("Expected TimestampMillisecondArray"))?;
-                    arr.value(row_idx) * 1_000
+                    arr.value(row_idx).checked_mul(1_000)
+                        .ok_or_else(|| anyhow::anyhow!("Timestamp millis overflow converting to micros"))?
                 }
                 TimeUnit::Microsecond => {
                     let arr = array.as_any().downcast_ref::<TimestampMicrosecondArray>()
@@ -1473,13 +1425,15 @@ pub(crate) fn convert_arrow_to_owned_value(
         DataType::Date32 => {
             let arr = array.as_any().downcast_ref::<Date32Array>()
                 .ok_or_else(|| anyhow::anyhow!("Expected Date32Array"))?;
-            let micros = arr.value(row_idx) as i64 * 86_400 * 1_000_000;
+            let micros = (arr.value(row_idx) as i64).checked_mul(86_400 * 1_000_000)
+                .ok_or_else(|| anyhow::anyhow!("Date32 overflow converting to micros"))?;
             Ok(OwnedValue::Date(tantivy::DateTime::from_timestamp_micros(micros)))
         }
         DataType::Date64 => {
             let arr = array.as_any().downcast_ref::<Date64Array>()
                 .ok_or_else(|| anyhow::anyhow!("Expected Date64Array"))?;
-            let micros = arr.value(row_idx) * 1_000;
+            let micros = arr.value(row_idx).checked_mul(1_000)
+                .ok_or_else(|| anyhow::anyhow!("Date64 overflow converting to micros"))?;
             Ok(OwnedValue::Date(tantivy::DateTime::from_timestamp_micros(micros)))
         }
 

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -399,10 +399,17 @@ pub async fn create_split_from_parquet(
     })?;
 
     // Single-threaded writer ensures docs within each segment are in insertion order.
-    // Merges are allowed (default LogMergePolicy) — the __pq_file_hash and
-    // __pq_row_in_file fast fields make doc→parquet resolution merge-safe.
+    //
+    // NoMergePolicy is critical (F5): fast-field transcoding assigns
+    // `doc_id = global_parquet_row` while walking the manifest files in order,
+    // which is only valid for a single segment whose doc_ids equal insertion
+    // order. A background LogMergePolicy merge would reorder docs (breaking
+    // transcoded aggregations/sorting) and could also GC segment files out from
+    // under `create_quickwit_split` while it bundles the temp dir. Disabling
+    // merges keeps doc_id == insertion order and removes the bundling race.
     let mut writer = index.writer_with_num_threads(1, parquet_config.writer_heap_size)
         .context("Failed to create index writer")?;
+    writer.set_merge_policy(Box::new(tantivy::indexer::NoMergePolicy));
 
     // ── Step 8: Initialize statistics accumulators ───────────────────────
     let mut accumulators: HashMap<String, StatisticsAccumulator> = HashMap::new();
@@ -595,6 +602,9 @@ pub async fn create_split_from_parquet(
     }
 
     writer.commit().context("Failed to commit tantivy index")?;
+    // Ensure no merge threads are still running before we inspect segments and
+    // bundle the temp dir (belt-and-suspenders alongside NoMergePolicy — F5).
+    writer.wait_merging_threads().context("Failed to wait for merge threads")?;
 
     // ── Step 10: Build segment_row_ranges from whatever segments exist ──
     // With __pq_file_hash and __pq_row_in_file fast fields, doc→parquet
@@ -616,6 +626,22 @@ pub async fn create_split_from_parquet(
         anyhow::bail!(
             "Segment row count mismatch: segments have {} rows but indexed {} rows",
             docs_in_segments, total_rows
+        );
+    }
+
+    // Single-segment guard (F5): when fast fields are served from parquet
+    // (Hybrid/ParquetOnly), transcoding assumes doc_id == global parquet row,
+    // which only holds for a single segment in insertion order. A multi-segment
+    // index (writer heap flushed mid-file) would silently transcode wrong values
+    // for parquet-served fast fields. NoMergePolicy prevents merges but not
+    // multi-segment flushes, so reject that combination rather than corrupt data.
+    if parquet_config.fast_field_mode != FastFieldMode::Disabled && segment_metas.len() > 1 {
+        anyhow::bail!(
+            "Parquet companion fast-field mode {:?} produced {} segments ({} rows). \
+             Parquet-served fast fields require a single segment (doc_id == parquet \
+             row); increase writer_heap_size so the input fits in one segment, or use \
+             FastFieldMode::Disabled.",
+            parquet_config.fast_field_mode, segment_metas.len(), total_rows
         );
     }
 

--- a/native/src/parquet_companion/indexing.rs
+++ b/native/src/parquet_companion/indexing.rs
@@ -201,12 +201,30 @@ pub async fn create_split_from_parquet(
     )?;
 
     // ── Step 4: Derive tantivy schema ───────────────────────────────────
+    // Config-key convention (M1): users declare all field-scoped config
+    // (tokenizer_overrides, ip_address_fields, json_fields) by *parquet column
+    // name* — that's what they see in the file. Internally, schema derivation
+    // and the indexing loop both work with *tantivy field names*, so translate
+    // these keys through the name mapping exactly once here to a single tantivy-
+    // keyed convention. Keys with no mapping pass through unchanged, and a key
+    // already given as the tantivy name (mapping miss) also passes through, so
+    // both conventions resolve identically. `skip_fields` stays parquet-keyed
+    // because it is applied to parquet columns *before* mapping.
+    let map_to_tantivy = |k: &str| -> String {
+        name_mapping.get(k).cloned().unwrap_or_else(|| k.to_string())
+    };
     let config = SchemaDerivationConfig {
         fast_field_mode: parquet_config.fast_field_mode,
         skip_fields: parquet_config.schema_config.skip_fields.clone(),
-        tokenizer_overrides: parquet_config.schema_config.tokenizer_overrides.clone(),
-        ip_address_fields: parquet_config.schema_config.ip_address_fields.clone(),
-        json_fields: parquet_config.schema_config.json_fields.clone(),
+        tokenizer_overrides: parquet_config.schema_config.tokenizer_overrides.iter()
+            .map(|(k, v)| (map_to_tantivy(k), v.clone()))
+            .collect(),
+        ip_address_fields: parquet_config.schema_config.ip_address_fields.iter()
+            .map(|k| map_to_tantivy(k))
+            .collect(),
+        json_fields: parquet_config.schema_config.json_fields.iter()
+            .map(|k| map_to_tantivy(k))
+            .collect(),
         fieldnorms_enabled: parquet_config.schema_config.fieldnorms_enabled,
         store_fields: false, // Companion mode: parquet is the store
     };
@@ -255,29 +273,50 @@ pub async fn create_split_from_parquet(
     let mut string_indexing_modes: HashMap<String, StringIndexingMode> = HashMap::new();
     let mut companion_hash_fields_map: HashMap<String, CompanionFieldInfo> = HashMap::new();
 
-    for (field_name, tokenizer_value) in &config.tokenizer_overrides {
-        // Resolve the tantivy field name via name mapping
-        let tantivy_name = name_mapping
-            .get(field_name.as_str())
-            .map(|s| s.as_str())
-            .unwrap_or(field_name.as_str());
+    // Arrow type per parquet column, for validating string-only overrides (M2).
+    let arrow_type_by_name: HashMap<&str, &DataType> = arrow_schema.fields().iter()
+        .map(|f| (f.name().as_str(), f.data_type()))
+        .collect();
 
+    // Iterate the user's original parquet-keyed overrides so we still have the
+    // parquet column name for arrow-type validation; map to the tantivy name
+    // for registration (consistent with the derivation config above — M1).
+    for (parquet_name, tokenizer_value) in &parquet_config.schema_config.tokenizer_overrides {
         if let Some(mode) = string_indexing::parse_tokenizer_override(tokenizer_value) {
+            // M2: compact string-indexing modes (exact_only, text_uuid_*, …) only
+            // make sense on a string column. Derivation applies them only in the
+            // Utf8/LargeUtf8 arm, so an override on a numeric column would create
+            // a numeric field here yet register ExactOnly and rewrite the manifest
+            // type to U64 — corrupting hash-rewrite reads. Reject it up front.
+            match arrow_type_by_name.get(parquet_name.as_str()) {
+                Some(DataType::Utf8) | Some(DataType::LargeUtf8) => {}
+                Some(other) => anyhow::bail!(
+                    "Tokenizer override '{}' on column '{}' requires a string (Utf8) \
+                     column, but it has arrow type {:?}.",
+                    tokenizer_value, parquet_name, other
+                ),
+                None => anyhow::bail!(
+                    "Tokenizer override references unknown parquet column '{}'.",
+                    parquet_name
+                ),
+            }
+
+            let tantivy_name = map_to_tantivy(parquet_name);
             // Build companion field info for *_exactonly modes
             if string_indexing::needs_companion_field(&mode) {
-                let companion_name = string_indexing::companion_field_name(tantivy_name);
+                let companion_name = string_indexing::companion_field_name(&tantivy_name);
                 let pattern = string_indexing::regex_pattern(&mode)
                     .unwrap_or("")
                     .to_string();
                 companion_hash_fields_map.insert(
                     companion_name.clone(),
                     CompanionFieldInfo {
-                        original_field_name: tantivy_name.to_string(),
+                        original_field_name: tantivy_name.clone(),
                         regex_pattern: pattern,
                     },
                 );
             }
-            string_indexing_modes.insert(tantivy_name.to_string(), mode);
+            string_indexing_modes.insert(tantivy_name, mode);
         }
     }
 
@@ -427,6 +466,31 @@ pub async fn create_split_from_parquet(
     let mut cumulative_row_offset: u64 = 0;
     let mut total_rows: u64 = 0;
 
+    // Column projection (E1): only the columns we actually index (present in
+    // column_mapping — every skipped or unsupported-type column is excluded).
+    // Reading, decompressing and Arrow-decoding all N columns of a wide table
+    // when we index only a handful is ~95% wasted I/O/CPU. Compute the arrow
+    // top-level field indices to keep once (schema is validated consistent
+    // across files) and apply ProjectionMask::roots per file below.
+    let indexed_parquet_cols: std::collections::HashSet<&str> = column_mapping.iter()
+        .map(|m| m.parquet_column_name.as_str())
+        .collect();
+    let projection_indices: Vec<usize> = arrow_schema.fields().iter().enumerate()
+        .filter_map(|(i, f)| {
+            if indexed_parquet_cols.contains(f.name().as_str()) { Some(i) } else { None }
+        })
+        .collect();
+    // Only project when it is a proper, non-empty subset — a full or empty mask
+    // gains nothing and the empty case is a degenerate no-columns read.
+    let apply_projection =
+        !projection_indices.is_empty() && projection_indices.len() < arrow_schema.fields().len();
+    if apply_projection {
+        debug_println!(
+            "🏗️ CREATE_FROM_PARQUET: projecting {} of {} parquet columns during indexing",
+            projection_indices.len(), arrow_schema.fields().len()
+        );
+    }
+
     for file_path in parquet_files {
         let file = std::fs::File::open(file_path)
             .with_context(|| format!("Failed to open parquet file: {}", file_path))?;
@@ -448,11 +512,16 @@ pub async fn create_split_from_parquet(
         // Files WITH a native offset index don't need page locations stored in the
         // manifest — the CachedParquetReader will load the offset index directly
         // from the footer at read time via PageIndexPolicy::Optional.
-        let has_native_offset_index = pq_metadata.row_groups().first()
-            .map(|rg| rg.columns().first()
-                .map(|col| col.offset_index_offset().is_some())
-                .unwrap_or(false))
-            .unwrap_or(false);
+        //
+        // Per-column offset-index presence is legal per the parquet spec, so
+        // require EVERY column of EVERY row group to carry an offset index before
+        // treating the file as natively indexed; otherwise a column without one
+        // would be unreadable at page granularity (L4).
+        let has_native_offset_index = !pq_metadata.row_groups().is_empty()
+            && pq_metadata.row_groups().iter().all(|rg| {
+                !rg.columns().is_empty()
+                    && rg.columns().iter().all(|col| col.offset_index_offset().is_some())
+            });
 
         // Open a separate file handle for page location scanning (only needed
         // for files that lack a native offset index in their footer).
@@ -553,14 +622,26 @@ pub async fn create_split_from_parquet(
 
         // Reuse the reader_builder (which already holds the file handle) instead
         // of re-reading the file from disk.
-        let reader = reader_builder
-            .with_batch_size(parquet_config.reader_batch_size)
+        let mut builder = reader_builder.with_batch_size(parquet_config.reader_batch_size);
+        if apply_projection {
+            // Root-level indices: arrow top-level field position == parquet root
+            // field index (nested types stay whole). Matches build_column_projection.
+            let mask = parquet::arrow::ProjectionMask::roots(
+                pq_metadata.file_metadata().schema_descr(),
+                projection_indices.iter().cloned(),
+            );
+            builder = builder.with_projection(mask);
+        }
+        let reader = builder
             .build()
             .context("Failed to build parquet reader")?;
 
         let mut row_in_file: u64 = 0;
         for batch_result in reader {
             let batch = batch_result.context("Failed to read record batch")?;
+            // Decode Dictionary-encoded columns to their value type so the
+            // per-type extraction below downcasts to a concrete array (M3).
+            let batch = decode_dictionary_columns(batch)?;
             let batch_schema = batch.schema();
 
             // Resolve column → tantivy field once per batch (batch-invariant work),
@@ -937,7 +1018,11 @@ pub(crate) fn add_arrow_value_to_doc(
             let val = arr.value(row_idx);
             doc.add_u64(field, val);
             if let Some(acc) = accumulators.get_mut(field_name) {
-                acc.observe_i64(val as i64);
+                // Saturate rather than `as i64` (which wraps u64 > i64::MAX to a
+                // negative min/max — L1). Query bounds are i64, so a saturated
+                // max of i64::MAX is safe (no i64 query can exceed it), and small
+                // values still set an accurate min.
+                acc.observe_i64(i64::try_from(val).unwrap_or(i64::MAX));
             }
         }
 
@@ -1212,26 +1297,30 @@ fn add_json_string_value(
     json_str: &str,
     field_name: &str,
 ) -> Result<()> {
-    let parsed: serde_json::Value = serde_json::from_str(json_str)
+    // Char-safe preview for error messages — slicing `&json_str[..100]` panics
+    // when byte 100 lands inside a multi-byte UTF-8 character (L2).
+    let preview = |s: &str| -> String { s.chars().take(100).collect() };
+
+    // Parse once directly into OwnedValue rather than parsing to serde_json::Value
+    // and then re-parsing (E8): an object becomes OwnedValue::Object, anything
+    // else is rejected below.
+    let owned: tantivy::schema::OwnedValue = serde_json::from_str(json_str)
         .with_context(|| format!(
             "Failed to parse JSON string for field '{}': '{}'",
             field_name,
-            if json_str.len() > 100 { &json_str[..100] } else { json_str }
+            preview(json_str)
         ))?;
-    match parsed {
-        serde_json::Value::Object(_) => {
-            let owned: tantivy::schema::OwnedValue = serde_json::from_str(json_str)?;
-            if let tantivy::schema::OwnedValue::Object(obj) = owned {
-                let json_map: std::collections::BTreeMap<String, tantivy::schema::OwnedValue> =
-                    obj.into_iter().collect();
-                doc.add_object(field, json_map);
-            }
+    match owned {
+        tantivy::schema::OwnedValue::Object(obj) => {
+            let json_map: std::collections::BTreeMap<String, tantivy::schema::OwnedValue> =
+                obj.into_iter().collect();
+            doc.add_object(field, json_map);
         }
         _ => {
             anyhow::bail!(
                 "JSON field '{}' contains non-object value. JSON fields must contain JSON objects, got: {}",
                 field_name,
-                if json_str.len() > 100 { &json_str[..100] } else { json_str }
+                preview(json_str)
             );
         }
     }
@@ -1595,6 +1684,42 @@ fn build_column_mapping(
     mappings
 }
 
+/// Decode any Dictionary-encoded columns in a batch to their value type.
+///
+/// Non-dictionary columns are returned unchanged; when the batch has no
+/// dictionary columns the input is returned as-is (no allocation). This lets the
+/// per-type value extraction (which downcasts to concrete arrays like
+/// `StringArray`) handle pandas/pyarrow categorical columns instead of silently
+/// dropping them (M3).
+pub(crate) fn decode_dictionary_columns(batch: RecordBatch) -> Result<RecordBatch> {
+    let has_dict = batch.schema().fields().iter()
+        .any(|f| matches!(f.data_type(), DataType::Dictionary(_, _)));
+    if !has_dict {
+        return Ok(batch);
+    }
+
+    let schema = batch.schema();
+    let mut new_fields: Vec<Arc<arrow_schema::Field>> = Vec::with_capacity(batch.num_columns());
+    let mut new_cols: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
+    for (i, field) in schema.fields().iter().enumerate() {
+        let col = batch.column(i);
+        if let DataType::Dictionary(_, value_type) = field.data_type() {
+            let decoded = arrow::compute::cast(col.as_ref(), value_type)
+                .with_context(|| format!("Failed to decode dictionary column '{}'", field.name()))?;
+            new_fields.push(Arc::new(arrow_schema::Field::new(
+                field.name(), value_type.as_ref().clone(), field.is_nullable(),
+            )));
+            new_cols.push(decoded);
+        } else {
+            new_fields.push(field.clone());
+            new_cols.push(col.clone());
+        }
+    }
+    let new_schema = Arc::new(ArrowSchema::new(new_fields));
+    RecordBatch::try_new(new_schema, new_cols)
+        .context("Failed to rebuild record batch after dictionary decode")
+}
+
 /// Compute relative path from table_root.
 fn compute_relative_path(file_path: &str, table_root: &str) -> String {
     if table_root.is_empty() {
@@ -1602,12 +1727,15 @@ fn compute_relative_path(file_path: &str, table_root: &str) -> String {
     }
 
     let root = table_root.trim_end_matches('/');
-    if file_path.starts_with(root) {
-        let relative = &file_path[root.len()..];
-        relative.trim_start_matches('/').to_string()
-    } else {
-        file_path.to_string()
+    // Only strip when `root` is a full path-segment prefix: the remainder must be
+    // empty or begin with '/'. Otherwise `/data/tablex/...` would be wrongly
+    // treated as living under root `/data/table` (L3).
+    if let Some(rest) = file_path.strip_prefix(root) {
+        if rest.is_empty() || rest.starts_with('/') {
+            return rest.trim_start_matches('/').to_string();
+        }
     }
+    file_path.to_string()
 }
 
 #[cfg(test)]
@@ -1632,6 +1760,17 @@ mod tests {
         assert_eq!(
             compute_relative_path("file.parquet", ""),
             "file.parquet"
+        );
+        // L3: a sibling directory sharing the root as a string prefix but not a
+        // path-segment prefix must NOT be stripped.
+        assert_eq!(
+            compute_relative_path("/data/tablex/part.parquet", "/data/table"),
+            "/data/tablex/part.parquet"
+        );
+        // Exact match → empty relative path.
+        assert_eq!(
+            compute_relative_path("/data/table", "/data/table"),
+            ""
         );
     }
 

--- a/native/src/parquet_companion/manifest.rs
+++ b/native/src/parquet_companion/manifest.rs
@@ -33,7 +33,17 @@ fn pack_page_locations(locations: &[PageLocationEntry]) -> Vec<u8> {
 }
 
 /// Unpack page locations from compact binary (20 bytes per entry, little-endian).
-fn unpack_page_locations(bytes: &[u8]) -> Vec<PageLocationEntry> {
+///
+/// Returns an error if the byte length is not an exact multiple of the 20-byte
+/// record size, which indicates corrupt/truncated input. (Previously trailing
+/// `len % 20` bytes were silently dropped.)
+fn unpack_page_locations(bytes: &[u8]) -> Result<Vec<PageLocationEntry>, String> {
+    if bytes.len() % 20 != 0 {
+        return Err(format!(
+            "Corrupt page location data: {} bytes is not a multiple of the 20-byte record size",
+            bytes.len()
+        ));
+    }
     let mut locations = Vec::with_capacity(bytes.len() / 20);
     let mut i = 0;
     while i + 20 <= bytes.len() {
@@ -44,7 +54,7 @@ fn unpack_page_locations(bytes: &[u8]) -> Vec<PageLocationEntry> {
         });
         i += 20;
     }
-    locations
+    Ok(locations)
 }
 
 fn serialize_page_locations<S: serde::Serializer>(
@@ -65,7 +75,7 @@ fn deserialize_page_locations<'de, D: serde::Deserializer<'de>>(
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(&b64)
         .map_err(serde::de::Error::custom)?;
-    Ok(unpack_page_locations(&bytes))
+    unpack_page_locations(&bytes).map_err(serde::de::Error::custom)
 }
 
 /// Current manifest format version
@@ -179,7 +189,7 @@ pub struct ColumnMapping {
 
 /// Storage configuration metadata embedded in the manifest
 /// (describes how to access the parquet files, without actual credentials)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParquetStorageConfigMeta {
     /// Storage protocol: "local", "s3", "azure"
     pub protocol: String,
@@ -274,6 +284,18 @@ impl ParquetManifest {
             ));
         }
 
+        // The first parquet file must start at global row 0, otherwise the
+        // monotonicity loop below (which starts at i=1) would validate a
+        // manifest whose rows begin at a nonzero offset.
+        if let Some(first) = self.parquet_files.first() {
+            if first.row_offset != 0 {
+                return Err(format!(
+                    "First parquet file must start at row_offset 0, but starts at {}",
+                    first.row_offset
+                ));
+            }
+        }
+
         // Verify row_offset monotonicity for files
         for i in 1..self.parquet_files.len() {
             let prev = &self.parquet_files[i - 1];
@@ -283,6 +305,33 @@ impl ParquetManifest {
                 return Err(format!(
                     "File row_offset gap: file[{}] ends at {} but file[{}] starts at {}",
                     i - 1, expected_offset, i, curr.row_offset
+                ));
+            }
+        }
+
+        // Verify segment_row_ranges form a contiguous, non-overlapping cover of
+        // [0, total_rows). Overlapping ranges would silently map two doc_ids to
+        // the same global row. Sort by row_offset first since segments need not
+        // be stored in row order. Runs after the file checks so a nonzero
+        // first-file offset surfaces its own (more specific) error first.
+        {
+            let mut ranges: Vec<&SegmentRowRange> = self.segment_row_ranges.iter().collect();
+            ranges.sort_by_key(|r| r.row_offset);
+            let mut expected_offset: u64 = 0;
+            for r in &ranges {
+                if r.row_offset != expected_offset {
+                    return Err(format!(
+                        "Segment row ranges are not contiguous: segment {} starts at row_offset {} \
+                         but expected {} (overlap or gap)",
+                        r.segment_ord, r.row_offset, expected_offset
+                    ));
+                }
+                expected_offset += r.num_rows;
+            }
+            if expected_offset != self.total_rows {
+                return Err(format!(
+                    "Segment row ranges cover {} rows but total_rows={}",
+                    expected_offset, self.total_rows
                 ));
             }
         }
@@ -354,6 +403,68 @@ mod tests {
     }
 
     #[test]
+    fn test_manifest_validation_first_file_nonzero_offset() {
+        let mut manifest = make_test_manifest();
+        // Shift the only file (and its segment) to start at a nonzero offset.
+        manifest.parquet_files[0].row_offset = 100;
+        manifest.segment_row_ranges[0].row_offset = 100;
+        let err = manifest.validate().unwrap_err();
+        assert!(
+            err.contains("First parquet file must start at row_offset 0"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_manifest_validation_segment_gap() {
+        let mut manifest = make_test_manifest();
+        // Two segments with a gap: [0,400) then [500,1000) — 100 rows uncovered.
+        manifest.segment_row_ranges = vec![
+            SegmentRowRange { segment_ord: 0, row_offset: 0, num_rows: 400 },
+            SegmentRowRange { segment_ord: 1, row_offset: 500, num_rows: 600 },
+        ];
+        let err = manifest.validate().unwrap_err();
+        assert!(
+            err.contains("not contiguous"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_manifest_validation_segment_overlap() {
+        let mut manifest = make_test_manifest();
+        // Two overlapping segments: [0,600) and [500,1100) both map row 500.
+        manifest.segment_row_ranges = vec![
+            SegmentRowRange { segment_ord: 0, row_offset: 0, num_rows: 600 },
+            SegmentRowRange { segment_ord: 1, row_offset: 500, num_rows: 600 },
+        ];
+        // total_rows stays 1000; segment sum (1200) mismatches, but even with a
+        // matching sum the contiguity check must reject the overlap.
+        manifest.total_rows = 1200;
+        manifest.parquet_files[0].num_rows = 1200;
+        let err = manifest.validate().unwrap_err();
+        assert!(
+            err.contains("not contiguous"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_manifest_validation_segment_not_starting_at_zero() {
+        let mut manifest = make_test_manifest();
+        manifest.segment_row_ranges[0].row_offset = 10;
+        let err = manifest.validate().unwrap_err();
+        assert!(
+            err.contains("not contiguous"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
     fn test_resolve_path_relative() {
         let manifest = make_test_manifest();
         assert_eq!(
@@ -419,13 +530,28 @@ mod tests {
         ];
         let packed = pack_page_locations(&locations);
         assert_eq!(packed.len(), 60); // 3 * 20 bytes
-        let unpacked = unpack_page_locations(&packed);
+        let unpacked = unpack_page_locations(&packed).unwrap();
         assert_eq!(unpacked.len(), 3);
         assert_eq!(unpacked[0].offset, 1000);
         assert_eq!(unpacked[0].compressed_page_size, 500);
         assert_eq!(unpacked[0].first_row_index, 0);
         assert_eq!(unpacked[2].offset, 1800);
         assert_eq!(unpacked[2].first_row_index, 200);
+    }
+
+    #[test]
+    fn test_unpack_page_locations_rejects_non_multiple_length() {
+        // A byte buffer whose length is not a multiple of the 20-byte record
+        // size indicates corruption and must error, not silently truncate.
+        let corrupt = vec![0u8; 25]; // 20 + 5 trailing bytes
+        assert!(unpack_page_locations(&corrupt).is_err());
+
+        // Empty is valid (zero records).
+        assert!(unpack_page_locations(&[]).unwrap().is_empty());
+
+        // Exact multiples still decode.
+        let ok = vec![0u8; 40];
+        assert_eq!(unpack_page_locations(&ok).unwrap().len(), 2);
     }
 
     #[test]

--- a/native/src/parquet_companion/merge.rs
+++ b/native/src/parquet_companion/merge.rs
@@ -81,12 +81,15 @@ pub fn combine_parquet_manifests(
     for (i, dir) in source_dirs.iter().enumerate() {
         let meta_path = dir.join("meta.json");
         if !meta_path.exists() {
-            crate::debug_println!(
-                "⚠️ PARQUET_MERGE: Missing meta.json in source split[{}] ({:?}), \
-                 skipping deletion check",
+            // A companion split always carries a meta.json; its absence means
+            // the extracted split is corrupt. Skipping the deletion check here
+            // could let a split with deletions through and corrupt doc→row
+            // mapping, so fail instead of silently continuing (L11).
+            anyhow::bail!(
+                "Cannot merge: source split[{}] ({:?}) is missing meta.json; \
+                 unable to verify it has no deletions.",
                 i, dir
             );
-            continue;
         }
         let meta_bytes = std::fs::read(&meta_path)
             .with_context(|| format!("Failed to read meta.json from {:?}", meta_path))?;
@@ -129,6 +132,26 @@ pub fn combine_parquet_manifests(
                      split[0] has {} mappings, split[{}] has {} mappings. \
                      All splits must be built from the same parquet schema.",
                     base_mapping.len(), i, manifest.column_mapping.len()
+                );
+            }
+        }
+    }
+
+    // Validate: all manifests share the same storage_config (M8).
+    // The combined manifest keeps only split[0]'s storage_config; if split[1]
+    // was built over a different bucket/endpoint, its relative paths would then
+    // resolve against the wrong storage after merge (wrong rows if a same-named
+    // file exists there). Reject the merge rather than silently mis-resolve.
+    if manifests.len() > 1 {
+        let base_storage = &manifests[0].storage_config;
+        for (i, manifest) in manifests.iter().enumerate().skip(1) {
+            if manifest.storage_config != *base_storage {
+                anyhow::bail!(
+                    "Cannot merge splits with incompatible storage_config: split[0] \
+                     and split[{}] were built over different storage backends. Only \
+                     split[0]'s storage_config is retained after merge, so relative \
+                     paths from other splits would resolve against the wrong backend.",
+                    i
                 );
             }
         }
@@ -202,22 +225,23 @@ pub fn combine_parquet_manifests(
         num_rows: cumulative_rows,
     }];
 
-    // Union string_hash_fields from all manifests (they should be identical for same-schema splits).
+    // Union string_hash_fields from all manifests. A hash-field-name mismatch for
+    // the same tantivy field means the splits hash that field differently, which
+    // would corrupt hash-based aggregation reads on the merged split — reject it
+    // with a hard error rather than a release-mode no-op debug_assert (D3).
     let mut combined_hash_fields = manifests[0].string_hash_fields.clone();
     for (i, manifest) in manifests.iter().enumerate().skip(1) {
         for (k, v) in &manifest.string_hash_fields {
             if let Some(existing) = combined_hash_fields.get(k) {
-                debug_assert_eq!(existing, v,
-                    "string_hash_fields mismatch during merge for field {}", k);
+                if existing != v {
+                    anyhow::bail!(
+                        "Cannot merge: string_hash_fields mismatch for field '{}' \
+                         between split[0] ({}) and split[{}] ({})",
+                        k, existing, i, v
+                    );
+                }
             }
             combined_hash_fields.insert(k.clone(), v.clone());
-        }
-        if manifest.string_hash_fields != manifests[0].string_hash_fields {
-            debug_println!(
-                "⚠️ MERGE_MANIFEST: string_hash_fields differ between split[0] and split[{}]; \
-                 using union (this may indicate schema inconsistency)",
-                i
-            );
         }
     }
 
@@ -294,6 +318,16 @@ pub fn combine_parquet_manifests(
 mod tests {
     use super::*;
 
+    /// Write a minimal no-deletion meta.json into a source split dir, matching
+    /// what a real extracted companion split always carries. Required because
+    /// combine_parquet_manifests now hard-fails on a missing meta.json (L11).
+    fn write_no_deletion_meta(dir: &Path) {
+        let meta = serde_json::json!({
+            "segments": [{ "segment_id": "seg", "max_doc": 1, "deletes": serde_json::Value::Null }]
+        });
+        std::fs::write(dir.join("meta.json"), serde_json::to_string(&meta).unwrap()).unwrap();
+    }
+
     fn make_test_manifest(table_root: &str, files: Vec<(&str, u64, u64)>) -> ParquetManifest {
         let mut parquet_files = Vec::new();
         let mut offset = 0u64;
@@ -357,6 +391,7 @@ mod tests {
         let m = make_test_manifest("s3://bucket/table", vec![("part1.parquet", 100, 1024)]);
         let serialized = serialize_manifest(&m).unwrap();
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), &serialized).unwrap();
+        write_no_deletion_meta(dir1.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
@@ -380,7 +415,9 @@ mod tests {
         m2.fast_field_mode = FastFieldMode::Hybrid;
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
@@ -402,7 +439,9 @@ mod tests {
         let m2 = make_test_manifest("s3://bucket", vec![("p2.parquet", 200, 2048)]);
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
@@ -440,8 +479,11 @@ mod tests {
         let m3 = make_test_manifest("s3://b", vec![("d.parquet", 100, 1024)]);
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
         std::fs::write(dir3.path().join(MANIFEST_FILENAME), serialize_manifest(&m3).unwrap()).unwrap();
+        write_no_deletion_meta(dir3.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path(), dir3.path()],
@@ -482,7 +524,9 @@ mod tests {
         let m2 = make_test_manifest("s3://bucket", vec![("p2.parquet", 200, 2048)]);
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         // Write a meta.json with deletions in dir2, using tantivy's real shape:
         // deletions are nested under `deletes: {num_deleted_docs, opstamp}`.
@@ -520,7 +564,9 @@ mod tests {
         let m2 = make_test_manifest("s3://bucket", vec![("p2.parquet", 200, 2048)]);
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         // Write meta.json with zero deletions — should pass
         let meta_no_deletions = serde_json::json!({
@@ -578,7 +624,9 @@ mod tests {
         }];
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
@@ -616,7 +664,9 @@ mod tests {
         });
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
@@ -649,7 +699,9 @@ mod tests {
         m2.string_indexing_modes.insert("field_a".to_string(), StringIndexingMode::TextUuidStrip);
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
@@ -682,7 +734,9 @@ mod tests {
         m2.column_mapping = mapping;
 
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
+        write_no_deletion_meta(dir1.path());
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
+        write_no_deletion_meta(dir2.path());
 
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],

--- a/native/src/parquet_companion/merge.rs
+++ b/native/src/parquet_companion/merge.rs
@@ -136,6 +136,26 @@ pub fn combine_parquet_manifests(
         cumulative_rows += manifest.total_rows;
     }
 
+    // Reject duplicate relative paths across the merged manifests. Because
+    // table_root is not persisted, two splits built over different tables whose
+    // files share a relative name would collide in `build_file_hash_index` (a
+    // HashMap keyed by path hash keeps only the last entry), silently resolving
+    // documents to the wrong parquet file.
+    {
+        let mut seen = std::collections::HashSet::with_capacity(combined_files.len());
+        for file in &combined_files {
+            if !seen.insert(file.relative_path.as_str()) {
+                anyhow::bail!(
+                    "Cannot merge splits: duplicate parquet file relative path '{}' \
+                     across source manifests. Relative paths must be unique because \
+                     table_root is not persisted and doc→parquet resolution keys on \
+                     the path hash.",
+                    file.relative_path
+                );
+            }
+        }
+    }
+
     // Rebuild segment_row_ranges: merged = single segment covering all rows
     let merged_segment_ranges = vec![SegmentRowRange {
         segment_ord: 0,

--- a/native/src/parquet_companion/merge.rs
+++ b/native/src/parquet_companion/merge.rs
@@ -18,13 +18,19 @@ use crate::debug_println;
 /// - All or no splits must have manifests (mixing is not allowed)
 /// - No deletions in any source (identity mapping requirement)
 /// - Same fast_field_mode across all sources
-/// - Row offsets are adjusted based on cumulative row count
+/// - Row offsets are adjusted based on cumulative row count, following the
+///   same segment ordering quickwit's `combine_index_meta` produces for the
+///   merged index (the LAST source split's docs come first).
 /// - Segment row ranges are rebuilt for the merged single segment
+///
+/// `expected_merged_docs`, when provided, is asserted to equal the combined
+/// row count as a backstop against ordering/deletion bugs (F1/F2/M7).
 ///
 /// Returns None if no splits have manifests.
 pub fn combine_parquet_manifests(
     source_dirs: &[&Path],
     output_dir: &Path,
+    expected_merged_docs: Option<u64>,
 ) -> Result<Option<()>> {
     // Read manifests from source directories
     let mut manifests: Vec<Option<ParquetManifest>> = Vec::new();
@@ -91,7 +97,12 @@ pub fn combine_parquet_manifests(
 
         if let Some(segments) = meta.get("segments").and_then(|s| s.as_array()) {
             for seg in segments {
-                let num_deleted = seg.get("num_deleted_docs")
+                // Tantivy nests deletions under `deletes: Option<DeleteMeta>`
+                // (InnerSegmentMeta, no serde flatten). The real shape is
+                // {"segment_id":…,"max_doc":100,"deletes":{"num_deleted_docs":5,…}},
+                // so a top-level `num_deleted_docs` lookup would always miss.
+                let num_deleted = seg.get("deletes")
+                    .and_then(|d| d.get("num_deleted_docs"))
                     .and_then(|n| n.as_u64())
                     .unwrap_or(0);
                 if num_deleted > 0 {
@@ -123,17 +134,45 @@ pub fn combine_parquet_manifests(
         }
     }
 
-    // Build combined manifest
+    // Build combined manifest.
+    //
+    // CRITICAL: the merged doc order is NOT the input order. Quickwit's
+    // `combine_index_meta` pops the LAST index_meta as the base then extends
+    // with the rest in order, so the merged segment/doc order is
+    // `[n-1, 0, 1, …, n-2]`. Positional consumers of the manifest (transcode
+    // assigning doc_id = global_row + row, legacy positional retrieval, hash
+    // touch-up fallback) require row_offsets that match that merged order, so
+    // we concatenate manifests in the same order rather than input order.
+    let n = manifests.len();
+    let merge_order: Vec<usize> = std::iter::once(n - 1).chain(0..n - 1).collect();
+
     let mut combined_files: Vec<ParquetFileEntry> = Vec::new();
     let mut cumulative_rows: u64 = 0;
 
-    for manifest in &manifests {
+    for &idx in &merge_order {
+        let manifest = &manifests[idx];
         for file in &manifest.parquet_files {
             let mut adjusted_file = file.clone();
             adjusted_file.row_offset = cumulative_rows + file.row_offset;
             combined_files.push(adjusted_file);
         }
         cumulative_rows += manifest.total_rows;
+    }
+
+    // Backstop (M7): the combined row count must equal the actual merged doc
+    // count. A mismatch means an ordering bug, an unguarded deletion, or a
+    // manifest whose total_rows drifted from its file rows — all of which would
+    // silently map doc_ids to wrong parquet rows.
+    if let Some(merged_docs) = expected_merged_docs {
+        if cumulative_rows != merged_docs {
+            anyhow::bail!(
+                "Combined parquet manifest row count ({}) does not match merged \
+                 document count ({}). This indicates deletions, an ordering bug, \
+                 or corrupt manifest metadata; refusing to produce a split that \
+                 would map documents to wrong parquet rows.",
+                cumulative_rows, merged_docs
+            );
+        }
     }
 
     // Reject duplicate relative paths across the merged manifests. Because
@@ -302,6 +341,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         ).unwrap();
 
         assert!(result.is_none());
@@ -321,6 +361,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         );
 
         assert!(result.is_err());
@@ -344,6 +385,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         );
 
         assert!(result.is_err());
@@ -365,6 +407,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         ).unwrap();
 
         assert!(result.is_some());
@@ -373,10 +416,14 @@ mod tests {
         let combined_data = std::fs::read(output.path().join(MANIFEST_FILENAME)).unwrap();
         let combined = deserialize_manifest(&combined_data).unwrap();
 
+        // Merged doc order mirrors quickwit's combine_index_meta: the LAST
+        // split (m2) comes first, so p2 is at offset 0 and p1 follows at 200.
         assert_eq!(combined.total_rows, 300);
         assert_eq!(combined.parquet_files.len(), 2);
+        assert_eq!(combined.parquet_files[0].relative_path, "p2.parquet");
         assert_eq!(combined.parquet_files[0].row_offset, 0);
-        assert_eq!(combined.parquet_files[1].row_offset, 100);
+        assert_eq!(combined.parquet_files[1].relative_path, "p1.parquet");
+        assert_eq!(combined.parquet_files[1].row_offset, 200);
         assert_eq!(combined.segment_row_ranges.len(), 1);
         assert_eq!(combined.segment_row_ranges[0].num_rows, 300);
     }
@@ -399,6 +446,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path(), dir3.path()],
             output.path(),
+        None,
         ).unwrap();
 
         assert!(result.is_some());
@@ -406,20 +454,22 @@ mod tests {
         let combined_data = std::fs::read(output.path().join(MANIFEST_FILENAME)).unwrap();
         let combined = deserialize_manifest(&combined_data).unwrap();
 
+        // Merged order mirrors combine_index_meta: [m3, m1, m2] (last split
+        // first). So: d (m3, 100 rows) → a (m1, 50) → b,c (m2, 30+20).
         assert_eq!(combined.total_rows, 200);
         assert_eq!(combined.parquet_files.len(), 4);
-        // m1: file a at offset 0
-        assert_eq!(combined.parquet_files[0].relative_path, "a.parquet");
+        // m3: file d at offset 0 (last split becomes the base)
+        assert_eq!(combined.parquet_files[0].relative_path, "d.parquet");
         assert_eq!(combined.parquet_files[0].row_offset, 0);
-        // m2: file b at offset 50 (after m1's 50 rows)
-        assert_eq!(combined.parquet_files[1].relative_path, "b.parquet");
-        assert_eq!(combined.parquet_files[1].row_offset, 50);
-        // m2: file c at offset 80 (50 + 30)
-        assert_eq!(combined.parquet_files[2].relative_path, "c.parquet");
-        assert_eq!(combined.parquet_files[2].row_offset, 80);
-        // m3: file d at offset 100 (50 + 50)
-        assert_eq!(combined.parquet_files[3].relative_path, "d.parquet");
-        assert_eq!(combined.parquet_files[3].row_offset, 100);
+        // m1: file a at offset 100 (after m3's 100 rows)
+        assert_eq!(combined.parquet_files[1].relative_path, "a.parquet");
+        assert_eq!(combined.parquet_files[1].row_offset, 100);
+        // m2: file b at offset 150 (100 + 50)
+        assert_eq!(combined.parquet_files[2].relative_path, "b.parquet");
+        assert_eq!(combined.parquet_files[2].row_offset, 150);
+        // m2: file c at offset 180 (150 + 30)
+        assert_eq!(combined.parquet_files[3].relative_path, "c.parquet");
+        assert_eq!(combined.parquet_files[3].row_offset, 180);
     }
 
     #[test]
@@ -434,12 +484,13 @@ mod tests {
         std::fs::write(dir1.path().join(MANIFEST_FILENAME), serialize_manifest(&m1).unwrap()).unwrap();
         std::fs::write(dir2.path().join(MANIFEST_FILENAME), serialize_manifest(&m2).unwrap()).unwrap();
 
-        // Write a meta.json with deletions in dir2
+        // Write a meta.json with deletions in dir2, using tantivy's real shape:
+        // deletions are nested under `deletes: {num_deleted_docs, opstamp}`.
         let meta_with_deletions = serde_json::json!({
             "segments": [{
                 "segment_id": "abc123",
                 "max_doc": 200,
-                "num_deleted_docs": 5
+                "deletes": { "num_deleted_docs": 5, "opstamp": 7 }
             }]
         });
         std::fs::write(
@@ -450,6 +501,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         );
 
         assert!(result.is_err());
@@ -490,6 +542,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         );
 
         assert!(result.is_ok());
@@ -530,6 +583,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         );
 
         assert!(result.is_err());
@@ -567,6 +621,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         ).unwrap();
         assert!(result.is_some());
 
@@ -599,6 +654,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("string_indexing_modes mismatch"));
@@ -631,6 +687,7 @@ mod tests {
         let result = combine_parquet_manifests(
             &[dir1.path(), dir2.path()],
             output.path(),
+        None,
         );
 
         assert!(result.is_ok());

--- a/native/src/parquet_companion/name_mapping.rs
+++ b/native/src/parquet_companion/name_mapping.rs
@@ -24,13 +24,18 @@ pub fn resolve_name_mapping(
     explicit_mapping: &HashMap<String, String>,
     auto_detect: bool,
 ) -> Result<NameMapping> {
-    let schema = parquet_metadata.file_metadata().schema_descr();
     let mut mapping = NameMapping::new();
 
-    // Start with identity mapping for all columns
-    for i in 0..schema.num_columns() {
-        let col = schema.column(i);
-        mapping.insert(col.name().to_string(), col.name().to_string());
+    // Start with an identity mapping for every top-level field.
+    //
+    // We deliberately enumerate the root group's direct children rather than
+    // parquet *leaf* columns: the top-level fields are exactly what become
+    // tantivy fields (see `derive_tantivy_schema_with_mapping`). For nested
+    // types (struct/list/map) the leaf enumeration explodes a single top-level
+    // column into multiple leaves — and, critically for Iceberg, hangs the
+    // field-id off the *group* node, which never appears in the leaf list.
+    for field_name in top_level_field_names(parquet_metadata) {
+        mapping.insert(field_name.clone(), field_name);
     }
 
     // Layer 2: Auto-detect Iceberg mapping if requested
@@ -54,11 +59,32 @@ pub fn resolve_name_mapping(
     Ok(mapping)
 }
 
+/// Enumerate the top-level (root) schema field names.
+///
+/// These are the columns that become tantivy fields. We intentionally use the
+/// root group's direct children rather than parquet leaf columns — for nested
+/// types (struct/list/map) a single top-level column expands into multiple
+/// leaves, and Iceberg attaches the field-id to the *group* node, which never
+/// appears in the leaf enumeration.
+fn top_level_field_names(
+    metadata: &parquet::file::metadata::ParquetMetaData,
+) -> Vec<String> {
+    metadata
+        .file_metadata()
+        .schema_descr()
+        .root_schema()
+        .get_fields()
+        .iter()
+        .map(|field| field.name().to_string())
+        .collect()
+}
+
 /// Auto-detect field ID → name mapping from Iceberg schema metadata.
 ///
 /// Iceberg stores schema as JSON in the parquet file's key-value metadata
-/// under the key "iceberg.schema". This contains field IDs that map to
-/// physical column ordinals.
+/// under the key "iceberg.schema". This contains field IDs that map to the
+/// parquet field-ids carried on each top-level schema node (including group
+/// nodes for nested types).
 fn auto_detect_iceberg_mapping(
     metadata: &parquet::file::metadata::ParquetMetaData,
 ) -> Option<NameMapping> {
@@ -74,8 +100,26 @@ fn auto_detect_iceberg_mapping(
     let iceberg_schema: serde_json::Value = serde_json::from_str(iceberg_schema_json).ok()?;
 
     let fields = iceberg_schema.get("fields")?.as_array()?;
-    let mut mapping = NameMapping::new();
 
+    // Build a one-pass index of field_id → physical column name over the
+    // top-level schema nodes. Iceberg attaches the field-id to the top-level
+    // node (group nodes included), which is the granularity that becomes a
+    // tantivy field. This avoids the previous O(fields × leaf-columns) scan and
+    // — unlike leaf enumeration — resolves field-ids on nested/group columns.
+    let mut id_to_column: HashMap<i32, String> = HashMap::new();
+    for field in metadata
+        .file_metadata()
+        .schema_descr()
+        .root_schema()
+        .get_fields()
+    {
+        let info = field.get_basic_info();
+        if info.has_id() {
+            id_to_column.insert(info.id(), field.name().to_string());
+        }
+    }
+
+    let mut mapping = NameMapping::new();
     for field in fields {
         let id = match field.get("id").and_then(|v| v.as_i64()) {
             Some(id) => id,
@@ -86,15 +130,9 @@ fn auto_detect_iceberg_mapping(
             None => continue, // Skip fields with missing/invalid name
         };
 
-        // In Iceberg, the field ID corresponds to the parquet column's field_id
-        // We need to find which parquet column has this field_id
-        let schema_descr = metadata.file_metadata().schema_descr();
-        for i in 0..schema_descr.num_columns() {
-            let col = schema_descr.column(i);
-            if col.self_type().get_basic_info().id() == id as i32 {
-                mapping.insert(col.name().to_string(), name.to_string());
-                break;
-            }
+        // Look up the physical column carrying this field-id (if any).
+        if let Some(col_name) = id_to_column.get(&(id as i32)) {
+            mapping.insert(col_name.clone(), name.to_string());
         }
     }
 
@@ -105,27 +143,57 @@ fn auto_detect_iceberg_mapping(
     }
 }
 
-/// Validate that all parquet columns have a name mapping
+/// Validate the resolved name mapping against the parquet schema.
+///
+/// Both invariants are checked against the set of *top-level* fields (the
+/// columns that become tantivy fields), not parquet leaf columns:
+///
+/// 1. **Completeness** — every top-level field has a mapping entry.
+/// 2. **No dangling keys** — every mapping key names a real top-level field.
+///    This makes the check non-vacuous: it catches typo'd explicit-mapping
+///    keys (which are otherwise silent no-ops) and any mapping key that
+///    resolves to no real column.
+///
+/// # Limitation
+/// Mapping is performed at top-level field granularity. Renaming a sub-field
+/// *inside* a nested struct/list/map is not modeled here — only the top-level
+/// column (which is what tantivy indexes) is validated.
 pub fn validate_name_mapping_completeness(
     mapping: &NameMapping,
     parquet_metadata: &parquet::file::metadata::ParquetMetaData,
 ) -> Result<()> {
-    let schema = parquet_metadata.file_metadata().schema_descr();
-    let mut unmapped = Vec::new();
+    use std::collections::HashSet;
 
-    for i in 0..schema.num_columns() {
-        let col = schema.column(i);
-        let col_name = col.name();
-        if !mapping.contains_key(col_name) {
-            unmapped.push(col_name.to_string());
-        }
-    }
+    let field_names: HashSet<String> = top_level_field_names(parquet_metadata)
+        .into_iter()
+        .collect();
 
-    if !unmapped.is_empty() {
+    // (1) Every real top-level field must be mapped.
+    let mut unmapped: Vec<String> = field_names
+        .iter()
+        .filter(|name| !mapping.contains_key(*name))
+        .cloned()
+        .collect();
+    unmapped.sort();
+
+    // (2) Every mapping key must correspond to a real top-level field. This is
+    //     where typo'd explicit-mapping keys surface instead of being silently
+    //     dropped.
+    let mut unknown: Vec<String> = mapping
+        .keys()
+        .filter(|key| !field_names.contains(*key))
+        .cloned()
+        .collect();
+    unknown.sort();
+
+    if !unmapped.is_empty() || !unknown.is_empty() {
         anyhow::bail!(
-            "Incomplete name mapping: {} columns unmapped: {:?}",
+            "Invalid name mapping: {} unmapped column(s): {:?}; \
+             {} mapping key(s) matching no column: {:?}",
             unmapped.len(),
-            unmapped
+            unmapped,
+            unknown.len(),
+            unknown
         );
     }
 
@@ -160,6 +228,155 @@ pub fn validate_consistent_mapping_across_files(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use parquet::file::metadata::{FileMetaData, KeyValue, ParquetMetaData};
+    use parquet::schema::types::{SchemaDescriptor, Type, TypePtr};
+    use std::sync::Arc;
+
+    /// A test schema field: a primitive top-level column with an optional
+    /// Iceberg field-id.
+    fn primitive_field(name: &str, field_id: Option<i32>) -> TypePtr {
+        Arc::new(
+            Type::primitive_type_builder(name, parquet::basic::Type::INT64)
+                .with_repetition(parquet::basic::Repetition::OPTIONAL)
+                .with_id(field_id)
+                .build()
+                .unwrap(),
+        )
+    }
+
+    /// A test schema field: a top-level *group* (nested) column carrying an
+    /// optional Iceberg field-id on the group node itself. Exercises the M5
+    /// case where the field-id lives on a group node, not a leaf.
+    fn group_field(name: &str, field_id: Option<i32>, child: &str) -> TypePtr {
+        Arc::new(
+            Type::group_type_builder(name)
+                .with_repetition(parquet::basic::Repetition::OPTIONAL)
+                .with_id(field_id)
+                .with_fields(vec![primitive_field(child, None)])
+                .build()
+                .unwrap(),
+        )
+    }
+
+    /// Build test parquet metadata from a set of top-level fields and an
+    /// optional `iceberg.schema` JSON payload.
+    fn make_metadata(fields: Vec<TypePtr>, iceberg_schema: Option<&str>) -> ParquetMetaData {
+        let schema = SchemaDescriptor::new(Arc::new(
+            Type::group_type_builder("test_schema")
+                .with_fields(fields)
+                .build()
+                .unwrap(),
+        ));
+        let kv = iceberg_schema.map(|json| {
+            vec![KeyValue::new(
+                "iceberg.schema".to_string(),
+                Some(json.to_string()),
+            )]
+        });
+        let file_metadata = FileMetaData::new(1, 0, None, kv, Arc::new(schema), None);
+        ParquetMetaData::new(file_metadata, vec![])
+    }
+
+    #[test]
+    fn test_resolve_identity_mapping_top_level_fields() {
+        let meta = make_metadata(
+            vec![primitive_field("col_a", None), primitive_field("col_b", None)],
+            None,
+        );
+        let mapping = resolve_name_mapping(&meta, &HashMap::new(), false).unwrap();
+        assert_eq!(mapping.get("col_a"), Some(&"col_a".to_string()));
+        assert_eq!(mapping.get("col_b"), Some(&"col_b".to_string()));
+        assert_eq!(mapping.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_identity_uses_group_node_not_leaf() {
+        // A nested group column has a child leaf named "child"; the top-level
+        // field is "nested". The mapping must key on the top-level field.
+        let meta = make_metadata(vec![group_field("nested", None, "child")], None);
+        let mapping = resolve_name_mapping(&meta, &HashMap::new(), false).unwrap();
+        assert!(mapping.contains_key("nested"), "top-level group must be mapped");
+        assert!(!mapping.contains_key("child"), "leaf child must not appear");
+    }
+
+    #[test]
+    fn test_explicit_mapping_overrides() {
+        let meta = make_metadata(vec![primitive_field("col_a", None)], None);
+        let mut explicit = HashMap::new();
+        explicit.insert("col_a".to_string(), "renamed_a".to_string());
+        let mapping = resolve_name_mapping(&meta, &explicit, false).unwrap();
+        assert_eq!(mapping.get("col_a"), Some(&"renamed_a".to_string()));
+    }
+
+    #[test]
+    fn test_auto_detect_iceberg_primitive() {
+        let iceberg = r#"{"fields":[{"id":1,"name":"user_name"},{"id":2,"name":"user_age"}]}"#;
+        let meta = make_metadata(
+            vec![
+                primitive_field("col1", Some(1)),
+                primitive_field("col2", Some(2)),
+            ],
+            Some(iceberg),
+        );
+        let mapping = resolve_name_mapping(&meta, &HashMap::new(), true).unwrap();
+        assert_eq!(mapping.get("col1"), Some(&"user_name".to_string()));
+        assert_eq!(mapping.get("col2"), Some(&"user_age".to_string()));
+    }
+
+    #[test]
+    fn test_auto_detect_iceberg_matches_group_node_field_id() {
+        // M5 regression: the field-id lives on the top-level group node, which
+        // the old leaf-column scan could never match.
+        let iceberg = r#"{"fields":[{"id":7,"name":"address"}]}"#;
+        let meta = make_metadata(vec![group_field("addr_struct", Some(7), "city")], Some(iceberg));
+        let mapping = resolve_name_mapping(&meta, &HashMap::new(), true).unwrap();
+        assert_eq!(
+            mapping.get("addr_struct"),
+            Some(&"address".to_string()),
+            "renaming a nested/group column via field-id must work"
+        );
+    }
+
+    #[test]
+    fn test_validate_completeness_ok() {
+        let meta = make_metadata(
+            vec![primitive_field("col_a", None), primitive_field("col_b", None)],
+            None,
+        );
+        let mapping = resolve_name_mapping(&meta, &HashMap::new(), false).unwrap();
+        assert!(validate_name_mapping_completeness(&mapping, &meta).is_ok());
+    }
+
+    #[test]
+    fn test_validate_detects_unmapped_column() {
+        let meta = make_metadata(
+            vec![primitive_field("col_a", None), primitive_field("col_b", None)],
+            None,
+        );
+        // Mapping is missing col_b.
+        let mut mapping = NameMapping::new();
+        mapping.insert("col_a".to_string(), "col_a".to_string());
+        let err = validate_name_mapping_completeness(&mapping, &meta).unwrap_err();
+        assert!(err.to_string().contains("unmapped"), "got: {}", err);
+        assert!(err.to_string().contains("col_b"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_validate_detects_typoed_explicit_key() {
+        // L13 regression: an explicit-mapping key naming a non-existent column
+        // must be reported, not silently dropped.
+        let meta = make_metadata(vec![primitive_field("col_a", None)], None);
+        let mut explicit = HashMap::new();
+        explicit.insert("col_typo".to_string(), "renamed".to_string());
+        let mapping = resolve_name_mapping(&meta, &explicit, false).unwrap();
+        let err = validate_name_mapping_completeness(&mapping, &meta).unwrap_err();
+        assert!(
+            err.to_string().contains("matching no column"),
+            "got: {}",
+            err
+        );
+        assert!(err.to_string().contains("col_typo"), "got: {}", err);
+    }
 
     #[test]
     fn test_consistent_mapping_ok() {

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -65,6 +65,56 @@ pub fn derive_tantivy_schema(
     derive_tantivy_schema_with_mapping(arrow_schema, config, None)
 }
 
+/// Validate that resolved tantivy field names are unique and do not collide
+/// with reserved parquet-companion internal field names. Returns a clean error
+/// rather than letting `SchemaBuilder::add_field` panic across JNI (F8).
+fn validate_resolved_field_names(
+    arrow_schema: &ArrowSchema,
+    config: &SchemaDerivationConfig,
+    name_mapping: Option<&HashMap<String, String>>,
+) -> Result<()> {
+    use super::indexing::{PARQUET_FILE_HASH_FIELD, PARQUET_ROW_IN_FILE_FIELD, PHASH_FIELD_PREFIX};
+    use super::string_indexing::COMPANION_SUFFIX;
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    for field in arrow_schema.fields() {
+        let parquet_name = field.name();
+        if config.skip_fields.contains(parquet_name.as_str()) {
+            continue;
+        }
+        let resolved = name_mapping
+            .and_then(|m| m.get(parquet_name.as_str()))
+            .map(|s| s.as_str())
+            .unwrap_or(parquet_name.as_str());
+
+        if resolved == PARQUET_FILE_HASH_FIELD
+            || resolved == PARQUET_ROW_IN_FILE_FIELD
+            || resolved.starts_with(PHASH_FIELD_PREFIX)
+            || resolved.ends_with(COMPANION_SUFFIX)
+        {
+            anyhow::bail!(
+                "Parquet column '{}' resolves to reserved tantivy field name '{}'. \
+                 Names equal to '{}'/'{}', starting with '{}', or ending with '{}' are \
+                 reserved for parquet companion internal fields; rename the column or \
+                 add a name mapping.",
+                parquet_name, resolved,
+                PARQUET_FILE_HASH_FIELD, PARQUET_ROW_IN_FILE_FIELD,
+                PHASH_FIELD_PREFIX, COMPANION_SUFFIX
+            );
+        }
+
+        if !seen.insert(resolved) {
+            anyhow::bail!(
+                "Duplicate tantivy field name '{}' after applying name mapping: two \
+                 parquet columns resolve to the same name. Tantivy field names must be \
+                 unique; adjust the name mapping so each column maps to a distinct name.",
+                resolved
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Derive tantivy schema with optional name mapping (parquet_col → tantivy_field).
 /// When a name mapping is provided, the tantivy field will use the mapped display name.
 pub fn derive_tantivy_schema_with_mapping(
@@ -72,6 +122,15 @@ pub fn derive_tantivy_schema_with_mapping(
     config: &SchemaDerivationConfig,
     name_mapping: Option<&HashMap<String, String>>,
 ) -> Result<Schema> {
+    // Validate resolved tantivy field names before touching SchemaBuilder (F8).
+    // tantivy's SchemaBuilder::add_field PANICS on a duplicate name, which would
+    // unwind across the JNI boundary. Detect (a) two columns resolving to the
+    // same tantivy name (explicit or Iceberg mapping collision) and (b) columns
+    // colliding with reserved companion field names (__pq_file_hash /
+    // __pq_row_in_file added unconditionally at index time, _phash_* and
+    // *__uuids added for string modes) here, and return a clean error instead.
+    validate_resolved_field_names(arrow_schema, config, name_mapping)?;
+
     let mut builder = SchemaBuilder::new();
 
     // Collect all tantivy field names for collision detection with companion fields.
@@ -1393,6 +1452,86 @@ mod tests {
 
         assert!(schema.get_field("log_line").is_ok());
         assert!(schema.get_field("log_line__uuids").is_err());
+    }
+
+    // ── F8: reserved-name / uniqueness validation ────────────────────────
+
+    #[test]
+    fn test_name_mapping_collision_errors() {
+        // Two columns mapped to the same tantivy name would panic in
+        // SchemaBuilder::add_field; we must reject it with a clean error.
+        let arrow = ArrowSchema::new(vec![
+            Field::new("col_a", DataType::Utf8, true),
+            Field::new("col_b", DataType::Utf8, true),
+        ]);
+        let mut mapping = HashMap::new();
+        mapping.insert("col_a".to_string(), "name".to_string());
+        mapping.insert("col_b".to_string(), "name".to_string());
+        let config = SchemaDerivationConfig::default();
+
+        let err = derive_tantivy_schema_with_mapping(&arrow, &config, Some(&mapping))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Duplicate tantivy field name"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_mapping_collides_with_identity_name_errors() {
+        // Mapping col_a → "name" collides with a physical "name" column.
+        let arrow = ArrowSchema::new(vec![
+            Field::new("col_a", DataType::Utf8, true),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let mut mapping = HashMap::new();
+        mapping.insert("col_a".to_string(), "name".to_string());
+        let config = SchemaDerivationConfig::default();
+
+        let err = derive_tantivy_schema_with_mapping(&arrow, &config, Some(&mapping))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Duplicate tantivy field name"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_reserved_pq_field_name_errors() {
+        // A user column named __pq_file_hash collides with the hidden field
+        // added unconditionally at index time.
+        let arrow = ArrowSchema::new(vec![
+            Field::new("__pq_file_hash", DataType::Int64, true),
+        ]);
+        let config = SchemaDerivationConfig::default();
+
+        let err = derive_tantivy_schema(&arrow, &config).unwrap_err().to_string();
+        assert!(err.contains("reserved"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_reserved_phash_and_uuids_prefix_errors() {
+        for reserved in ["_phash_x", "trace__uuids", "__pq_row_in_file"] {
+            let arrow = ArrowSchema::new(vec![
+                Field::new(reserved, DataType::Utf8, true),
+            ]);
+            let config = SchemaDerivationConfig::default();
+            let err = derive_tantivy_schema(&arrow, &config).unwrap_err().to_string();
+            assert!(err.contains("reserved"), "name {} — got: {}", reserved, err);
+        }
+    }
+
+    #[test]
+    fn test_skipped_column_does_not_trigger_collision() {
+        // A skipped column sharing a resolved name must not count as a collision.
+        let arrow = ArrowSchema::new(vec![
+            Field::new("dup", DataType::Utf8, true),
+            Field::new("keep", DataType::Utf8, true),
+        ]);
+        let mut mapping = HashMap::new();
+        mapping.insert("keep".to_string(), "dup".to_string());
+        let mut config = SchemaDerivationConfig::default();
+        config.skip_fields.insert("dup".to_string());
+
+        // "dup" column is skipped, so mapping "keep" → "dup" is unique overall.
+        let schema = derive_tantivy_schema_with_mapping(&arrow, &config, Some(&mapping)).unwrap();
+        assert!(schema.get_field("dup").is_ok());
     }
 }
 

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -382,11 +382,17 @@ fn add_field_for_arrow_type(
         }
 
         DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_) => {
+            // Bytes must consult should_add_fast so the Disabled "fast for ALL"
+            // contract holds and meta.json fast promotion is backed by real
+            // native data (bytes are not transcode-serviceable from parquet) — M4.
+            let mut opts = BytesOptions::default().set_indexed();
             if config.store_fields {
-                builder.add_bytes_field(name, INDEXED | STORED);
-            } else {
-                builder.add_bytes_field(name, INDEXED);
+                opts = opts.set_stored();
             }
+            if should_add_fast(config, name, data_type) {
+                opts = opts.set_fast();
+            }
+            builder.add_bytes_field(name, opts);
         }
 
         DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64 => {
@@ -420,6 +426,14 @@ fn add_field_for_arrow_type(
             builder.add_json_field(name, opts);
         }
 
+        DataType::Dictionary(_, value_type) => {
+            // Dictionary-encoded (pandas/pyarrow categorical) columns: derive the
+            // field by the DECODED value type so they are searchable instead of
+            // being silently dropped as an "Unknown" column (M3). Batches are
+            // decoded to the value type before indexing/retrieval.
+            return add_field_for_arrow_type(builder, name, value_type, config, all_field_names);
+        }
+
         _ => {
             debug_println!(
                 "⚠️ SCHEMA_DERIVE: Unsupported type {:?} for field '{}', skipping",
@@ -442,16 +456,26 @@ fn add_field_for_arrow_type(
 /// so the reader sees all fields as fast. The ParquetAugmentedDirectory then intercepts
 /// .fast file reads for fields that have no native data and serves from parquet.
 fn should_add_fast(config: &SchemaDerivationConfig, field_name: &str, data_type: &DataType) -> bool {
+    // Types the transcode path cannot reconstruct from the parquet column (it has
+    // no IpAddr/Bytes/Decimal256 arm) must ALWAYS get native fast data, in every
+    // mode — otherwise meta.json promotes them to fast but reads find no native
+    // data and no parquet fallback, so aggregations silently return empty (IP in
+    // ParquetOnly) or hard-error at query time (Decimal256/FixedSizeBinary in
+    // Hybrid) — M4. IP fields arrive as Utf8 columns declared via config.
+    let non_parquet_serviceable = config.ip_address_fields.contains(field_name)
+        || matches!(data_type,
+            DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_)
+            | DataType::Decimal256(_, _)
+        );
+
     match config.fast_field_mode {
         FastFieldMode::Disabled => true, // All native fast fields
         FastFieldMode::Hybrid => {
-            // IP address fields are treated as native fast fields in hybrid mode,
-            // even though they come from Utf8 Arrow columns.
-            if config.ip_address_fields.contains(field_name) {
+            if non_parquet_serviceable {
                 return true;
             }
-            // Only numeric/bool/date get native fast fields in hybrid mode
-            // Text fields are served from parquet at read time
+            // Numeric/bool/date get native fast fields in hybrid mode; raw text
+            // fields are served from parquet at read time (transcode-serviceable).
             matches!(data_type,
                 DataType::Boolean
                 | DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64
@@ -461,7 +485,9 @@ fn should_add_fast(config: &SchemaDerivationConfig, field_name: &str, data_type:
                 | DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64
             )
         }
-        FastFieldMode::ParquetOnly => false, // No native fast fields
+        // ParquetOnly serves everything from parquet EXCEPT the non-serviceable
+        // types, which still need native fast data.
+        FastFieldMode::ParquetOnly => non_parquet_serviceable,
     }
 }
 
@@ -547,12 +573,19 @@ pub fn arrow_type_to_tantivy_type(data_type: &DataType) -> &'static str {
         DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => "I64",
         DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => "U64",
         DataType::Float32 | DataType::Float64 => "F64",
+        // Decimal128 → F64 is a deliberate, lossy design point: values above 2^53
+        // or with non-zero scale lose precision, but index and retrieval share the
+        // same f64 round-trip so they stay mutually consistent (L10). Decimal256
+        // is kept as text to avoid exceeding f64 range entirely.
         DataType::Decimal128(_, _) => "F64",
         DataType::Decimal256(_, _) => "Str",
         DataType::Utf8 | DataType::LargeUtf8 => "Str",
         DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_) => "Bytes",
         DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64 => "Date",
-        DataType::List(_) | DataType::LargeList(_) | DataType::Map(_, _) | DataType::Struct(_) => "Json",
+        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _)
+            | DataType::Map(_, _) | DataType::Struct(_) => "Json",
+        // Dictionary-encoded columns map by their decoded value type (M3).
+        DataType::Dictionary(_, value_type) => arrow_type_to_tantivy_type(value_type),
         _ => "Unknown",
     }
 }
@@ -574,6 +607,8 @@ pub fn arrow_type_to_parquet_type(data_type: &DataType) -> &'static str {
         DataType::Timestamp(_, _) => "INT64",
         DataType::Date32 => "INT32",
         DataType::Date64 => "INT64",
+        // Dictionary-encoded columns map by their decoded value type (M3).
+        DataType::Dictionary(_, value_type) => arrow_type_to_parquet_type(value_type),
         _ => "BYTE_ARRAY",
     }
 }
@@ -866,7 +901,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ip_address_field_parquet_only_not_fast() {
+    fn test_ip_address_field_parquet_only_is_fast() {
         let arrow = ArrowSchema::new(vec![
             Field::new("src_ip", DataType::Utf8, true),
         ]);
@@ -876,9 +911,11 @@ mod tests {
 
         let schema = derive_tantivy_schema(&arrow, &config).unwrap();
 
+        // IP fields have no parquet transcode arm, so they must be NATIVE fast
+        // even in ParquetOnly — otherwise IP aggregations silently return empty (M4).
         let src_ip_field = schema.get_field("src_ip").unwrap();
         let src_ip_entry = schema.get_field_entry(src_ip_field);
-        assert!(!src_ip_entry.is_fast(), "IP fields should NOT be fast in ParquetOnly mode");
+        assert!(src_ip_entry.is_fast(), "IP fields must be fast even in ParquetOnly mode");
     }
 
     #[test]

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -73,9 +73,16 @@ fn validate_resolved_field_names(
     config: &SchemaDerivationConfig,
     name_mapping: Option<&HashMap<String, String>>,
 ) -> Result<()> {
-    use super::indexing::{PARQUET_FILE_HASH_FIELD, PARQUET_ROW_IN_FILE_FIELD, PHASH_FIELD_PREFIX};
-    use super::string_indexing::COMPANION_SUFFIX;
+    use super::indexing::{PARQUET_FILE_HASH_FIELD, PARQUET_ROW_IN_FILE_FIELD};
 
+    // Only the two __pq_* row-tracking fields are added *unconditionally* at
+    // index time with no collision guard, so a user column with either exact
+    // name would panic in SchemaBuilder. The `_phash_<field>` and
+    // `<field>__uuids` companion fields are added conditionally and already
+    // handle collisions precisely at their creation site (indexing.rs disables
+    // the fingerprint for the shadowed field; add_field_for_arrow_type bails
+    // with a clean error), so a legitimately-named column like `session__uuids`
+    // or `_phash_temp` must NOT be rejected here.
     let mut seen: HashSet<&str> = HashSet::new();
     for field in arrow_schema.fields() {
         let parquet_name = field.name();
@@ -87,19 +94,13 @@ fn validate_resolved_field_names(
             .map(|s| s.as_str())
             .unwrap_or(parquet_name.as_str());
 
-        if resolved == PARQUET_FILE_HASH_FIELD
-            || resolved == PARQUET_ROW_IN_FILE_FIELD
-            || resolved.starts_with(PHASH_FIELD_PREFIX)
-            || resolved.ends_with(COMPANION_SUFFIX)
-        {
+        if resolved == PARQUET_FILE_HASH_FIELD || resolved == PARQUET_ROW_IN_FILE_FIELD {
             anyhow::bail!(
                 "Parquet column '{}' resolves to reserved tantivy field name '{}'. \
-                 Names equal to '{}'/'{}', starting with '{}', or ending with '{}' are \
-                 reserved for parquet companion internal fields; rename the column or \
-                 add a name mapping.",
+                 '{}' and '{}' are reserved for parquet companion row tracking; \
+                 rename the column or add a name mapping.",
                 parquet_name, resolved,
-                PARQUET_FILE_HASH_FIELD, PARQUET_ROW_IN_FILE_FIELD,
-                PHASH_FIELD_PREFIX, COMPANION_SUFFIX
+                PARQUET_FILE_HASH_FIELD, PARQUET_ROW_IN_FILE_FIELD
             );
         }
 
@@ -1506,14 +1507,28 @@ mod tests {
     }
 
     #[test]
-    fn test_reserved_phash_and_uuids_prefix_errors() {
-        for reserved in ["_phash_x", "trace__uuids", "__pq_row_in_file"] {
+    fn test_reserved_pq_row_field_name_errors() {
+        let arrow = ArrowSchema::new(vec![
+            Field::new("__pq_row_in_file", DataType::Utf8, true),
+        ]);
+        let config = SchemaDerivationConfig::default();
+        let err = derive_tantivy_schema(&arrow, &config).unwrap_err().to_string();
+        assert!(err.contains("reserved"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_phash_and_uuids_named_columns_are_allowed() {
+        // These names are only reserved when a companion field would actually
+        // collide (handled precisely at field-creation time). As standalone
+        // user columns with no matching base field, they must be allowed.
+        for allowed in ["_phash_x", "trace__uuids"] {
             let arrow = ArrowSchema::new(vec![
-                Field::new(reserved, DataType::Utf8, true),
+                Field::new(allowed, DataType::Utf8, true),
             ]);
             let config = SchemaDerivationConfig::default();
-            let err = derive_tantivy_schema(&arrow, &config).unwrap_err().to_string();
-            assert!(err.contains("reserved"), "name {} — got: {}", reserved, err);
+            let schema = derive_tantivy_schema(&arrow, &config)
+                .unwrap_or_else(|e| panic!("name {} should be allowed: {}", allowed, e));
+            assert!(schema.get_field(allowed).is_ok());
         }
     }
 

--- a/native/src/parquet_companion/schema_derivation.rs
+++ b/native/src/parquet_companion/schema_derivation.rs
@@ -456,26 +456,17 @@ fn add_field_for_arrow_type(
 /// so the reader sees all fields as fast. The ParquetAugmentedDirectory then intercepts
 /// .fast file reads for fields that have no native data and serves from parquet.
 fn should_add_fast(config: &SchemaDerivationConfig, field_name: &str, data_type: &DataType) -> bool {
-    // Types the transcode path cannot reconstruct from the parquet column (it has
-    // no IpAddr/Bytes/Decimal256 arm) must ALWAYS get native fast data, in every
-    // mode — otherwise meta.json promotes them to fast but reads find no native
-    // data and no parquet fallback, so aggregations silently return empty (IP in
-    // ParquetOnly) or hard-error at query time (Decimal256/FixedSizeBinary in
-    // Hybrid) — M4. IP fields arrive as Utf8 columns declared via config.
-    let non_parquet_serviceable = config.ip_address_fields.contains(field_name)
-        || matches!(data_type,
-            DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_)
-            | DataType::Decimal256(_, _)
-        );
-
     match config.fast_field_mode {
         FastFieldMode::Disabled => true, // All native fast fields
         FastFieldMode::Hybrid => {
-            if non_parquet_serviceable {
+            // IP address fields are treated as native fast fields in hybrid mode,
+            // even though they come from Utf8 Arrow columns. In ParquetOnly they
+            // are transcoded from parquet (see transcode.rs record_arrow_value).
+            if config.ip_address_fields.contains(field_name) {
                 return true;
             }
-            // Numeric/bool/date get native fast fields in hybrid mode; raw text
-            // fields are served from parquet at read time (transcode-serviceable).
+            // Numeric/bool/date get native fast fields in hybrid mode; raw text,
+            // bytes, decimal256 and IP are served from parquet at read time.
             matches!(data_type,
                 DataType::Boolean
                 | DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64
@@ -485,9 +476,7 @@ fn should_add_fast(config: &SchemaDerivationConfig, field_name: &str, data_type:
                 | DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64
             )
         }
-        // ParquetOnly serves everything from parquet EXCEPT the non-serviceable
-        // types, which still need native fast data.
-        FastFieldMode::ParquetOnly => non_parquet_serviceable,
+        FastFieldMode::ParquetOnly => false, // Everything served from parquet at read time
     }
 }
 
@@ -901,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ip_address_field_parquet_only_is_fast() {
+    fn test_ip_address_field_parquet_only_not_fast() {
         let arrow = ArrowSchema::new(vec![
             Field::new("src_ip", DataType::Utf8, true),
         ]);
@@ -911,11 +900,11 @@ mod tests {
 
         let schema = derive_tantivy_schema(&arrow, &config).unwrap();
 
-        // IP fields have no parquet transcode arm, so they must be NATIVE fast
-        // even in ParquetOnly — otherwise IP aggregations silently return empty (M4).
+        // In ParquetOnly IP fields are served from parquet at read time (the
+        // transcode path has an IpAddr arm — M4), so they are NOT native fast.
         let src_ip_field = schema.get_field("src_ip").unwrap();
         let src_ip_entry = schema.get_field_entry(src_ip_field);
-        assert!(src_ip_entry.is_fast(), "IP fields must be fast even in ParquetOnly mode");
+        assert!(!src_ip_entry.is_fast(), "IP fields are parquet-served (not native fast) in ParquetOnly");
     }
 
     #[test]

--- a/native/src/parquet_companion/statistics.rs
+++ b/native/src/parquet_companion/statistics.rs
@@ -21,6 +21,12 @@ pub struct ColumnStatisticsResult {
     pub min_bool: Option<bool>,
     pub max_bool: Option<bool>,
     pub null_count: u64,
+    /// Count of NaN float values, tracked separately from null_count so an
+    /// all-NaN column (min/max None, null_count 0, nan_count > 0) is
+    /// distinguishable from an empty/all-null column and a pruning consumer
+    /// does not treat it as "no data". Defaulted for manifest back-compat.
+    #[serde(default)]
+    pub nan_count: u64,
 }
 
 /// Accumulator for computing column statistics during indexing
@@ -38,6 +44,11 @@ pub struct StatisticsAccumulator {
     min_bool: Option<bool>,
     max_bool: Option<bool>,
     null_count: u64,
+    nan_count: u64,
+    /// Set when a truncated string value has no representable ceiling (all
+    /// prefix chars are char::MAX). Once set, max_string is reported as None so
+    /// pruning never uses a too-low upper bound (L6).
+    max_string_unbounded: bool,
     truncate_length: usize,
 }
 
@@ -57,6 +68,8 @@ impl StatisticsAccumulator {
             min_bool: None,
             max_bool: None,
             null_count: 0,
+            nan_count: 0,
+            max_string_unbounded: false,
             truncate_length,
         }
     }
@@ -71,8 +84,10 @@ impl StatisticsAccumulator {
     }
 
     pub fn observe_f64(&mut self, value: f64) {
-        // Exclude NaN from statistics
+        // NaN has no ordering and can't participate in min/max; count it
+        // separately so an all-NaN column is distinguishable from empty (M10).
         if value.is_nan() {
+            self.nan_count += 1;
             return;
         }
         self.min_double = Some(self.min_double.map_or(value, |m| m.min(value)));
@@ -80,32 +95,46 @@ impl StatisticsAccumulator {
     }
 
     pub fn observe_string(&mut self, value: &str) {
-        let truncated_min = if self.truncate_length > 0 && value.len() > self.truncate_length {
-            safe_truncate(value, self.truncate_length).to_string()
-        } else {
-            value.to_string()
-        };
+        // Borrow the truncated prefix; allocate only when it becomes a new
+        // extreme, and never clone the retained value on the no-change path (E4).
+        let truncated_min: &str =
+            if self.truncate_length > 0 && value.len() > self.truncate_length {
+                safe_truncate(value, self.truncate_length)
+            } else {
+                value
+            };
 
-        let truncated_max = if self.truncate_length > 0 && value.len() > self.truncate_length {
-            truncate_ceiling(safe_truncate(value, self.truncate_length))
-        } else {
-            value.to_string()
-        };
+        match self.min_string {
+            Some(ref m) if truncated_min >= m.as_str() => {} // unchanged, no alloc
+            _ => self.min_string = Some(truncated_min.to_string()),
+        }
 
-        self.min_string = Some(
-            self.min_string
-                .as_ref()
-                .map_or(truncated_min.clone(), |m| {
-                    if truncated_min < *m { truncated_min.clone() } else { m.clone() }
-                }),
-        );
-        self.max_string = Some(
-            self.max_string
-                .as_ref()
-                .map_or(truncated_max.clone(), |m| {
-                    if truncated_max > *m { truncated_max.clone() } else { m.clone() }
-                }),
-        );
+        // Ceiling for the max bound. truncate_ceiling returns None when the
+        // truncated prefix has no representable ceiling (all chars char::MAX);
+        // in that case the column's max is unbounded and must report None so
+        // pruning never uses a too-low upper bound (L6).
+        if !self.max_string_unbounded {
+            let truncated_max: Option<String> =
+                if self.truncate_length > 0 && value.len() > self.truncate_length {
+                    match truncate_ceiling(safe_truncate(value, self.truncate_length)) {
+                        Some(c) => Some(c),
+                        None => {
+                            self.max_string_unbounded = true;
+                            self.max_string = None;
+                            None
+                        }
+                    }
+                } else {
+                    Some(value.to_string())
+                };
+
+            if let Some(tmax) = truncated_max {
+                match self.max_string {
+                    Some(ref m) if tmax <= *m => {} // unchanged, no alloc
+                    _ => self.max_string = Some(tmax),
+                }
+            }
+        }
     }
 
     pub fn observe_timestamp_micros(&mut self, micros: i64) {
@@ -133,6 +162,7 @@ impl StatisticsAccumulator {
             min_bool: self.min_bool,
             max_bool: self.max_bool,
             null_count: self.null_count,
+            nan_count: self.nan_count,
         }
     }
 }
@@ -154,33 +184,58 @@ fn safe_truncate(s: &str, max_bytes: usize) -> &str {
 /// Truncate a string and adjust the last character up by 1 to create a ceiling value.
 /// This ensures pruning correctness: any string that starts with the original prefix
 /// is guaranteed to be <= the ceiling.
-fn truncate_ceiling(s: &str) -> String {
+///
+/// Returns `None` when no valid ceiling exists (every character is `char::MAX`),
+/// so callers can mark the upper bound as unbounded rather than emit a floor that
+/// would wrongly prune values above the prefix (L6).
+fn truncate_ceiling(s: &str) -> Option<String> {
     let mut chars: Vec<char> = s.chars().collect();
-    // Walk backwards to find a character we can increment
-    while let Some(last) = chars.last_mut() {
-        if *last < char::MAX {
-            *last = char::from_u32(*last as u32 + 1).unwrap_or(char::MAX);
-            return chars.into_iter().collect();
+    // Walk backwards to find a character we can increment.
+    while let Some(&last) = chars.last() {
+        if last < char::MAX {
+            let mut next_u = last as u32 + 1;
+            // Skip the UTF-16 surrogate gap (0xD800..=0xDFFF), which is not a
+            // valid Unicode scalar value; the next scalar after 0xD7FF is 0xE000.
+            if (0xD800..=0xDFFF).contains(&next_u) {
+                next_u = 0xE000;
+            }
+            if let Some(next) = char::from_u32(next_u) {
+                *chars.last_mut().unwrap() = next;
+                return Some(chars.into_iter().collect());
+            }
         }
         chars.pop();
     }
-    // All chars were MAX - return the original
-    s.to_string()
+    // All chars were char::MAX — no representable ceiling.
+    None
 }
 
-/// Validate that statistics fields don't include unsupported types (Json, Bytes)
+/// Validate that requested statistics fields exist and have a supported type.
+///
+/// `field_types` maps every indexed (non-skipped, mapped) tantivy field to its
+/// type. A requested field absent from this map was skipped or does not exist,
+/// which would otherwise silently produce all-`None` statistics (L5) — reject it
+/// so the misconfiguration surfaces instead of yielding empty stats.
 pub fn validate_statistics_fields(
     fields: &[String],
     field_types: &std::collections::HashMap<String, String>,
 ) -> Result<(), String> {
     for field in fields {
-        if let Some(field_type) = field_types.get(field) {
-            if field_type == "Json" || field_type == "Bytes" {
+        match field_types.get(field) {
+            None => {
+                return Err(format!(
+                    "Statistics requested for field '{}', but it is not an indexed \
+                     column (it was skipped or does not exist in the parquet schema)",
+                    field
+                ));
+            }
+            Some(field_type) if field_type == "Json" || field_type == "Bytes" => {
                 return Err(format!(
                     "Field '{}' has type '{}' which does not support statistics",
                     field, field_type
                 ));
             }
+            Some(_) => {}
         }
     }
     Ok(())
@@ -236,8 +291,20 @@ mod tests {
 
     #[test]
     fn test_truncate_ceiling() {
-        assert_eq!(truncate_ceiling("abc"), "abd");
-        assert_eq!(truncate_ceiling("a"), "b");
+        assert_eq!(truncate_ceiling("abc").as_deref(), Some("abd"));
+        assert_eq!(truncate_ceiling("a").as_deref(), Some("b"));
+        // All-char::MAX prefix has no representable ceiling → None (L6).
+        let all_max: String = std::iter::repeat(char::MAX).take(3).collect();
+        assert_eq!(truncate_ceiling(&all_max), None);
+    }
+
+    #[test]
+    fn test_truncate_ceiling_surrogate_boundary() {
+        // A char just below the UTF-16 surrogate gap must increment to 0xE000,
+        // not loop forever or produce an invalid scalar.
+        let c = char::from_u32(0xD7FF).unwrap();
+        let ceiling = truncate_ceiling(&c.to_string()).unwrap();
+        assert_eq!(ceiling.chars().next().unwrap(), char::from_u32(0xE000).unwrap());
     }
 
     #[test]
@@ -314,11 +381,13 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_statistics_fields_unknown_field_passes() {
-        // Unknown fields (not in types map) should pass — validation only rejects known bad types
+    fn test_validate_statistics_fields_unknown_field_rejected() {
+        // Unknown fields (skipped or nonexistent) must be rejected rather than
+        // silently yielding all-None statistics (L5).
         let types = std::collections::HashMap::new();
         let result = validate_statistics_fields(&["mystery".to_string()], &types);
-        assert!(result.is_ok());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not an indexed column"));
     }
 
     #[test]
@@ -407,8 +476,23 @@ mod tests {
         acc.observe_f64(f64::NAN);
         acc.observe_f64(f64::NAN);
         let result = acc.finalize();
-        // All NaN → no min/max
+        // All NaN → no min/max, but nan_count distinguishes it from empty (M10).
         assert_eq!(result.min_double, None);
         assert_eq!(result.max_double, None);
+        assert_eq!(result.nan_count, 2);
+        assert_eq!(result.null_count, 0);
+    }
+
+    #[test]
+    fn test_string_max_ceiling_unbounded_reports_none() {
+        // A truncated value whose prefix is all char::MAX has no ceiling, so the
+        // max bound must report None rather than a too-low floor (L6).
+        let all_max: String = std::iter::repeat(char::MAX).take(8).collect();
+        let mut acc = StatisticsAccumulator::new("s", "Str", 4);
+        acc.observe_string(&all_max);
+        let result = acc.finalize();
+        assert_eq!(result.max_string, None);
+        // min still records the truncated prefix.
+        assert!(result.min_string.is_some());
     }
 }

--- a/native/src/parquet_companion/streaming_ffi.rs
+++ b/native/src/parquet_companion/streaming_ffi.rs
@@ -559,6 +559,19 @@ pub(crate) fn write_batch_to_ffi(
             _ => orig_field.as_ref().clone(),
         };
 
+        // Perform the fallible schema conversion BEFORE exporting the array. If it
+        // ran after the array write, a conversion failure (via `?`) would strand an
+        // already-exported FFI_ArrowArray in consumer memory with a live release
+        // callback the consumer never learns to invoke — a leaked Arrow buffer.
+        let ffi_schema = FFI_ArrowSchema::try_from(&export_field).map_err(|e| {
+            anyhow::anyhow!(
+                "FFI_ArrowSchema conversion failed for column {}: {}",
+                i,
+                e
+            )
+        })?;
+        let ffi_array = FFI_ArrowArray::new(&data);
+
         unsafe {
             // Write new FFI data directly — do NOT read+drop previous contents.
             //
@@ -572,17 +585,11 @@ pub(crate) fn write_batch_to_ffi(
             // batch. We just overwrite with new data. The consumer must have
             // already released any previous batch before calling back into this
             // function — failing to do so will leak the previous Arrow arrays.
-            std::ptr::write_unaligned(array_ptr, FFI_ArrowArray::new(&data));
-            std::ptr::write_unaligned(
-                schema_ptr,
-                FFI_ArrowSchema::try_from(&export_field).map_err(|e| {
-                    anyhow::anyhow!(
-                        "FFI_ArrowSchema conversion failed for column {}: {}",
-                        i,
-                        e
-                    )
-                })?,
-            );
+            //
+            // Both writes below are infallible, so a column is never left with its
+            // array exported but its schema missing.
+            std::ptr::write_unaligned(array_ptr, ffi_array);
+            std::ptr::write_unaligned(schema_ptr, ffi_schema);
         }
     }
 

--- a/native/src/parquet_companion/streaming_ffi.rs
+++ b/native/src/parquet_companion/streaming_ffi.rs
@@ -277,37 +277,47 @@ async fn produce_batches(
             0,
         );
 
-        // Feed batches through the accumulator → emit TARGET_BATCH_SIZE chunks
+        // Feed batches through the accumulator → emit TARGET_BATCH_SIZE chunks.
+        //
+        // M18: normalize timestamps to microseconds BEFORE accumulation. The accumulator
+        // concatenates pending batches against `batches[0].schema()`, so if one file reads
+        // as Timestamp(ms) and another as Timestamp(µs), an un-normalized accumulation
+        // window would fail `concat_batches` even though each file reads fine on its own.
+        // Normalizing on arrival guarantees the accumulator only ever holds a single,
+        // consistent timestamp unit.
         for batch in batches {
-            let emitted = accumulator.push(batch)?;
+            let normalized = normalize_timestamps(batch)?;
+            let emitted = accumulator.push(normalized)?;
             for emit_batch in emitted {
                 let renamed = rename_columns_to_tantivy(&emit_batch, &manifest.column_mapping)?;
-                let normalized = normalize_timestamps(renamed)?;
-                rows_emitted += normalized.num_rows();
-                if tx.send(Ok(normalized)).await.is_err() {
-                    if rows_emitted == 0 {
-                        return Err(anyhow::anyhow!(
-                            "Consumer dropped before any data was sent — possible consumer error"
-                        ));
-                    }
+                let n = renamed.num_rows();
+                if tx.send(Ok(renamed)).await.is_err() {
+                    // L14: a closed receiver means the consumer stopped early (Java closed
+                    // the stream, a LIMIT was satisfied, or the consumer itself errored).
+                    // This is a normal terminal condition — the channel is closed, so we
+                    // cannot report anything further to a gone consumer — and we stop
+                    // cleanly. (The former "consumer dropped before any data" error was
+                    // dead code: `rows_emitted` was incremented before the send, and an Err
+                    // could never reach a dropped receiver anyway.)
                     perf_println!(
                         "⏱️ STREAMING: consumer dropped after {} rows — stopping producer",
                         rows_emitted
                     );
                     return Ok(());
                 }
+                rows_emitted += n;
             }
         }
 
         files_processed += 1;
     }
 
-    // Flush remaining rows
+    // Flush remaining rows. Batches were normalized on arrival (M18), so the accumulator's
+    // output is already microsecond-normalized — only renaming remains.
     if let Some(final_batch) = accumulator.flush()? {
         let renamed = rename_columns_to_tantivy(&final_batch, &manifest.column_mapping)?;
-        let normalized = normalize_timestamps(renamed)?;
-        rows_emitted += normalized.num_rows();
-        let _ = tx.send(Ok(normalized)).await;
+        rows_emitted += renamed.num_rows();
+        let _ = tx.send(Ok(renamed)).await;
     }
 
     perf_println!(
@@ -499,11 +509,16 @@ fn parquet_type_to_arrow_type(parquet_type: &str, tantivy_type: &str) -> DataTyp
 /// Write a RecordBatch to pre-allocated FFI addresses.
 /// Same pattern as arrow_ffi_export.rs but operates on a single batch.
 ///
-/// IMPORTANT: If the FFI addresses have been written to before (e.g., in a
-/// streaming loop), the previous `FFI_ArrowArray`/`FFI_ArrowSchema` values are
-/// read and dropped first to release their Arrow buffer memory via the `release`
-/// callback. Callers that allocate fresh zeroed memory for each call are also safe
-/// (a zeroed `FFI_ArrowArray` has `release = null`, which means no-op on drop).
+/// IMPORTANT — ownership protocol (L15): this function writes the new
+/// `FFI_ArrowArray`/`FFI_ArrowSchema` values DIRECTLY into the target addresses and does
+/// NOT read+drop whatever was there before. Reading+dropping stale or uninitialized memory
+/// would invoke a garbage `release` function pointer and previously caused SIGBUS crashes
+/// (`Unsafe.allocateMemory` does not zero its allocations). Per the Arrow C Data Interface
+/// spec, the CONSUMER (Java/Spark) owns the exported structures and must invoke each
+/// `release` callback after importing a batch. When addresses are reused across a streaming
+/// loop, the caller MUST have already released the previous batch before calling back in;
+/// failing to do so leaks the previous Arrow buffers (a leak, not a crash). See the safety
+/// comment at the write site below for the full rationale.
 ///
 /// Timestamps are normalized to microseconds for Spark compatibility. The
 /// streaming path's `produce_batches` already normalizes, so the check here
@@ -732,5 +747,61 @@ mod tests {
             parquet_type_to_arrow_type("INT64", "Date"),
             DataType::Timestamp(TimeUnit::Microsecond, None)
         );
+    }
+
+    /// M18: two files delivering different timestamp units within one accumulation window
+    /// must accumulate cleanly once each batch is normalized on arrival. Without the
+    /// normalize-before-push fix, `concat_batches` fails on the mismatched schemas.
+    #[test]
+    fn test_normalize_before_accumulate_mixed_timestamp_units() {
+        let ms_schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        )]));
+        let us_schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        )]));
+
+        let ms_batch = RecordBatch::try_new(
+            ms_schema,
+            vec![Arc::new(TimestampMillisecondArray::from(vec![1_000i64, 2_000i64]))],
+        )
+        .unwrap();
+        let us_batch = RecordBatch::try_new(
+            us_schema,
+            vec![Arc::new(TimestampMicrosecondArray::from(vec![3_000_000i64]))],
+        )
+        .unwrap();
+
+        // Pre-normalization the two schemas differ, so a naive accumulation would fail.
+        assert_ne!(ms_batch.schema(), us_batch.schema());
+
+        // Normalize each batch as it "arrives" (mirrors produce_batches), then accumulate.
+        let n1 = normalize_timestamps(ms_batch).unwrap();
+        let n2 = normalize_timestamps(us_batch).unwrap();
+        assert_eq!(n1.schema(), n2.schema(), "normalized schemas must match");
+
+        let mut acc = BatchAccumulator::new(1000);
+        assert!(acc.push(n1).unwrap().is_empty());
+        assert!(acc.push(n2).unwrap().is_empty());
+
+        // Flush concatenates the two normalized batches without a schema-mismatch error.
+        let flushed = acc.flush().unwrap().expect("expected a flushed batch");
+        assert_eq!(flushed.num_rows(), 3);
+        assert_eq!(
+            *flushed.schema().field(0).data_type(),
+            DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        let col = flushed
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(col.value(0), 1_000_000); // 1000 ms → µs
+        assert_eq!(col.value(1), 2_000_000);
+        assert_eq!(col.value(2), 3_000_000); // already µs
     }
 }

--- a/native/src/parquet_companion/streaming_ffi.rs
+++ b/native/src/parquet_companion/streaming_ffi.rs
@@ -127,8 +127,16 @@ pub fn start_streaming_retrieval(
         projected_fields.map(|f| f.into());
 
     let handle = tokio::spawn(async move {
+        use futures::FutureExt;
         let tx_err = tx.clone();
-        let result = produce_batches(
+        // Catch producer panics (arrow compute kernels, concat_batches, …) and
+        // funnel them onto the channel as an Err. Without this, a panic drops
+        // `tx` during unwind, the consumer's blocking_recv() returns None, and
+        // nativeNextBatch maps that to a clean EOF — silently truncating the
+        // result set (F7). AssertUnwindSafe is sound here: on panic we only
+        // send an error string and never touch the partially-mutated producer
+        // state again.
+        let produce_fut = produce_batches(
             tx,
             groups,
             projected_fields_arc,
@@ -137,11 +145,26 @@ pub fn start_streaming_retrieval(
             metadata_cache.as_ref(),
             byte_cache.as_ref(),
             coalesce_config,
-        )
-        .await;
+        );
 
-        if let Err(e) = result {
-            let _ = tx_err.send(Err(e)).await;
+        match std::panic::AssertUnwindSafe(produce_fut).catch_unwind().await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                let _ = tx_err.send(Err(e)).await;
+            }
+            Err(panic) => {
+                let msg = panic
+                    .downcast_ref::<&str>()
+                    .map(|s| s.to_string())
+                    .or_else(|| panic.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "unknown panic".to_string());
+                let _ = tx_err
+                    .send(Err(anyhow::anyhow!(
+                        "Parquet streaming producer panicked: {}",
+                        msg
+                    )))
+                    .await;
+            }
         }
     });
 

--- a/native/src/parquet_companion/string_indexing.rs
+++ b/native/src/parquet_companion/string_indexing.rs
@@ -103,16 +103,31 @@ pub fn needs_companion_field(mode: &StringIndexingMode) -> bool {
     )
 }
 
-/// Strip all regex matches from text, collapsing multiple whitespace to single spaces.
+/// Strip all regex matches from text.
+///
+/// When at least one match is replaced, the resulting text has its whitespace
+/// collapsed (multiple whitespace runs → single spaces) and trimmed, to tidy up
+/// the gaps left by removed matches.
+///
+/// When the regex does NOT match (the dominant case for UUID-mode fields), the
+/// input is returned byte-for-byte unchanged — no re-tokenizing, no reallocation,
+/// and importantly no whitespace collapsing. Collapsing on no-match rows would
+/// make the indexed text diverge from the source text even though nothing was
+/// stripped.
 pub fn strip_pattern(text: &str, compiled_regex: &regex::Regex) -> String {
-    let stripped = compiled_regex.replace_all(text, " ");
-    // Collapse multiple whitespace and trim
-    let mut collapsed = String::new();
-    for (i, word) in stripped.split_whitespace().enumerate() {
-        if i > 0 { collapsed.push(' '); }
-        collapsed.push_str(word);
+    match compiled_regex.replace_all(text, " ") {
+        // No replacement occurred: return the input unchanged.
+        std::borrow::Cow::Borrowed(_) => text.to_string(),
+        // A match was replaced: collapse whitespace and trim.
+        std::borrow::Cow::Owned(stripped) => {
+            let mut collapsed = String::new();
+            for (i, word) in stripped.split_whitespace().enumerate() {
+                if i > 0 { collapsed.push(' '); }
+                collapsed.push_str(word);
+            }
+            collapsed
+        }
     }
-    collapsed
 }
 
 /// Extract all regex matches from text, returning (stripped_text, matches).
@@ -274,6 +289,18 @@ mod tests {
         let text = "no uuids here";
         let result = strip_pattern(text, &re);
         assert_eq!(result, "no uuids here");
+    }
+
+    #[test]
+    fn test_strip_pattern_no_match_byte_identical() {
+        // When the regex never matches, the input must be returned unchanged,
+        // including any tabs, newlines, leading/trailing and repeated whitespace.
+        // Collapsing on a no-match row would make indexed text differ from source.
+        let re = regex::Regex::new(UUID_REGEX).unwrap();
+        let text = "  leading\tand\ttabs\nand   multiple   spaces  ";
+        let result = strip_pattern(text, &re);
+        assert_eq!(result, text);
+        assert_eq!(result.as_bytes(), text.as_bytes());
     }
 
     #[test]

--- a/native/src/parquet_companion/transcode.rs
+++ b/native/src/parquet_companion/transcode.rs
@@ -37,6 +37,32 @@ pub type MetadataCache = Arc<Mutex<HashMap<std::path::PathBuf, Arc<parquet::file
 
 use crate::debug_println;
 
+/// Ensure every requested parquet column name is present in the file's arrow schema.
+///
+/// Transcoding projects a fixed set of columns out of each parquet file. If a
+/// requested column is silently absent, it is dropped from the projection and
+/// never recorded, yielding a column with fewer values than `num_docs` and
+/// corrupt columnar bytes. This converts that silent corruption into a clear error.
+fn ensure_columns_present(
+    parquet_schema: &arrow_schema::Schema,
+    requested: &[&str],
+    parquet_path: &str,
+) -> Result<()> {
+    let missing: Vec<&str> = requested
+        .iter()
+        .copied()
+        .filter(|name| !parquet_schema.fields().iter().any(|f| f.name() == *name))
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "Parquet file '{}' is missing required column(s) {:?} during transcode; \
+             the split manifest schema and the parquet file schema have diverged",
+            parquet_path, missing
+        );
+    }
+    Ok(())
+}
+
 /// Source of data for a fast field column
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FieldSource {
@@ -74,8 +100,10 @@ pub struct TranscodeColumn {
     /// Column index in parquet schema
     pub parquet_col_idx: usize,
     /// Fast field tokenizer for text columns (e.g. "raw", "default").
-    /// When set to a non-"raw" tokenizer, transcoding applies tokenization to
-    /// produce individual term entries in the columnar dictionary.
+    /// Transcoding only ever produces raw (untokenized) string columns, so only
+    /// fields with the "raw" tokenizer (or unset) are transcoded — see
+    /// [`columns_to_transcode`], which filters out non-"raw" text fields because a
+    /// parquet raw-string fast field cannot reproduce tantivy's tokenized terms.
     pub fast_field_tokenizer: Option<String>,
 }
 
@@ -215,6 +243,12 @@ async fn transcode_via_columnar_writer(
         let parquet_schema = builder.schema().clone();
         let parquet_file_schema = builder.parquet_schema().clone();
 
+        // A requested column that is silently absent from this file would be
+        // dropped from the projection and never recorded, producing a column with
+        // fewer values than num_docs and corrupt columnar bytes. Surface it as an
+        // error instead of silently corrupting the output.
+        ensure_columns_present(&parquet_schema, &parquet_col_names, parquet_path)?;
+
         let col_indices: Vec<usize> = parquet_col_names
             .iter()
             .filter_map(|name| {
@@ -348,6 +382,12 @@ async fn transcode_str_columns_direct(
 
         let parquet_schema = builder.schema().clone();
         let parquet_file_schema = builder.parquet_schema().clone();
+
+        // A requested column that is silently absent from this file would be
+        // dropped from the projection and its collector would record zero ordinals
+        // with has_nulls=false, producing a Full-cardinality column with a value
+        // count below num_docs — malformed columnar bytes. Error instead.
+        ensure_columns_present(&parquet_schema, &parquet_col_names, parquet_path)?;
 
         let col_indices: Vec<usize> = parquet_col_names
             .iter()
@@ -740,11 +780,15 @@ fn extract_timestamp_micros(array: &dyn Array, row: usize) -> Result<i64> {
     use arrow_array::*;
     use arrow_schema::TimeUnit;
     match array.data_type() {
+        // All conversions use checked arithmetic: extreme values from an untrusted
+        // parquet file would otherwise overflow (panic in debug, wrong date in release).
         DataType::Timestamp(TimeUnit::Second, _) => {
-            Ok(array.as_any().downcast_ref::<TimestampSecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampSecondArray array"))?.value(row) * 1_000_000)
+            array.as_any().downcast_ref::<TimestampSecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampSecondArray array"))?.value(row)
+                .checked_mul(1_000_000).ok_or_else(|| anyhow::anyhow!("Timestamp seconds overflow converting to micros"))
         }
         DataType::Timestamp(TimeUnit::Millisecond, _) => {
-            Ok(array.as_any().downcast_ref::<TimestampMillisecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampMillisecondArray array"))?.value(row) * 1_000)
+            array.as_any().downcast_ref::<TimestampMillisecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampMillisecondArray array"))?.value(row)
+                .checked_mul(1_000).ok_or_else(|| anyhow::anyhow!("Timestamp millis overflow converting to micros"))
         }
         DataType::Timestamp(TimeUnit::Microsecond, _) => {
             Ok(array.as_any().downcast_ref::<TimestampMicrosecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampMicrosecondArray array"))?.value(row))
@@ -753,10 +797,12 @@ fn extract_timestamp_micros(array: &dyn Array, row: usize) -> Result<i64> {
             Ok(array.as_any().downcast_ref::<TimestampNanosecondArray>().ok_or_else(|| anyhow::anyhow!("Expected TimestampNanosecondArray array"))?.value(row) / 1_000)
         }
         DataType::Date32 => {
-            Ok(array.as_any().downcast_ref::<Date32Array>().ok_or_else(|| anyhow::anyhow!("Expected Date32Array array"))?.value(row) as i64 * 86_400_000_000i64)
+            (array.as_any().downcast_ref::<Date32Array>().ok_or_else(|| anyhow::anyhow!("Expected Date32Array array"))?.value(row) as i64)
+                .checked_mul(86_400_000_000i64).ok_or_else(|| anyhow::anyhow!("Date32 overflow converting to micros"))
         }
         DataType::Date64 => {
-            Ok(array.as_any().downcast_ref::<Date64Array>().ok_or_else(|| anyhow::anyhow!("Expected Date64Array array"))?.value(row) * 1_000i64)
+            array.as_any().downcast_ref::<Date64Array>().ok_or_else(|| anyhow::anyhow!("Expected Date64Array array"))?.value(row)
+                .checked_mul(1_000i64).ok_or_else(|| anyhow::anyhow!("Date64 overflow converting to micros"))
         }
         _ => anyhow::bail!("Cannot extract timestamp from {:?}", array.data_type()),
     }
@@ -776,6 +822,18 @@ pub fn columns_to_transcode(
             let source = field_source(&mapping.tantivy_type, mode);
             if source != FieldSource::Parquet {
                 return false;
+            }
+            // Non-"raw" tokenized text fields split text into tokens during native
+            // indexing; a parquet raw-string fast field cannot reproduce those
+            // terms, so transcoding them would diverge from a standard split. Skip
+            // them (matching promote_meta_json_all_fast, which only promotes raw
+            // text fields to fast fields).
+            if mapping.tantivy_type == "Str" {
+                if let Some(tok) = &mapping.fast_field_tokenizer {
+                    if tok != "raw" {
+                        return false;
+                    }
+                }
             }
             // If specific columns requested, filter to those
             if let Some(requested) = requested_columns {

--- a/native/src/parquet_companion/transcode.rs
+++ b/native/src/parquet_companion/transcode.rs
@@ -467,6 +467,32 @@ async fn transcode_str_columns_direct(
                             collector.non_null_doc_ids.push(doc_id);
                         }
                     }
+                    DataType::Decimal256(_, _) => {
+                        // Decimal256 maps to a tantivy "Str" field (values exceed
+                        // f64 range). Serialize each value to its decimal string so
+                        // the field is served from parquet instead of hard-erroring
+                        // at query time in Hybrid mode (M4).
+                        let dec = array.as_any().downcast_ref::<arrow_array::Decimal256Array>()
+                            .context("Expected Decimal256Array for Decimal256 column")?;
+                        for row in 0..dec.len() {
+                            let doc_id = global_row + row as u32;
+                            if dec.is_null(row) {
+                                collector.has_nulls = true;
+                                continue;
+                            }
+                            let s = dec.value_as_string(row);
+                            let bytes = s.as_bytes();
+                            let ord = if let Some(&existing) = collector.dict.get(bytes) {
+                                existing
+                            } else {
+                                let next_id = collector.dict.len() as u32;
+                                collector.dict.insert(bytes.to_vec(), next_id);
+                                next_id
+                            };
+                            collector.ordinals.push(ord as u64);
+                            collector.non_null_doc_ids.push(doc_id);
+                        }
+                    }
                     other => {
                         anyhow::bail!(
                             "Unexpected data type {:?} for Str column '{}'",
@@ -700,6 +726,19 @@ fn record_arrow_value(
             let val = extract_bytes(array, row)?;
             writer.record_bytes(doc_id, column_name, &val);
         }
+        "IpAddr" => {
+            // IP fields are stored in parquet as their string form; parse and
+            // record so IP columns can be served from parquet in ParquetOnly mode
+            // (Hybrid keeps them native) — M4.
+            let s = extract_string(array, row)?;
+            let ip: std::net::IpAddr = s.parse()
+                .with_context(|| format!("Failed to parse IP '{}' for column '{}'", s, column_name))?;
+            let ipv6 = match ip {
+                std::net::IpAddr::V4(v4) => v4.to_ipv6_mapped(),
+                std::net::IpAddr::V6(v6) => v6,
+            };
+            writer.record_ip_addr(doc_id, column_name, ipv6);
+        }
         "Date" => {
             let micros = extract_timestamp_micros(array, row)?;
             // Tantivy DateTime uses nanoseconds internally
@@ -765,12 +804,15 @@ fn extract_string(array: &dyn Array, row: usize) -> Result<String> {
     }
 }
 
-/// Extract bytes from Binary/LargeBinary arrays.
+/// Extract bytes from Binary/LargeBinary/FixedSizeBinary arrays.
 fn extract_bytes(array: &dyn Array, row: usize) -> Result<Vec<u8>> {
     use arrow_array::*;
     match array.data_type() {
         DataType::Binary => Ok(array.as_any().downcast_ref::<BinaryArray>().ok_or_else(|| anyhow::anyhow!("Expected BinaryArray array"))?.value(row).to_vec()),
         DataType::LargeBinary => Ok(array.as_any().downcast_ref::<LargeBinaryArray>().ok_or_else(|| anyhow::anyhow!("Expected LargeBinaryArray array"))?.value(row).to_vec()),
+        // FixedSizeBinary → Bytes tantivy type: without this arm a Hybrid/ParquetOnly
+        // query on such a field hard-errors at transcode time (M4).
+        DataType::FixedSizeBinary(_) => Ok(array.as_any().downcast_ref::<FixedSizeBinaryArray>().ok_or_else(|| anyhow::anyhow!("Expected FixedSizeBinaryArray array"))?.value(row).to_vec()),
         _ => anyhow::bail!("Cannot extract bytes from {:?}", array.data_type()),
     }
 }

--- a/native/src/parquet_companion/transcode.rs
+++ b/native/src/parquet_companion/transcode.rs
@@ -467,11 +467,14 @@ async fn transcode_str_columns_direct(
                             collector.non_null_doc_ids.push(doc_id);
                         }
                     }
-                    DataType::Decimal256(_, _) => {
-                        // Decimal256 maps to a tantivy "Str" field (values exceed
-                        // f64 range). Serialize each value to its decimal string so
-                        // the field is served from parquet instead of hard-erroring
-                        // at query time in Hybrid mode (M4).
+                    DataType::Decimal256(_, scale) => {
+                        // Decimal256 maps to a tantivy "Str" field. Serve it from
+                        // parquet instead of hard-erroring in Hybrid (M4). CRITICAL:
+                        // format EXACTLY as the native indexing path (indexing.rs)
+                        // and doc retrieval (doc_retrieval.rs) do — scale 0 → raw
+                        // i256 string, else the lossy f64 form — otherwise the
+                        // transcoded fast-field term would never match the indexed
+                        // term or the retrieved value for the same row.
                         let dec = array.as_any().downcast_ref::<arrow_array::Decimal256Array>()
                             .context("Expected Decimal256Array for Decimal256 column")?;
                         for row in 0..dec.len() {
@@ -480,7 +483,15 @@ async fn transcode_str_columns_direct(
                                 collector.has_nulls = true;
                                 continue;
                             }
-                            let s = dec.value_as_string(row);
+                            let raw = dec.value(row); // i256
+                            let s = if *scale == 0 {
+                                raw.to_string()
+                            } else {
+                                let parsed = raw.to_string().parse::<f64>().map_err(|e| {
+                                    anyhow::anyhow!("Failed to parse Decimal256 value '{}' as f64: {}", raw, e)
+                                })?;
+                                (parsed / 10f64.powi(*scale as i32)).to_string()
+                            };
                             let bytes = s.as_bytes();
                             let ord = if let Some(&existing) = collector.dict.get(bytes) {
                                 existing

--- a/native/src/parquet_companion/validation.rs
+++ b/native/src/parquet_companion/validation.rs
@@ -1,4 +1,14 @@
 // validation.rs - Staleness and missing file checks for parquet companion mode
+//
+// STATUS: Currently UNUSED / not wired into any read path.
+//
+// `FileValidator` and `MissingFilePolicy` are only re-exported from `mod.rs`; no
+// retrieval or transcode path constructs a `FileValidator`, so the staleness /
+// missing-file protection it implements is not yet enforced at query time. The
+// module is retained (rather than deleted) because it is intended to be wired
+// into the read path in the future. If you are extending the read path, this is
+// the place that should be invoked before serving parquet-backed rows. Until
+// then, treat this module as scaffolding.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -10,7 +20,16 @@ use super::manifest::ParquetManifest;
 pub enum MissingFilePolicy {
     /// Fail the query immediately if any referenced file is missing or stale
     Fail,
-    /// Log a warning and return empty/null values for documents in missing files
+    /// Log a warning and continue as if the file were valid.
+    ///
+    /// NOTE: Despite the name, this does NOT substitute empty/null values for the
+    /// documents in a missing/stale file. `evaluate_result` returns `Result<(),
+    /// String>`, which can only express "ok" or "error" — there is no third
+    /// outcome to signal "present-but-substitute-empties". So `Warn` collapses to
+    /// a logged no-op: the validation is skipped and the query proceeds, with any
+    /// subsequent read of the actually-missing file failing on its own. Delivering
+    /// true empty/null substitution would require a richer return type
+    /// (e.g. an enum of Present/Substitute/Error) and cooperation from the reader.
     Warn,
 }
 
@@ -73,13 +92,27 @@ impl FileValidator {
                 actual_size: Some(actual_size),
                 expected_size,
             },
-            Err(_) => FileValidationResult {
-                path: resolved_path.to_string(),
-                exists: false,
-                size_matches: false,
-                actual_size: None,
-                expected_size,
-            },
+            // Only a definitive "not found" is a cacheable absence. Transient
+            // storage failures (S3 503, timeouts, throttling, auth, I/O) must NOT
+            // be cached as `exists: false` — doing so would poison the cache
+            // forever (there is no TTL), permanently failing a file that was only
+            // temporarily unreachable. Surface the error to the caller instead so
+            // a later call can retry.
+            Err(err) if err.kind() == quickwit_storage::StorageErrorKind::NotFound => {
+                FileValidationResult {
+                    path: resolved_path.to_string(),
+                    exists: false,
+                    size_matches: false,
+                    actual_size: None,
+                    expected_size,
+                }
+            }
+            Err(err) => {
+                return Err(format!(
+                    "Transient storage error validating '{}': {} (not cached; retry)",
+                    resolved_path, err
+                ));
+            }
         };
 
         let eval = self.evaluate_result(&result);

--- a/native/src/quickwit_split/jni_functions.rs
+++ b/native/src/quickwit_split/jni_functions.rs
@@ -633,6 +633,7 @@ fn create_java_column_statistics_map<'a>(
             env.call_method(&stat_obj, "setMaxBool", "(Z)V", &[JValue::Bool(v as u8)])?;
         }
         env.call_method(&stat_obj, "setNullCount", "(J)V", &[JValue::Long(stat.null_count as i64)])?;
+        env.call_method(&stat_obj, "setNanCount", "(J)V", &[JValue::Long(stat.nan_count as i64)])?;
 
         // Put into map
         let key_jstr = string_to_jstring(env, &stat.field_name)?;
@@ -1789,10 +1790,27 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_merge_QuickwitSpli
     convert_throwable(&mut env, |env| {
         let output_dir_str = jstring_to_string(env, &output_dir)?;
 
-        // Retrieve context clone from registry, then release the registry entry
+        // Retrieve context clone from registry.
         let ctx_arc = crate::utils::jlong_to_arc::<Mutex<ArrowFfiSplitContext>>(ctx_handle)
             .ok_or_else(|| anyhow!("Invalid context handle for finishAllSplits"))?;
-        release_arc(ctx_handle); // Remove from registry; ctx_arc is now the sole owner
+
+        // We now hold one clone and the registry holds one, so strong_count == 2
+        // in the normal case. A higher count means another thread (e.g. an
+        // in-flight addArrowBatch) still references the context. If we released
+        // the registry entry first and THEN try_unwrap failed, the session would
+        // be gone yet unrecoverable (M17). Detect that up front and fail without
+        // deregistering, so the caller can retry after its batch completes.
+        if Arc::strong_count(&ctx_arc) > 2 {
+            anyhow::bail!(
+                "Cannot finish splits: the Arrow split context is still in use by \
+                 another operation (an addArrowBatch call has not returned). Ensure \
+                 all batches are submitted before finishAllSplits; the session is \
+                 left intact so you can retry."
+            );
+        }
+
+        // Safe to tear down: release the registry entry so ctx_arc is sole owner.
+        release_arc(ctx_handle);
 
         // Extract the context from Arc<Mutex<>>
         let ctx = Arc::try_unwrap(ctx_arc)

--- a/native/src/quickwit_split/jni_functions.rs
+++ b/native/src/quickwit_split/jni_functions.rs
@@ -1798,8 +1798,15 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_merge_QuickwitSpli
         // in the normal case. A higher count means another thread (e.g. an
         // in-flight addArrowBatch) still references the context. If we released
         // the registry entry first and THEN try_unwrap failed, the session would
-        // be gone yet unrecoverable (M17). Detect that up front and fail without
-        // deregistering, so the caller can retry after its batch completes.
+        // be gone yet unrecoverable (M17). Guard against that by checking the
+        // count before releasing and again immediately before the release call.
+        //
+        // The documented usage model is a single caller driving begin → addBatch
+        // → finish sequentially, so this reliably rejects the misuse case. A
+        // concurrent addArrowBatch racing in the tiny window between the second
+        // check and release_arc remains theoretically possible (fully closing it
+        // would require re-inserting the Arc on a failed try_unwrap); this guard
+        // makes that window negligibly small rather than eliminating it.
         if Arc::strong_count(&ctx_arc) > 2 {
             anyhow::bail!(
                 "Cannot finish splits: the Arrow split context is still in use by \
@@ -1809,7 +1816,14 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_merge_QuickwitSpli
             );
         }
 
-        // Safe to tear down: release the registry entry so ctx_arc is sole owner.
+        // Re-check right before tearing down to minimize the race window, then
+        // release the registry entry so ctx_arc is the sole owner.
+        if Arc::strong_count(&ctx_arc) > 2 {
+            anyhow::bail!(
+                "Cannot finish splits: the Arrow split context became in-use by \
+                 another operation; the session is left intact so you can retry."
+            );
+        }
         release_arc(ctx_handle);
 
         // Extract the context from Arc<Mutex<>>

--- a/native/src/quickwit_split/jni_functions.rs
+++ b/native/src/quickwit_split/jni_functions.rs
@@ -1800,12 +1800,11 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_merge_QuickwitSpli
             .into_inner()
             .map_err(|e| anyhow!("Failed to unwrap mutex: {}", e))?;
 
-        // Create a default SplitConfig (JNI layer uses defaults; future: accept from Java)
-        let split_config = default_split_config("arrow-ffi", "arrow-ffi-source", "arrow-ffi-node");
-
-        // Run async finish in tokio runtime
+        // The split config is a single source of truth stored in the context at
+        // begin time; finish_all_splits reads it directly so every split in the
+        // session (auto-rolled and final) shares the same identity.
         let results = QuickwitRuntimeManager::global().handle()
-            .block_on(finish_all_splits(ctx, &output_dir_str, &split_config))?;
+            .block_on(finish_all_splits(ctx, &output_dir_str))?;
 
         // Convert results to Java ArrayList<HashMap<String, Object>>
         let array_list_class = env.find_class("java/util/ArrayList")?;
@@ -2005,11 +2004,10 @@ pub extern "system" fn Java_io_indextables_tantivy4java_split_merge_QuickwitSpli
         let mut ctx = ctx_arc.lock()
             .map_err(|e| anyhow!("Failed to lock context: {}", e))?;
 
-        let split_config = default_split_config("arrow-ffi", "arrow-ffi-source", "arrow-ffi-node");
-
+        // Split config comes from the context (single source of truth set at begin).
         let result = QuickwitRuntimeManager::global().handle()
             .block_on(roll_partition_split(
-                &mut ctx, &partition_key_str, &output_dir_str, &split_config,
+                &mut ctx, &partition_key_str, &output_dir_str,
             ))?;
 
         // Convert single result to Java HashMap<String, Object>

--- a/native/src/quickwit_split/merge_impl.rs
+++ b/native/src/quickwit_split/merge_impl.rs
@@ -349,7 +349,7 @@ pub fn merge_splits_impl(split_urls: &[String], output_path: &str, config: &Inte
         let source_refs: Vec<&std::path::Path> = source_paths.iter()
             .map(|p| p.as_path())
             .collect();
-        match crate::parquet_companion::merge::combine_parquet_manifests(&source_refs, &output_temp_dir) {
+        match crate::parquet_companion::merge::combine_parquet_manifests(&source_refs, &output_temp_dir, Some(merged_docs as u64)) {
             Ok(Some(())) => {
                 debug_log!("📦 PARQUET_COMPANION: Combined parquet manifests from {} source splits into merged output", source_refs.len());
                 true
@@ -359,8 +359,16 @@ pub fn merge_splits_impl(split_urls: &[String], output_path: &str, config: &Inte
                 false
             }
             Err(e) => {
-                debug_log!("⚠️ PARQUET_COMPANION: Failed to combine parquet manifests: {} (continuing without manifest)", e);
-                false
+                // Do NOT swallow this: if any source split had a parquet manifest,
+                // combining is mandatory. A merged companion split without a manifest
+                // has searchable postings but no stored fields — every subsequent
+                // document retrieval fails, silently, unless debug logging is on.
+                // Fail the merge so the corruption surfaces at merge time (F3).
+                return Err(anyhow!(
+                    "Failed to combine parquet companion manifests during merge: {}. \
+                     Refusing to produce a merged split without a valid parquet manifest.",
+                    e
+                ));
             }
         }
     };

--- a/native/src/searcher/aggregation/bucket_results.rs
+++ b/native/src/searcher/aggregation/bucket_results.rs
@@ -33,6 +33,7 @@ pub(crate) fn create_terms_result_object(
     exclude_filter: Option<&std::collections::HashSet<String>>,
     missing_value: Option<&str>,
     needs_resort: bool,
+    result_size: Option<usize>,
 ) -> anyhow::Result<jobject> {
     debug_println!(
         "RUST DEBUG: Creating TermsResult for '{}' with {} buckets",
@@ -92,6 +93,15 @@ pub(crate) fn create_terms_result_object(
     // Tantivy sorted by U64 hash value which doesn't match string ordering.
     if needs_resort {
         resolved_buckets.sort_by(|(a, _), (b, _)| a.cmp(b));
+    }
+
+    // Phase 2b: When an include/exclude filter was applied, Tantivy was asked for an
+    // enlarged `size` so the filter had enough candidate buckets. Truncate back to the
+    // originally-requested size now that filtering (and any resort) is done. The
+    // ordering here is either doc_count-desc (preserved from Tantivy) or string-key
+    // order (from the resort above), so truncation keeps the correct top-`size`.
+    if let Some(size) = result_size {
+        resolved_buckets.truncate(size);
     }
 
     // Phase 3: Create Java objects from the resolved, filtered, sorted list.

--- a/native/src/searcher/aggregation/deserialize.rs
+++ b/native/src/searcher/aggregation/deserialize.rs
@@ -121,6 +121,7 @@ pub(crate) fn deserialize_aggregation_results(
             None,  // exclude_filter: not available in this deserialization path
             None,  // missing_value
             false, // needs_resort
+            None,  // result_size
         ) {
             Ok(java_obj) => {
                 if !java_obj.is_null() {
@@ -373,6 +374,7 @@ pub(crate) fn find_specific_aggregation_result(
         let exclude_filter = touchup.and_then(|t| t.exclude_strings.as_ref());
         let missing_value = touchup.and_then(|t| t.missing_value.as_deref());
         let needs_resort = touchup.map(|t| t.needs_resort).unwrap_or(false);
+        let result_size = touchup.and_then(|t| t.result_size);
 
         return create_java_aggregation_from_final_result(
             env,
@@ -385,6 +387,7 @@ pub(crate) fn find_specific_aggregation_result(
             exclude_filter,
             missing_value,
             needs_resort,
+            result_size,
         );
     } else {
         debug_println!(

--- a/native/src/searcher/aggregation/sub_aggregations.rs
+++ b/native/src/searcher/aggregation/sub_aggregations.rs
@@ -48,7 +48,7 @@ pub(crate) fn create_sub_aggregations_map(
         // Convert aggregation result to Java object, passing through hash resolution context.
         // Sub-aggregations don't carry per-name include/exclude/missing/resort info.
         let java_agg_result = create_java_aggregation_from_final_result(
-            env, agg_name, agg_result, false, resolution_map, redirected_names, None, None, None, false,
+            env, agg_name, agg_result, false, resolution_map, redirected_names, None, None, None, false, None,
         )?;
 
         if !java_agg_result.is_null() {
@@ -91,6 +91,7 @@ pub(crate) fn create_java_aggregation_from_final_result(
     exclude_filter: Option<&std::collections::HashSet<String>>,
     missing_value: Option<&str>,
     needs_resort: bool,
+    result_size: Option<usize>,
 ) -> anyhow::Result<jobject> {
     debug_println!(
         "RUST DEBUG: Creating Java aggregation for '{}', type: {:?}, date_histogram_hint: {}",
@@ -207,7 +208,7 @@ pub(crate) fn create_java_aggregation_from_final_result(
                     } else {
                         None
                     };
-                    create_terms_result_object(env, aggregation_name, buckets, effective_map, redirected_names, include_filter, exclude_filter, missing_value, needs_resort)
+                    create_terms_result_object(env, aggregation_name, buckets, effective_map, redirected_names, include_filter, exclude_filter, missing_value, needs_resort, result_size)
                 }
                 BucketResult::Range { buckets } => {
                     debug_println!("RUST DEBUG: Creating RangeResult");

--- a/src/main/java/io/indextables/tantivy4java/split/ColumnStatistics.java
+++ b/src/main/java/io/indextables/tantivy4java/split/ColumnStatistics.java
@@ -32,6 +32,10 @@ public class ColumnStatistics {
     // Null count
     private long nullCount;
 
+    // NaN count (float columns) — tracked separately from nullCount so an
+    // all-NaN column is distinguishable from an empty/all-null one.
+    private long nanCount;
+
     public ColumnStatistics(String fieldName, String fieldType) {
         this.fieldName = fieldName;
         this.fieldType = fieldType;
@@ -50,6 +54,7 @@ public class ColumnStatistics {
     public Boolean getMinBool() { return minBool; }
     public Boolean getMaxBool() { return maxBool; }
     public long getNullCount() { return nullCount; }
+    public long getNanCount() { return nanCount; }
 
     // Setters for JNI construction
     void setMinLong(long v) { this.minLong = v; }
@@ -63,6 +68,7 @@ public class ColumnStatistics {
     void setMinBool(boolean v) { this.minBool = v; }
     void setMaxBool(boolean v) { this.maxBool = v; }
     void setNullCount(long v) { this.nullCount = v; }
+    void setNanCount(long v) { this.nanCount = v; }
 
     /**
      * Check if a long range overlaps with this column's statistics.


### PR DESCRIPTION
Resolves the code-review findings for the `parquet_companion` module across
two review documents (the read/indexing-path review and
`PARQUET_COMPANION_INDEXING_REVIEW.md`). **All high, medium, low, efficiency,
and design findings are addressed** except a full de-triplication refactor
(D1), whose concrete drift bugs (M12, M14) are fixed directly. Every change is
covered by the 982 passing native lib unit tests plus new regression tests.

Two rounds of Sonnet code review were run against the changes; both rounds'
findings were addressed (notably: the F8 reserved-name check was narrowed to
avoid false-positives, and the M4 fast-field fix was reworked to keep the
index and read sides consistent — see "Review corrections" below).

---

## High-severity (8/8)

- **F1** merged manifest row order now mirrors quickwit's `combine_index_meta`
  (`[n-1, 0, …, n-2]`), not input order.
- **F2** merge deletion guard reads the nested `deletes.num_deleted_docs`.
- **F3** manifest-combine failures fail the merge instead of silently producing
  a manifest-less split.
- **F4** `hash_parquet_path` uses stable xxh64, not `DefaultHasher`.
- **F5** indexing writer uses `NoMergePolicy` + `wait_merging_threads()` and
  rejects multi-segment output when fast fields are parquet-served.
- **F6** FFI `add_arrow_batch` validates column names/types, not just count.
- **F7** streaming producer panics surface as a channel error, not a clean EOF.
- **F8** name-mapping collisions and reserved `__pq_*` names return a clean
  error instead of panicking in `SchemaBuilder`.
- **M7** backstop: combined manifest row count must equal merged doc count.

## Medium / low / efficiency / design

- **Config & schema** — M1 one config-key convention (parquet→tantivy resolved
  once); M2 reject string-mode overrides on non-string columns; M3 Dictionary
  columns derived/decoded by value type; M4 IP/FixedSizeBinary/Decimal256 served
  correctly from parquet (new transcode arms) instead of empty/hard-error;
  M5/E7/L13 name mapping walks top-level fields, one-pass field-id index,
  validates explicit keys.
- **Merge & manifest** — M8 storage_config compat check; M9 `validate()` covers
  first-file offset, file contiguity, segment coverage; L7 page-location length
  check; L11/D3 missing meta.json and hash-field mismatch are hard errors.
- **Statistics** — M10 nan_count (surfaced through `ColumnStatistics`); L5
  reject stats on skipped/unknown fields; L6 unbounded-ceiling handling; L1
  UInt64 saturation; E4 fewer allocations.
- **Value conversion** — M12 FixedSizeList/complex types serialize as JSON;
  M13 row-count mismatch hard-errors; M14 checked date/timestamp math; L9 u32
  TANT-offset overflow guard; L10 documented lossy Decimal128→f64; E3 share the
  manifest via `Arc` across batch fan-out.
- **FFI ingestion** — M16 atomic-per-batch add; M17 finish_all_splits attempts
  all partitions + the JNI caller guards the registry teardown; M18 normalize
  timestamps before accumulation; M19 Date32 ISO stats; L14/L15 dead branch /
  stale comment; L16 bounded partition writers; E6 partition-key routing cache.
- **Indexing** — E1 project only indexed columns; E8 parse JSON once; E2
  per-batch column resolution + concurrent hash touch-up; L2 char-safe error
  previews; L3 path-boundary check; L4 all-column offset-index requirement;
  L8 deterministic zero-row-file resolution.
- **Validation / misc** — M6 fix cache poisoning on transient errors; M15
  range/date_range/extended_stats/percentile_ranks trigger transcode; L17 dead
  ES-style range removed; E5 no-match strip returns input unchanged; D6
  ES-shape range removed.

## Review corrections (from the Sonnet passes)

- F8 reserved-name validation narrowed to the two always-added `__pq_*` fields
  (companion `_phash_*`/`*__uuids` collisions are handled precisely at their
  creation sites), so legitimately-named columns aren't rejected.
- M4 reworked: the first attempt made types native on the index side only,
  diverging from the read side. Instead the read side (`record_arrow_value`
  IpAddr arm, `extract_bytes` FixedSizeBinary, str-direct Decimal256) was
  fixed to match the unchanged `field_source`, and the Decimal256 transcode
  string form was aligned exactly with the index/retrieval formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
