### PR TITLE
fix: surface full error chain in JNI boundary exceptions (convert_throwable)

### DIFF
--- a/native/src/utils.rs
+++ b/native/src/utils.rs
@@ -151,7 +151,7 @@ where
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(env))) {
         Ok(Ok(value)) => Ok(value),
         Ok(Err(error)) => {
-            let _ = env.throw_new("java/lang/RuntimeException", error.to_string());
+            let _ = env.throw_new("java/lang/RuntimeException", format!("{:?}", error));
             Err(error)
         }
         Err(panic_info) => {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>tantivy4java</artifactId>
-    <version>0.34.4</version>
+    <version>0.34.4.1</version>
     <packaging>jar</packaging>
 
     <name>Tantivy4Java Experimental</name>


### PR DESCRIPTION
## Summary

`convert_throwable()` (`native/src/utils.rs`) is the single, universal JNI exception-conversion path — every native function exposed to Java routes its error through it. It previously built the `RuntimeException` message with `error.to_string()`, which invokes `anyhow::Error`'s `Display` impl and renders **only the outermost error**. Every `.context(...)` layer attached as the error propagated up through the native call stack (and the true root cause) was discarded before the exception ever reached the JVM.

This masked the real cause behind generic errors like "Failed to add document to tantivy index," making them undiagnosable from the Java side without attaching a native debugger.

## Change

One-line fix, same function, same branch:

```rust
- let _ = env.throw_new("java/lang/RuntimeException", error.to_string());
+ let _ = env.throw_new("java/lang/RuntimeException", format!("{:?}", error));
```

`format!("{:?}", error)` uses `anyhow::Error`'s `Debug` impl, which is specifically designed to print the full error chain — root cause followed by every `.context(...)` layer — instead of just the top-level message.

## Blast radius

`convert_throwable` is the only JNI exception-conversion path in the codebase (confirmed via `grep -rl convert_throwable native/src/` — only `utils.rs` defines it). It's called from 33+ sites across 3 JNI modules:
- `native/src/quickwit_split/jni_functions.rs`
- `native/src/split_searcher/document_retrieval/doc_retrieval_jni.rs`
- `native/src/split_searcher/jni_prewarm.rs`

Because the fix is made once at the shared boundary function, every call site gets the fuller error message with no per-call-site changes needed.

## Backward compatibility

- Purely a diagnostic/message-content change. No change to control flow, exception type (`RuntimeException` unchanged), success/failure behavior, or return values — `Err(error)` is still returned identically after the exception is thrown.
- Exception messages become longer and can be multi-line. Any caller/log pipeline that parses the exception message by exact string match or a strict single-line assumption should account for this. No such caller was identified in this codebase.
- No config changes or flags — the fix is unconditional.

## Test plan

- [x] `cargo check` on `native/` compiles cleanly (only pre-existing warnings)
- [x] Verified via `grep` that `convert_throwable` has a single definition site and is the only JNI exception-conversion path
- [x] Change validated in production use — this fix is what allowed a downstream `/local_disk0` scratch-directory leak root cause to be correctly diagnosed instead of surfacing only as a masked generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
