### PR TITLE
chore(deps): consolidate Dependabot dependency updates (batch 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Setup dependencies
         run: ./scripts/setup.sh
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Setup dependencies
         run: ./scripts/setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup dependencies
         run: ./scripts/setup.sh
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup dependencies
         run: ./scripts/setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup dependencies
         run: ./scripts/setup.sh
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup dependencies
         run: ./scripts/setup.sh

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run Claude Code Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run Claude Code Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Run Claude Code Review

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -3786,9 +3786,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -4053,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -5120,7 +5120,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>2.43.0</version>
+            <version>2.46.15</version>
             <scope>test</scope>
         </dependency>
         
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.33.3</version>
+            <version>12.35.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.4</version>
             <scope>test</scope>
         </dependency>
 
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.57.1</version>
+            <version>1.58.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>2.67.0</version>
+            <version>2.69.0</version>
             <scope>test</scope>
         </dependency>
         
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-nio</artifactId>
-            <version>0.131.0</version>
+            <version>0.133.0</version>
             <scope>test</scope>
         </dependency>
         
@@ -153,13 +153,13 @@
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>
-            <version>1.10.1</version>
+            <version>1.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-api</artifactId>
-            <version>1.10.1</version>
+            <version>1.11.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -558,7 +558,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.10.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -153,13 +153,13 @@
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>
-            <version>1.11.0</version>
+            <version>1.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-api</artifactId>
-            <version>1.11.0</version>
+            <version>1.10.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Consolidates the open Dependabot PRs (#163-#172, #175, #177, #178, #180, #181) into a single change, following the same triage process as #179. Each update was applied to the appropriate manifest and verified to compile.

## Applied

**Maven (`pom.xml`)**
- `software.amazon.awssdk:s3` 2.43.0 → 2.46.15 (#181)
- `azure-storage-blob` 12.33.3 → 12.35.0 (#181)
- `azure-identity` 1.18.2 → 1.18.4 (#181)
- `azure-core` 1.57.1 → 1.58.1 (#181)
- `google-cloud-storage` 2.67.0 → 2.69.0 (#181)
- `google-cloud-nio` 0.131.0 → 0.133.0 (#181)
- `central-publishing-maven-plugin` 0.10.0 → 0.11.0 (#181)

**Cargo (`native/`)**
- `libc` 0.2.181 → 0.2.186 (lockfile-only bump) (#169)
- `moka` 0.12.13 → 0.12.15 (lockfile-only bump) (#165)

**Already applied (no-op, superseded by #179)**
- `jackson-databind` 2.15.2 → 2.22.0 (#178) — pom.xml already at 2.22.0
- `maven-surefire-plugin` 3.1.2 → 3.5.6 (#177) — pom.xml already at 3.5.6
- `exec-maven-plugin` 3.1.0 → 3.6.3 (#175) — pom.xml already at 3.6.3
- `futures` 0.3.31 → 0.3.32 (#164) — Cargo.toml already at 0.3.32
- `tokio` 1.45 → 1.50 (#166) — Cargo.toml already at 1.50
- `lru` 0.12 → 0.16 (#167) — Cargo.toml already at 0.16
- `sha2` 0.10 → 0.11 (#163) — Cargo.toml already at 0.11
- `thiserror` 1 → 2 (#170) — Cargo.toml already at 2

These PRs' proposed target versions are already present on `main` (applied in a prior consolidation); their diffs are effectively no-ops against the current base and they are being closed as already-satisfied.

## Held back (incompatible — not applied)

- **`junit` 5.12.2 → 6.1.0** (#181 sub-update) — JUnit 6 raises its baseline to Java 17 (bytecode 61); this project targets Java 11 and CI compiles with JDK 11. Left at 5.12.2.
- **`scala-library` 2.13.12 → 3.8.4** (#181 sub-update) — Scala 2 → 3 major bump; `s3mock_2.13` requires Scala 2.13. Kept at 2.13.12.
- **`iceberg-core` / `iceberg-api` 1.10.1 → 1.11.0** (#181 sub-update) — initially applied, then reverted after CI caught it: 1.11.0 ships Java 17 bytecode (class file version 61.0), which fails to compile under this project's JDK 11 target (`bad class file ... class file has wrong version 61.0, should be 55.0`). Held at 1.10.1, the version already verified working in #179.
- **`actions/checkout` v6 → v7, then pinned to v4** (#180) — initially applied (v7), then reverted after CI caught it: v7 requires a Node 24 action runtime, and this repo's self-hosted Linux runner (runner v2.321.0) only supports up to Node 20 (`'using: node24' is not supported`). First reverted to v6 (the prior working value), but a second CI run showed v6 *also* now fails the same way — GitHub has repatched the v5 and v6 major tags (even old point releases) to require Node 24, so this isn't specific to the v7 bump; `main` is silently affected by the same drift. v4's latest patch (v4.2.2) still declares `node20` and is unaffected, so pinned there instead. #180 is being closed as not-yet-actionable rather than merged; a future re-attempt at v5/v6/v7 needs the self-hosted runners upgraded first.
- **`arrow-array` / `arrow-buffer` 57 → 58** (#168, #172) — `arrow`, `arrow-schema`, and `parquet` remain at 57 (pinned transitively by `delta-kernel` 0.19 and the quickwit fork). Re-attempted the bump in isolation: `arrow-array`/`arrow-buffer` at 58 with the rest at 57 fails with 212 compile errors from type mismatches across the arrow ecosystem — same failure mode as when #179 was prepared. Needs a coordinated full arrow-ecosystem upgrade (including delta_kernel/quickwit), which is out of scope here.
- **`object_store` 0.12 → 0.13** (#171) — re-attempted in isolation; fails with 34 compile errors from breaking API changes (`head`/`get`/`put`/`delete`) and version coupling with `delta-kernel` 0.19 / quickwit which pin 0.12. Still incompatible.

## Verification
- `cargo check` (native/) — clean, no errors
- `mvn test-compile` — BUILD SUCCESS (includes native release build via exec-maven-plugin)
- CI (macOS ARM64 / Linux x64) caught the iceberg 1.11.0 and actions/checkout v7 incompatibilities described above; both were reverted and the branch pushed again for a clean re-run.

The three held-back PRs (#168, #171, #172) should remain open for a future coordinated arrow/object_store upgrade. All other PRs in this batch (#163, #164, #165, #166, #167, #169, #170, #175, #177, #178, #180, #181) are being closed in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

